### PR TITLE
Fix and simplify alarm logic

### DIFF
--- a/crates/ct_worker/src/batcher_do.rs
+++ b/crates/ct_worker/src/batcher_do.rs
@@ -101,7 +101,7 @@ impl DurableObject for Batcher {
                 self.in_flight += 1;
 
                 // Set an alarm to flush the batch if it times out.
-                if self.batch.pending_leaves.is_empty() {
+                if self.state.storage().get_alarm().await?.is_none() {
                     self.state
                         .storage()
                         .set_alarm(Duration::from_millis(MAX_BATCH_TIMEOUT_MILLIS))

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -131,6 +131,7 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                         .ok_or("R2 object missing body")?
                         .response_body()?,
                 )
+                .map(|r| r.with_headers(headers_from_http_metadata(obj.http_metadata())))
             } else {
                 Response::error("Not found", 404)
             }
@@ -265,4 +266,18 @@ async fn add_chain_or_pre_chain(
 
 fn shard_id_from_cache_key(key: &CacheKey) -> u8 {
     key[0] % NUM_BATCHER_PROXIES
+}
+
+fn headers_from_http_metadata(meta: HttpMetadata) -> Headers {
+    let mut h = Headers::new();
+    if let Some(hdr) = meta.cache_control {
+        h.append("Cache-Control", &hdr).unwrap();
+    }
+    if let Some(hdr) = meta.content_encoding {
+        h.append("Content-Encoding", &hdr).unwrap();
+    }
+    if let Some(hdr) = meta.content_type {
+        h.append("Content-Type", &hdr).unwrap();
+    }
+    h
 }


### PR DESCRIPTION
 * Rather than track when the alarm was last fired, set it when the first
    entry is added to a batch, and delete the alarm if the batch is
    submitted before the timeout. Previously, there was a bug where we could
    get unflushed batches as a new alarm wasn't being set in the
    already-initialized DO.

    fixes #9, fixes #11

* Copy HTTP headers from R2 HTTP metadata when serving from Worker
   
   fixes #12