### PR TITLE
Add 'ct_worker_' prefix to ct_worker config crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,14 +292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
-name = "config"
-version = "0.2.0"
-dependencies = [
- "chrono",
- "serde",
-]
-
-[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,9 +429,9 @@ dependencies = [
  "base64 0.21.7",
  "byteorder",
  "chrono",
- "config",
  "console_error_panic_hook",
  "console_log",
+ "ct_worker_config",
  "ed25519-dalek",
  "futures-executor",
  "futures-util",
@@ -465,6 +457,14 @@ dependencies = [
  "tokio",
  "url",
  "worker",
+]
+
+[[package]]
+name = "ct_worker_config"
+version = "0.2.0"
+dependencies = [
+ "chrono",
+ "serde",
 ]
 
 [[package]]

--- a/crates/ct_worker/Cargo.toml
+++ b/crates/ct_worker/Cargo.toml
@@ -31,7 +31,7 @@ serde.workspace = true
 serde_json.workspace = true
 jsonschema = "0.26.2"
 static_ct_api = "0.2.0"
-config = { path = "./config" }
+config = { path = "./config", package = "ct_worker_config" }
 chrono.workspace = true
 url = "2.5.4"
 
@@ -45,7 +45,7 @@ futures-executor = "0.3.31"
 anyhow.workspace = true
 base64.workspace = true
 byteorder = "1.4"
-config = { path = "./config" }
+config = { path = "./config", package = "ct_worker_config" }
 console_error_panic_hook = "0.1.1"
 console_log = { version = "1.0" }
 ed25519-dalek = { workspace = true, features = ["pkcs8"] }

--- a/crates/ct_worker/config/Cargo.toml
+++ b/crates/ct_worker/config/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "config"
+name = "ct_worker_config"
 publish = false
 version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
All crate names in the workspace must be unique, so make it clear that the config crate is specific to the 'ct_worker' application.