### PR TITLE
Refactor pool logic

### DIFF
--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -64,11 +64,16 @@
                             "type": "string",
                             "description": "Provide a hint to place the log in a specific geographic location. See https://developers.cloudflare.com/durable-objects/reference/data-location/ for supported locations. If unspecified, the Durable Object will be created in proximity to the first request."
                         },
-                        "sequence_interval": {
+                        "sequence_interval_seconds": {
                             "type": "integer",
                             "minimum": 1,
                             "default": 1,
                             "description": "The duration in between sequencing operations, in seconds."
+                        },
+                        "max_pending_entry_holds": {
+                            "type": "integer",
+                            "default": 1,
+                            "description": "The maximum number of times a pending entry can be held back from sequencing to avoid creating partial tiles. If non-zero, pending entries may be delayed by a multiple of sequence interval."
                         }
                     },
                     "required": [

--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -64,12 +64,6 @@
                             "type": "string",
                             "description": "Provide a hint to place the log in a specific geographic location. See https://developers.cloudflare.com/durable-objects/reference/data-location/ for supported locations. If unspecified, the Durable Object will be created in proximity to the first request."
                         },
-                        "pool_size": {
-                            "type": "integer",
-                            "minimum": 1,
-                            "default": 4000,
-                            "description": "The maximum number of entries to sequence at a time. See lib.rs for more information on the default."
-                        },
                         "sequence_interval": {
                             "type": "integer",
                             "minimum": 1,

--- a/crates/ct_worker/config/src/lib.rs
+++ b/crates/ct_worker/config/src/lib.rs
@@ -27,16 +27,8 @@ pub struct LogParams {
     pub submission_url: String,
     pub temporal_interval: TemporalInterval,
     pub location_hint: Option<String>,
-    #[serde(default = "default_pool_size_seconds")]
-    pub pool_size: usize,
     #[serde(default = "default_sequence_interval_seconds")]
     pub sequence_interval: u64,
-}
-
-// Limit on the number of entries per batch. Tune this parameter to avoid running into various size limitations.
-// For instance, unexpectedly large leaves (e.g., with PQ signatures) could cause us to exceed the 128MB Workers memory limit. Storing 4000 10KB certificates is 40MB.
-fn default_pool_size_seconds() -> usize {
-    4000
 }
 
 fn default_sequence_interval_seconds() -> u64 {

--- a/crates/ct_worker/config/src/lib.rs
+++ b/crates/ct_worker/config/src/lib.rs
@@ -28,9 +28,15 @@ pub struct LogParams {
     pub temporal_interval: TemporalInterval,
     pub location_hint: Option<String>,
     #[serde(default = "default_sequence_interval_seconds")]
-    pub sequence_interval: u64,
+    pub sequence_interval_seconds: u64,
+    #[serde(default = "default_max_pending_entry_holds")]
+    pub max_pending_entry_holds: usize,
 }
 
 fn default_sequence_interval_seconds() -> u64 {
+    1
+}
+
+fn default_max_pending_entry_holds() -> usize {
     1
 }

--- a/crates/ct_worker/src/batcher_do.rs
+++ b/crates/ct_worker/src/batcher_do.rs
@@ -9,7 +9,7 @@
 use crate::{get_stub, load_cache_kv, LookupKey, QueryParams, SequenceMetadata};
 use base64::prelude::*;
 use futures_util::future::{join_all, select, Either};
-use static_ct_api::LogEntry;
+use static_ct_api::PendingLogEntry;
 use std::{
     collections::{HashMap, HashSet},
     time::Duration,
@@ -37,7 +37,7 @@ struct Batcher {
 
 // A batch of entries to be submitted to the Sequencer together.
 struct Batch {
-    pending_leaves: Vec<LogEntry>,
+    pending_leaves: Vec<PendingLogEntry>,
     by_hash: HashSet<LookupKey>,
     done: Sender<HashMap<LookupKey, SequenceMetadata>>,
 }
@@ -68,7 +68,7 @@ impl DurableObject for Batcher {
         match req.path().as_str() {
             "/add_leaf" => {
                 let name = &req.query::<QueryParams>()?.name;
-                let entry: LogEntry = req.json().await?;
+                let entry: PendingLogEntry = req.json().await?;
                 let key = entry.lookup_key();
 
                 if self.in_flight >= MAX_IN_FLIGHT {

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -228,7 +228,7 @@ async fn add_chain_or_pre_chain(
 
     // First persist issuers.
     let public_bucket = ObjectBucket {
-        sequence_interval: params.sequence_interval,
+        sequence_interval_seconds: params.sequence_interval_seconds,
         bucket: load_public_bucket(env, name)?,
         metrics: None,
     };

--- a/crates/ct_worker/src/lib.rs
+++ b/crates/ct_worker/src/lib.rs
@@ -385,7 +385,7 @@ trait ObjectBackend {
 }
 
 struct ObjectBucket {
-    sequence_interval: u64,
+    sequence_interval_seconds: u64,
     bucket: Bucket,
     metrics: Option<ObjectMetrics>,
 }
@@ -404,7 +404,7 @@ impl ObjectBackend for ObjectBucket {
         } else {
             metadata.cache_control = Some(format!(
                 "public, max-age={}, must-revalidate",
-                self.sequence_interval
+                self.sequence_interval_seconds
             ));
         }
         self.metrics

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -154,7 +154,7 @@ impl Sequencer {
             .trim_end_matches('/');
         let signing_key = load_signing_key(&self.env, name)?.clone();
         let witness_key = load_witness_key(&self.env, name)?.clone();
-        let sequence_interval = Duration::from_secs(params.sequence_interval);
+        let sequence_interval = Duration::from_secs(params.sequence_interval_seconds);
 
         self.config = Some(LogConfig {
             name: name.to_string(),
@@ -162,9 +162,10 @@ impl Sequencer {
             signing_key,
             witness_key,
             sequence_interval,
+            max_pending_entry_holds: params.max_pending_entry_holds,
         });
         self.public_bucket = Some(ObjectBucket {
-            sequence_interval: params.sequence_interval,
+            sequence_interval_seconds: params.sequence_interval_seconds,
             bucket: load_public_bucket(&self.env, name)?,
             metrics: Some(ObjectMetrics::new(&self.metrics.registry)),
         });

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -12,7 +12,7 @@ use crate::{
 use ctlog::{CreateError, LogConfig, PoolState, SequenceState};
 use futures_util::future::join_all;
 use log::{info, warn, Level};
-use static_ct_api::LogEntry;
+use static_ct_api::PendingLogEntry;
 use std::str::FromStr;
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -81,7 +81,7 @@ impl DurableObject for Sequencer {
             }
             "/add_batch" => {
                 endpoint = "add_batch";
-                let pending_entries: Vec<LogEntry> = req.json().await?;
+                let pending_entries: Vec<PendingLogEntry> = req.json().await?;
                 self.add_batch(&pending_entries).await
             }
             _ => {
@@ -220,7 +220,7 @@ impl Sequencer {
     // Add a batch of entries, returning a Response with metadata for
     // successfully sequenced entries. Entries that fail to be added (e.g., due to rate limiting)
     // are omitted.
-    async fn add_batch(&mut self, pending_entries: &[LogEntry]) -> Result<Response> {
+    async fn add_batch(&mut self, pending_entries: &[PendingLogEntry]) -> Result<Response> {
         // Safe to unwrap config here as the log must be initialized.
         let mut futures = Vec::with_capacity(pending_entries.len());
         for pending_entry in pending_entries {


### PR DESCRIPTION
This PR contains quite a bit of refactoring of the pool logic in order to address #33. The most significant change is using a separate https://docs.rs/tokio/latest/tokio/sync/watch/index.html `{Sender, Receiver}` pair per entry instead of per "pool" of entries. This gives us the flexibility to break up pools of pending entries so we can hold back some entries when sequencing to try to prefer creating full tiles.

The commits can be reviewed independently and each have more detailed commit messages, although some of the commits remove or refactor code added in previous commits (e.g., the `Pool` struct).

* 2af4060 Add ability to hold entries back from sequencing to reduce partial tiles
* f9cc093 Use Vec::with_capacity where applicable, and pass owned PendingLogEntry to avoid clone
* 3a0f655 Use one Sender per PendingLogEntry instead of per batch
* 41ec703 Add PendingLogEntry struct to avoid overloading LogEntry
* 7fce31e Merge Pool struct into PoolState
* 143fd22 Add pool receiver directly to in_sequencing HashMap
* 17261a8 Refactor pool logic