### PR TITLE
Switch to SQLite backend, fixes #2

### DIFF
--- a/crates/ct_worker/README.md
+++ b/crates/ct_worker/README.md
@@ -105,7 +105,7 @@ Follow these instructions to spin up a CT log on your local machine using the `d
 
 ### Deployment to a workers.dev subdomain
 
-Follow these instructions to deploy a CT log with the `dev` configuration to Cloudflare's network. This requires the [Workers paid plan](https://developers.cloudflare.com/workers/platform/pricing) as this project uses Durable Objects.
+Follow these instructions to deploy a CT log with the `dev` configuration to Cloudflare's network.
 
 Run the following for each of the `dev2025h1a` and `dev2025h2a` log shards to configure resources.
 

--- a/crates/ct_worker/wrangler.jsonc
+++ b/crates/ct_worker/wrangler.jsonc
@@ -50,7 +50,7 @@
                 {
                     // tag should be unique for each entry
                     "tag": "v1",
-                    "new_classes": [
+                    "new_sqlite_classes": [
                         "Sequencer",
                         "Batcher"
                     ]
@@ -103,7 +103,7 @@
                 {
                     // tag should be unique for each entry
                     "tag": "v1",
-                    "new_classes": [
+                    "new_sqlite_classes": [
                         "Sequencer",
                         "Batcher"
                     ]


### PR DESCRIPTION
The SQLite backend supports the KV API, so there's no need to wait for https://github.com/cloudflare/workers-rs/issues/645.

We'll need to re-create the cftest logs to update the backend if to start using it now, but otherwise they'll automatically be migrated sometime in 2025: https://blog.cloudflare.com/sqlite-in-durable-objects/#how-do-i-use-it.

I confirmed that I was able to deploy this to my Free Cloudflare account.