### PR TITLE
Move config to separate crate and enable build-time checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "config"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +437,7 @@ dependencies = [
  "base64 0.21.7",
  "byteorder",
  "chrono",
+ "config",
  "console_error_panic_hook",
  "console_log",
  "ed25519-dalek",
@@ -454,8 +463,8 @@ dependencies = [
  "thiserror",
  "tlog_tiles 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
+ "url",
  "worker",
- "x509-verify",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,10 @@ description = "An implementation of the Static Certificate Transparency API on C
 
 [profile.release]
 opt-level = "s"
-# This is needed as a workaround for https://github.com/cloudflare/workers-rs/issues/654.
+# Recommendations from https://developers.cloudflare.com/workers/languages/rust/#binary-size-wasm-opt:
 strip = true
+lto = true
+codegen-units = 1
 
 [profile.release-symbols]
 inherits = "release"
@@ -28,6 +30,7 @@ opt-level = 3
 debug = 1
 
 [workspace.dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.9.0", features = ["base64"] }

--- a/crates/ct_worker/Cargo.toml
+++ b/crates/ct_worker/Cargo.toml
@@ -12,11 +12,6 @@ description = "An implementation of c2sp.org/static-ct-api on Cloudflare Workers
 categories = ["cryptography"]
 keywords = ["ct", "certificate", "transparency", "crypto", "pki"]
 
-[profile.release]
-lto = true
-strip = true
-codegen-units = 1
-
 [package.metadata.release]
 release = false
 
@@ -36,6 +31,9 @@ serde.workspace = true
 serde_json.workspace = true
 jsonschema = "0.26.2"
 static_ct_api = "0.1.0"
+config = { path = "./config" }
+chrono.workspace = true
+url = "2.5.4"
 
 [dev-dependencies]
 rand = { workspace = true, features = ["small_rng"]}
@@ -47,7 +45,7 @@ futures-executor = "0.3.31"
 anyhow.workspace = true
 base64.workspace = true
 byteorder = "1.4"
-chrono = { version = "0.4", features = ["serde"] }
+config = { path = "./config" }
 console_error_panic_hook = "0.1.1"
 console_log = { version = "1.0" }
 ed25519-dalek = { workspace = true, features = ["pkcs8"] }
@@ -69,8 +67,10 @@ thiserror.workspace = true
 tlog_tiles = "0.1.0"
 tokio = { version = "1", features = ["sync"] }
 worker = { version = "0.5.0" }
-x509-verify = "0.4.4"
 futures-util = "0.3.31"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+
+[package.metadata.cargo-machete]
+ignored = ["getrandom"]

--- a/crates/ct_worker/build.rs
+++ b/crates/ct_worker/build.rs
@@ -3,19 +3,21 @@
 
 // Build script to include per-environment configuration and trusted roots.
 
+use chrono::Months;
+use config::AppConfig;
 use serde_json::from_str;
 use std::env;
 use std::fs;
+use url::Url;
 
 fn main() {
     let env = env::var("DEPLOY_ENV").unwrap_or_else(|_| "dev".to_string());
-
-    // Get and validate config.
-    // TODO move AppConfig to a separate crate so we can validate the config contents here (e.g. temporal interval).
     let config_file = &format!("config.{env}.json");
     let config_contents = &fs::read_to_string(config_file).unwrap_or_else(|e| {
         panic!("failed to read config file '{config_file}': {e}");
     });
+
+    // Validate the config json against the schema.
     let json = from_str(config_contents).unwrap_or_else(|e| {
         panic!("failed to deserialize JSON config '{config_file}': {e}");
     });
@@ -26,22 +28,66 @@ fn main() {
         panic!("config '{config_file}' does not match schema 'config.schema.json': {e}");
     });
 
+    // Validate the config parameters.
+    let conf = serde_json::from_str::<AppConfig>(config_contents).unwrap_or_else(|e| {
+        panic!("failed to deserialize JSON config '{config_file}': {e}");
+    });
+    for (name, params) in conf.logs {
+        // Chrome's CT policy (https://googlechrome.github.io/CertificateTransparency/log_policy.html) states:
+        // "The certificate expiry ranges for CT Logs must be no longer than one calendar year and should be no shorter than six months."
+        assert!(
+            (params.temporal_interval.start_inclusive + Months::new(6)
+                ..=params.temporal_interval.start_inclusive + Months::new(12))
+                .contains(&params.temporal_interval.end_exclusive),
+            "{name} invalid temporal interval: [{}, {})",
+            params.temporal_interval.start_inclusive,
+            params.temporal_interval.end_exclusive
+        );
+        // Valid location hints: https://developers.cloudflare.com/durable-objects/reference/data-location/#supported-locations-1
+        if let Some(location) = &params.location_hint {
+            assert!(
+                ["wnam", "enam", "sam", "weur", "eeur", "apac", "oc", "afr", "me",]
+                    .contains(&location.as_str()),
+                "{name} invalid location hint: {location}"
+            );
+        }
+
+        check_url(&params.submission_url);
+        if !params.monitoring_url.is_empty() {
+            check_url(&params.monitoring_url);
+        }
+    }
+
     // Get and validate roots. Use 'default_roots.pem' if no environment-specific roots file is found.
     let mut roots_file: &str = &format!("roots.{env}.pem");
-    if !fs::exists(roots_file).expect("Cannot check if file exists") {
+    if !fs::exists(roots_file).expect("failed to check if file exists") {
         roots_file = "default_roots.pem";
     }
     let roots =
-        static_ct_api::load_pem_chain(&fs::read(roots_file).expect("Failed to read roots file"))
-            .expect("Unable to decode certificates");
+        static_ct_api::load_pem_chain(&fs::read(roots_file).expect("failed to read roots file"))
+            .expect("unable to decode certificates");
     assert!(!roots.is_empty(), "Roots file is empty");
 
     // Copy to OUT_DIR.
     let out_dir = env::var("OUT_DIR").unwrap();
-    fs::copy(config_file, format!("{out_dir}/config.json")).expect("Failed to copy config file");
-    fs::copy(roots_file, format!("{out_dir}/roots.pem")).expect("Failed to copy roots file");
+    fs::copy(config_file, format!("{out_dir}/config.json")).expect("failed to copy config file");
+    fs::copy(roots_file, format!("{out_dir}/roots.pem")).expect("failed to copy roots file");
 
     println!("cargo::rerun-if-env-changed=DEPLOY_ENV");
+    println!("cargo::rerun-if-changed=config.schema.json");
     println!("cargo::rerun-if-changed={config_file}");
     println!("cargo::rerun-if-changed={roots_file}");
+}
+
+// Validate the URL prefix according to https://datatracker.ietf.org/doc/html/rfc6962#section-4.
+// "The <log server> prefix can include a path as well as a server name and a port."
+fn check_url(s: &str) {
+    let u = Url::parse(s).unwrap();
+    assert!(["http", "https"].contains(&u.scheme()), "invalid scheme");
+    assert!(u.domain().is_some(), "invalid domain");
+    assert_eq!(
+        u.as_str(),
+        &format!("{}{}", u.origin().ascii_serialization(), u.path()),
+        "invalid URL components"
+    );
 }

--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -60,26 +60,6 @@
                                 "end_exclusive"
                             ]
                         },
-                        "signing_key_binding": {
-                            "type": "string",
-                            "default": "SIGNING_KEY_<log-name>",
-                            "description": "Binding for a Workers Secret containing a DER-encoded P-256 signing key."
-                        },
-                        "witness_key_binding": {
-                            "type": "string",
-                            "default": "WITNESS_KEY_<log-name>",
-                            "description": "Binding for a Workers Secret containing a DER-encoded Ed25519 signing key."
-                        },
-                        "public_bucket_binding": {
-                            "type": "string",
-                            "default": "static_ct_public_<log-name>",
-                            "description": "Binding for a public R2 bucket from which to serve this log's static assets."
-                        },
-                        "cache_kv_binding": {
-                            "type": "string",
-                            "default": "cache_<log-name>",
-                            "description": "Binding for a Workers KV namespace to use for this log's deduplication cache. The KV namespace must NOT be shared across logs."
-                        },
                         "location_hint": {
                             "type": "string",
                             "description": "Provide a hint to place the log in a specific geographic location. See https://developers.cloudflare.com/durable-objects/reference/data-location/ for supported locations. If unspecified, the Durable Object will be created in proximity to the first request."

--- a/crates/ct_worker/config/Cargo.toml
+++ b/crates/ct_worker/config/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "config"
+publish = false
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Configuration for ct_worker"
+
+[dependencies]
+chrono.workspace = true
+serde.workspace = true

--- a/crates/ct_worker/config/src/lib.rs
+++ b/crates/ct_worker/config/src/lib.rs
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+// CT log configuration, in a separate crate to allow build.rs to use it.
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TemporalInterval {
+    pub start_inclusive: DateTime<Utc>,
+    pub end_exclusive: DateTime<Utc>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct AppConfig {
+    pub logging_level: Option<String>,
+    pub logs: HashMap<String, LogParams>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct LogParams {
+    pub description: Option<String>,
+    pub log_type: Option<String>,
+    #[serde(default)]
+    pub monitoring_url: String,
+    pub submission_url: String,
+    pub temporal_interval: TemporalInterval,
+    pub location_hint: Option<String>,
+    #[serde(default = "default_pool_size")]
+    pub pool_size: usize,
+    #[serde(default = "default_sequence_interval")]
+    pub sequence_interval: u64,
+}
+
+// Limit on the number of entries per batch. Tune this parameter to avoid running into various size limitations.
+// For instance, unexpectedly large leaves (e.g., with PQ signatures) could cause us to exceed the 128MB Workers memory limit. Storing 4000 10KB certificates is 40MB.
+fn default_pool_size() -> usize {
+    4000
+}
+
+fn default_sequence_interval() -> u64 {
+    1
+}


### PR DESCRIPTION
Check config at build-time to prevent certain bad deploys, with these changes:
- Validate URLs.
- Validate temporal interval using chrono::Month to account for leap years.

Other:
- Simplify config by removing bindings and instead using defaults.
- Improve code DRYness with 'valid_log_name', 'load_kv_cache', 'load_public_bucket' helpers.
- Move [profile.release] directives to workspace root Cargo.toml (fix warning).