### PR TITLE
Add ability to tune per-log batching behavior

### DIFF
--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -77,7 +77,12 @@
                         "max_sequence_skips": {
                             "type": "integer",
                             "default": 0,
-                            "description": "The maximum number of times sequencing can be skipped to avoid creating partial tiles. If non-zero, pending entries may be delayed by a multiple of the sequence interval."
+                            "description": "The maximum number of times sequencing can be skipped to avoid creating partial tiles. If non-zero, pending entries may be delayed by either a multiple of the sequence interval or sequence_skip_threshold_millis if set."
+                        },
+                        "sequence_skip_threshold_millis": {
+                            "type": "integer",
+                            "default": 0,
+                            "description": "If non-zero, entries will only be skipped by sequencing (when max_sequenced_skips is non-zero) if they have been in the pool for less than this timeout."
                         },
                         "num_batchers": {
                             "type": "integer",
@@ -90,7 +95,7 @@
                             "type": "integer",
                             "minimum": 100,
                             "default": 1000,
-                            "description": "The maximum time to wait before submitting a batch to the sequencer, in milliseconds."
+                            "description": "The maximum duration to wait before submitting a batch to the sequencer, in milliseconds."
                         },
                         "max_batch_entries": {
                             "type": "integer",

--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -76,6 +76,7 @@
                         },
                         "max_sequence_skips": {
                             "type": "integer",
+                            "minimum": 0,
                             "default": 0,
                             "description": "The maximum number of times sequencing can be skipped to avoid creating partial tiles. If non-zero, pending entries may be delayed by either a multiple of the sequence interval or sequence_skip_threshold_millis if set."
                         },

--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -106,7 +106,7 @@
                         "enable_dedup": {
                             "type": "boolean",
                             "default": true,
-                            "description": "Enables checking the deduplication cache for add-(pre-)chain requests. Can be disable for tests and benchmarks."
+                            "description": "Enables checking the deduplication cache for add-(pre-)chain requests. Can be disabled for tests and benchmarks."
                         }
                     },
                     "required": [

--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -78,6 +78,25 @@
                             "type": "integer",
                             "default": 0,
                             "description": "The maximum number of times sequencing can be skipped to avoid creating partial tiles. If non-zero, pending entries may be delayed by a multiple of the sequence interval."
+                        },
+                        "num_batchers": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 8,
+                            "maximum": 255,
+                            "description": "The number of batchers to use to proxy requests to the sequencer. If zero, requests from the frontend worker go directly to the sequencer."
+                        },
+                        "batch_timeout_millis": {
+                            "type": "integer",
+                            "minimum": 100,
+                            "default": 1000,
+                            "description": "The maximum time to wait before submitting a batch to the sequencer, in milliseconds."
+                        },
+                        "max_batch_entries": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "default": 1000,
+                            "description": "The maximum number of entries per batch."
                         }
                     },
                     "required": [

--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -97,6 +97,11 @@
                             "minimum": 1,
                             "default": 1000,
                             "description": "The maximum number of entries per batch."
+                        },
+                        "disable_dedup": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Disable checking the deduplication cache for add-(pre-)chain requests (e.g., for tests or benchmarks)."
                         }
                     },
                     "required": [

--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
+    "additionalProperties": false,
     "properties": {
         "logging_level": {
             "type": "string",
@@ -15,9 +16,11 @@
         "logs": {
             "type": "object",
             "description": "Dictionary CT log shard names to configurations.",
+            "additionalProperties": false,
             "patternProperties": {
                 "^[a-zA-Z0-9_]+$": {
                     "type": "object",
+                    "additionalProperties": false,
                     "properties": {
                         "description": {
                             "type": "string",
@@ -43,6 +46,7 @@
                         },
                         "temporal_interval": {
                             "type": "object",
+                            "additionalProperties": false,
                             "properties": {
                                 "start_inclusive": {
                                     "type": "string",
@@ -70,10 +74,10 @@
                             "default": 1000,
                             "description": "The duration in between sequencing operations, in milliseconds."
                         },
-                        "max_pending_entry_holds": {
+                        "max_sequence_skips": {
                             "type": "integer",
-                            "default": 1,
-                            "description": "The maximum number of times a pending entry can be held back from sequencing to avoid creating partial tiles. If non-zero, pending entries may be delayed by a multiple of sequence interval."
+                            "default": 0,
+                            "description": "The maximum number of times sequencing can be skipped to avoid creating partial tiles. If non-zero, pending entries may be delayed by a multiple of the sequence interval."
                         }
                     },
                     "required": [

--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -64,11 +64,11 @@
                             "type": "string",
                             "description": "Provide a hint to place the log in a specific geographic location. See https://developers.cloudflare.com/durable-objects/reference/data-location/ for supported locations. If unspecified, the Durable Object will be created in proximity to the first request."
                         },
-                        "sequence_interval_seconds": {
+                        "sequence_interval_millis": {
                             "type": "integer",
-                            "minimum": 1,
-                            "default": 1,
-                            "description": "The duration in between sequencing operations, in seconds."
+                            "minimum": 100,
+                            "default": 1000,
+                            "description": "The duration in between sequencing operations, in milliseconds."
                         },
                         "max_pending_entry_holds": {
                             "type": "integer",

--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -81,8 +81,7 @@
                         },
                         "sequence_skip_threshold_millis": {
                             "type": "integer",
-                            "default": 0,
-                            "description": "If non-zero, entries will only be skipped by sequencing (when max_sequenced_skips is non-zero) if they have been in the pool for less than this timeout."
+                            "description": "If provided, entries will only be skipped by sequencing (when max_sequenced_skips is non-zero) if they have been in the pool for less than this timeout."
                         },
                         "num_batchers": {
                             "type": "integer",
@@ -103,10 +102,10 @@
                             "default": 1000,
                             "description": "The maximum number of entries per batch."
                         },
-                        "disable_dedup": {
+                        "enable_dedup": {
                             "type": "boolean",
-                            "default": false,
-                            "description": "Disable checking the deduplication cache for add-(pre-)chain requests (e.g., for tests or benchmarks)."
+                            "default": true,
+                            "description": "Enables checking the deduplication cache for add-(pre-)chain requests. Can be disable for tests and benchmarks."
                         }
                     },
                     "required": [

--- a/crates/ct_worker/config.schema.json
+++ b/crates/ct_worker/config.schema.json
@@ -81,6 +81,7 @@
                         },
                         "sequence_skip_threshold_millis": {
                             "type": "integer",
+                            "minimum": 0,
                             "description": "If provided, entries will only be skipped by sequencing (when max_sequenced_skips is non-zero) if they have been in the pool for less than this timeout."
                         },
                         "num_batchers": {

--- a/crates/ct_worker/config/src/lib.rs
+++ b/crates/ct_worker/config/src/lib.rs
@@ -29,14 +29,14 @@ pub struct LogParams {
     pub location_hint: Option<String>,
     #[serde(default = "default_sequence_interval_millis")]
     pub sequence_interval_millis: u64,
-    #[serde(default = "default_max_pending_entry_holds")]
-    pub max_pending_entry_holds: usize,
+    #[serde(default = "default_max_sequence_skips")]
+    pub max_sequence_skips: usize,
 }
 
 fn default_sequence_interval_millis() -> u64 {
     1000
 }
 
-fn default_max_pending_entry_holds() -> usize {
-    1
+fn default_max_sequence_skips() -> usize {
+    0
 }

--- a/crates/ct_worker/config/src/lib.rs
+++ b/crates/ct_worker/config/src/lib.rs
@@ -31,6 +31,7 @@ pub struct LogParams {
     pub sequence_interval_millis: u64,
     #[serde(default = "default_max_sequence_skips")]
     pub max_sequence_skips: usize,
+    pub sequence_skip_threshold_millis: Option<u64>,
     #[serde(default = "default_num_batchers")]
     pub num_batchers: u8,
     #[serde(default = "default_batch_timeout_millis")]

--- a/crates/ct_worker/config/src/lib.rs
+++ b/crates/ct_worker/config/src/lib.rs
@@ -37,6 +37,8 @@ pub struct LogParams {
     pub batch_timeout_millis: u64,
     #[serde(default = "default_max_batch_entries")]
     pub max_batch_entries: usize,
+    #[serde(default)]
+    pub disable_dedup: bool,
 }
 
 fn default_sequence_interval_millis() -> u64 {

--- a/crates/ct_worker/config/src/lib.rs
+++ b/crates/ct_worker/config/src/lib.rs
@@ -27,37 +27,30 @@ pub struct LogParams {
     pub submission_url: String,
     pub temporal_interval: TemporalInterval,
     pub location_hint: Option<String>,
-    #[serde(default = "default_sequence_interval_millis")]
+    #[serde(default = "default_u64::<1000>")]
     pub sequence_interval_millis: u64,
-    #[serde(default = "default_max_sequence_skips")]
+    #[serde(default = "default_usize::<0>")]
     pub max_sequence_skips: usize,
     pub sequence_skip_threshold_millis: Option<u64>,
-    #[serde(default = "default_num_batchers")]
+    #[serde(default = "default_u8::<8>")]
     pub num_batchers: u8,
-    #[serde(default = "default_batch_timeout_millis")]
+    #[serde(default = "default_u64::<1000>")]
     pub batch_timeout_millis: u64,
-    #[serde(default = "default_max_batch_entries")]
+    #[serde(default = "default_usize::<100>")]
     pub max_batch_entries: usize,
-    #[serde(default)]
-    pub disable_dedup: bool,
+    #[serde(default = "default_bool::<true>")]
+    pub enable_dedup: bool,
 }
 
-fn default_sequence_interval_millis() -> u64 {
-    1000
+fn default_bool<const V: bool>() -> bool {
+    V
 }
-
-fn default_max_sequence_skips() -> usize {
-    0
+fn default_u8<const V: u8>() -> u8 {
+    V
 }
-
-fn default_num_batchers() -> u8 {
-    8
+fn default_u64<const V: u64>() -> u64 {
+    V
 }
-
-fn default_batch_timeout_millis() -> u64 {
-    1000
-}
-
-fn default_max_batch_entries() -> usize {
-    100
+fn default_usize<const V: usize>() -> usize {
+    V
 }

--- a/crates/ct_worker/config/src/lib.rs
+++ b/crates/ct_worker/config/src/lib.rs
@@ -27,14 +27,14 @@ pub struct LogParams {
     pub submission_url: String,
     pub temporal_interval: TemporalInterval,
     pub location_hint: Option<String>,
-    #[serde(default = "default_sequence_interval_seconds")]
-    pub sequence_interval_seconds: u64,
+    #[serde(default = "default_sequence_interval_millis")]
+    pub sequence_interval_millis: u64,
     #[serde(default = "default_max_pending_entry_holds")]
     pub max_pending_entry_holds: usize,
 }
 
-fn default_sequence_interval_seconds() -> u64 {
-    1
+fn default_sequence_interval_millis() -> u64 {
+    1000
 }
 
 fn default_max_pending_entry_holds() -> usize {

--- a/crates/ct_worker/config/src/lib.rs
+++ b/crates/ct_worker/config/src/lib.rs
@@ -31,6 +31,12 @@ pub struct LogParams {
     pub sequence_interval_millis: u64,
     #[serde(default = "default_max_sequence_skips")]
     pub max_sequence_skips: usize,
+    #[serde(default = "default_num_batchers")]
+    pub num_batchers: u8,
+    #[serde(default = "default_batch_timeout_millis")]
+    pub batch_timeout_millis: u64,
+    #[serde(default = "default_max_batch_entries")]
+    pub max_batch_entries: usize,
 }
 
 fn default_sequence_interval_millis() -> u64 {
@@ -39,4 +45,16 @@ fn default_sequence_interval_millis() -> u64 {
 
 fn default_max_sequence_skips() -> usize {
     0
+}
+
+fn default_num_batchers() -> u8 {
+    8
+}
+
+fn default_batch_timeout_millis() -> u64 {
+    1000
+}
+
+fn default_max_batch_entries() -> usize {
+    100
 }

--- a/crates/ct_worker/src/batcher_do.rs
+++ b/crates/ct_worker/src/batcher_do.rs
@@ -127,8 +127,6 @@ impl<E: PendingLogEntryTrait> GenericBatcher<E> {
                 } else {
                     // Failed to sequence this entry, either due to an error
                     // submitting the batch or rate limiting at the Sequencer.
-                    // The entry's batch could have also been dropped before
-                    // this fetch task woke up and received the channel update.
                     Response::error("rate limited", 429)
                 };
                 self.in_flight -= 1;

--- a/crates/ct_worker/src/ctlog.rs
+++ b/crates/ct_worker/src/ctlog.rs
@@ -111,7 +111,7 @@ pub(crate) struct PoolState<P: PendingLogEntryTrait> {
     // that are potentially skippable.
     leftover_timestamps_millis: [UnixTimestamp; TlogTile::FULL_WIDTH as usize],
 
-    // The next slot to insert a entry timestamp.
+    // The next slot to insert an entry timestamp.
     leftover_timestamps_next_slot: usize,
 }
 
@@ -168,7 +168,8 @@ impl<E: PendingLogEntryTrait> PoolState<E> {
     // the corresponding Senders to update when the entries have been sequenced.
     //
     // Skip sequencing leftover entries that would be published as a partial
-    // tile unless they have already been held back `max_sequence_skips` times.
+    // tile unless they have already been held back `max_sequence_skips` times
+    // or have been in the pool longer than `sequence_skip_threshold_millis`.
     //
     // The return value is an Option that indicates whether or not a new
     // checkpoint should be produced (even if there are no new entries).

--- a/crates/ct_worker/src/ctlog.rs
+++ b/crates/ct_worker/src/ctlog.rs
@@ -707,7 +707,10 @@ async fn sequence_entries<L: LogEntryTrait>(
         // If the data tile is full, stage it.
         if n % u64::from(TlogTile::FULL_WIDTH) == 0 {
             stage_data_tile(n, &mut edge_tiles, &mut tile_uploads, &data_tile);
-            metrics.seq_data_tile_size.observe(data_tile.len().as_f64());
+            metrics
+                .seq_data_tile_size
+                .with_label_values(&["full"])
+                .observe(data_tile.len().as_f64());
             data_tile.clear();
         }
     }
@@ -715,7 +718,10 @@ async fn sequence_entries<L: LogEntryTrait>(
     // Stage leftover partial data tile, if any.
     if n != old_size && n % u64::from(TlogTile::FULL_WIDTH) != 0 {
         stage_data_tile(n, &mut edge_tiles, &mut tile_uploads, &data_tile);
-        metrics.seq_data_tile_size.observe(data_tile.len().as_f64());
+        metrics
+            .seq_data_tile_size
+            .with_label_values(&["partial"])
+            .observe(data_tile.len().as_f64());
     }
 
     // Produce and stage new tree tiles.

--- a/crates/ct_worker/src/ctlog.rs
+++ b/crates/ct_worker/src/ctlog.rs
@@ -199,7 +199,7 @@ impl<E: PendingLogEntryTrait> PoolState<E> {
             self.sequence_skips = usize::from(num_leftover_entries != 0);
             let split_index = self.pending_entries.len() - num_leftover_entries;
             let leftover_entries = self.pending_entries.split_off(split_index);
-            let leftover_pending = leftover_entries
+            let leftover_dedup = leftover_entries
                 .iter()
                 .filter_map(|(entry, _)| {
                     let lookup_key = entry.lookup_key();
@@ -208,7 +208,7 @@ impl<E: PendingLogEntryTrait> PoolState<E> {
                         .map(|rx| (lookup_key, rx))
                 })
                 .collect::<HashMap<_, _>>();
-            self.in_sequencing_dedup = std::mem::replace(&mut self.pending_dedup, leftover_pending);
+            self.in_sequencing_dedup = std::mem::replace(&mut self.pending_dedup, leftover_dedup);
             Some(std::mem::replace(
                 &mut self.pending_entries,
                 leftover_entries,

--- a/crates/ct_worker/src/ctlog.rs
+++ b/crates/ct_worker/src/ctlog.rs
@@ -111,7 +111,8 @@ pub(crate) struct PoolState<P: PendingLogEntryTrait> {
     // that are potentially skippable.
     leftover_timestamps_millis: [UnixTimestamp; TlogTile::FULL_WIDTH as usize],
 
-    // The next slot to insert an entry timestamp.
+    // The next slot to insert an entry timestamp, when reduced modulo
+    // `TlogTile::FULL_WIDTH`.
     leftover_timestamps_next_slot: usize,
 }
 

--- a/crates/ct_worker/src/ctlog.rs
+++ b/crates/ct_worker/src/ctlog.rs
@@ -72,7 +72,7 @@ impl LogConfig {
             origin: self.origin.clone(),
             checkpoint_signers: Vec::new(),
             sequence_interval: self.sequence_interval,
-            max_pending_entry_holds: self.max_pending_entry_holds,
+            max_sequence_skips: self.max_sequence_skips,
         }
     }
 }

--- a/crates/ct_worker/src/ctlog.rs
+++ b/crates/ct_worker/src/ctlog.rs
@@ -63,7 +63,7 @@ pub(crate) struct LogConfig {
     pub(crate) sequence_interval: Duration,
     pub(crate) max_sequence_skips: usize,
     pub(crate) sequence_skip_threshold_millis: Option<u64>,
-    pub(crate) disable_dedup: bool,
+    pub(crate) enable_dedup: bool,
 }
 
 #[cfg(test)]
@@ -77,7 +77,7 @@ impl LogConfig {
             sequence_interval: self.sequence_interval,
             max_sequence_skips: self.max_sequence_skips,
             sequence_skip_threshold_millis: None,
-            disable_dedup: false,
+            enable_dedup: true,
         }
     }
 }
@@ -506,7 +506,7 @@ pub(crate) fn add_leaf_to_pool<E: PendingLogEntryTrait>(
 ) -> AddLeafResult {
     let hash = entry.lookup_key();
 
-    if config.disable_dedup {
+    if !config.enable_dedup {
         // Bypass deduplication and rate limit checks.
         state.add(hash, entry)
     } else if let Some(result) = state.check(&hash) {
@@ -2126,7 +2126,7 @@ mod tests {
                 checkpoint_signers,
                 sequence_interval: Duration::from_secs(1),
                 max_sequence_skips: 0,
-                disable_dedup: false,
+                enable_dedup: true,
                 sequence_skip_threshold_millis: None,
             };
             let pool_state = PoolState::default();

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -205,7 +205,7 @@ async fn add_chain_or_pre_chain(
 
     // Check if entry is cached and return right away if so.
     let kv = load_cache_kv(env, name)?;
-    if !params.disable_dedup {
+    if params.enable_dedup {
         if let Some(metadata) = kv
             .get(&BASE64_STANDARD.encode(lookup_key))
             .bytes_with_metadata::<SequenceMetadata>()

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -231,7 +231,6 @@ async fn add_chain_or_pre_chain(
 
     // First persist issuers.
     let public_bucket = ObjectBucket {
-        sequence_interval_seconds: params.sequence_interval_seconds,
         bucket: load_public_bucket(env, name)?,
         metrics: None,
     };

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -277,7 +277,7 @@ async fn add_chain_or_pre_chain(
             .await
             .is_err()
         {
-            debug!("{name}: Failed to write entry to deduplication cache");
+            warn!("{name}: Failed to write entry to deduplication cache");
         }
     }
     let entry = StaticCTLogEntry {

--- a/crates/ct_worker/src/lib.rs
+++ b/crates/ct_worker/src/lib.rs
@@ -30,6 +30,10 @@ use worker::*;
 use x509_util::CertPool;
 use x509_verify::x509_cert::Certificate;
 
+const BATCH_ENDPOINT: &str = "/add_batch";
+const ENTRY_ENDPOINT: &str = "/add_entry";
+const METRICS_ENDPOINT: &str = "/metrics";
+
 // Application configuration.
 static CONFIG: LazyLock<AppConfig> = LazyLock::new(|| {
     serde_json::from_str::<AppConfig>(include_str!(concat!(env!("OUT_DIR"), "/config.json")))

--- a/crates/ct_worker/src/lib.rs
+++ b/crates/ct_worker/src/lib.rs
@@ -384,7 +384,6 @@ trait ObjectBackend {
 }
 
 struct ObjectBucket {
-    sequence_interval_seconds: u64,
     bucket: Bucket,
     metrics: Option<ObjectMetrics>,
 }
@@ -401,10 +400,7 @@ impl ObjectBackend for ObjectBucket {
         if opts.immutable {
             metadata.cache_control = Some("public, max-age=604800, immutable".into());
         } else {
-            metadata.cache_control = Some(format!(
-                "public, max-age={}, must-revalidate",
-                self.sequence_interval_seconds
-            ));
+            metadata.cache_control = Some("no-store".into());
         }
         self.metrics
             .as_ref()

--- a/crates/ct_worker/src/metrics.rs
+++ b/crates/ct_worker/src/metrics.rs
@@ -29,7 +29,7 @@ pub(crate) struct Metrics {
     pub(crate) seq_delay: Histogram,
     pub(crate) seq_leaf_size: Histogram,
     pub(crate) seq_tiles: Counter,
-    pub(crate) seq_data_tile_size: Histogram,
+    pub(crate) seq_data_tile_size: HistogramVec,
 
     pub(crate) tree_time: Gauge,
     pub(crate) tree_size: Gauge,
@@ -114,9 +114,10 @@ impl Metrics {
             r
         )
         .unwrap();
-        let seq_data_tile_size = register_histogram_with_registry!(
+        let seq_data_tile_size = register_histogram_vec_with_registry!(
             "sequencing_data_tiles_bytes",
             "Size of uploaded data tiles, including partials.",
+            &["type"],
             vec![10_000.0, 100_000.0, 1_000_000.0],
             r
         )

--- a/crates/ct_worker/src/metrics.rs
+++ b/crates/ct_worker/src/metrics.rs
@@ -116,7 +116,7 @@ impl Metrics {
         .unwrap();
         let seq_data_tile_size = register_histogram_vec_with_registry!(
             "sequencing_data_tiles_bytes",
-            "Size of uploaded data tiles, including partials.",
+            "Size of uploaded data tiles, with 'type' indicating whether the tile is full or partial.",
             &["type"],
             vec![10_000.0, 100_000.0, 1_000_000.0],
             r

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -7,14 +7,15 @@ use crate::{
     ctlog, load_public_bucket, load_signing_key, load_witness_key,
     metrics::{millis_diff_as_secs, AsF64, Metrics, ObjectMetrics},
     util::{self, now_millis},
-    DedupCache, MemoryCache, ObjectBucket, QueryParams, CONFIG, ROOTS,
+    DedupCache, MemoryCache, ObjectBucket, QueryParams, SequenceMetadata, BATCH_ENDPOINT, CONFIG,
+    ENTRY_ENDPOINT, METRICS_ENDPOINT, ROOTS,
 };
 use ctlog::{CreateError, LogConfig, PoolState, SequenceState};
 use futures_util::future::join_all;
 use log::{info, warn, Level};
 use static_ct_api::{
-    LogEntryTrait, PendingLogEntryTrait, StandardEd25519CheckpointSigner, StaticCTCheckpointSigner,
-    StaticCTLogEntry, StaticCTPendingLogEntry,
+    LogEntryTrait, LookupKey, PendingLogEntryTrait, StandardEd25519CheckpointSigner,
+    StaticCTCheckpointSigner, StaticCTLogEntry, StaticCTPendingLogEntry,
 };
 use std::str::FromStr;
 use std::time::Duration;
@@ -119,21 +120,27 @@ impl<E: PendingLogEntryTrait> GenericSequencer<E> {
         let start = now_millis();
         self.metrics.req_in_flight.inc();
 
-        let endpoint: &str;
-        let resp = match req.path().as_str() {
-            "/metrics" => {
-                endpoint = "metrics";
-                self.metrics.req_count.with_label_values(&["metrics"]).inc();
-                self.fetch_metrics()
+        let path = req.path();
+        let mut endpoint = path.trim_start_matches('/');
+        let resp = match path.as_str() {
+            METRICS_ENDPOINT => self.fetch_metrics(),
+            ENTRY_ENDPOINT => {
+                let pending_entry: E = req.json().await?;
+                let lookup_key = pending_entry.lookup_key();
+                let result = self.add_batch(vec![pending_entry]).await;
+                if result.is_empty() || result[0].0 != lookup_key {
+                    Response::error("rate limited", 429)
+                } else {
+                    Response::from_json(&result[0].1)
+                }
             }
-            "/add_batch" => {
-                endpoint = "add_batch";
+            BATCH_ENDPOINT => {
                 let pending_entries: Vec<E> = req.json().await?;
-                self.add_batch(pending_entries).await
+                Response::from_json(&self.add_batch(pending_entries).await)
             }
             _ => {
                 endpoint = "unknown";
-                Response::error("Unknown endpoint", 404)
+                Response::error("unknown endpoint", 404)
             }
         };
         self.metrics.req_count.with_label_values(&[endpoint]).inc();
@@ -262,10 +269,10 @@ impl<E: PendingLogEntryTrait> GenericSequencer<E> {
         Ok(())
     }
 
-    // Add a batch of entries, returning a Response with metadata for
-    // successfully sequenced entries. Entries that fail to be added (e.g., due to rate limiting)
-    // are omitted.
-    async fn add_batch(&mut self, pending_entries: Vec<E>) -> Result<Response> {
+    // Add a batch of entries, returning metadata for successfully sequenced
+    // entries. Entries that fail to be added (e.g., due to rate limiting) are
+    // omitted.
+    async fn add_batch(&mut self, pending_entries: Vec<E>) -> Vec<(LookupKey, SequenceMetadata)> {
         // Safe to unwrap config here as the log must be initialized.
         let mut futures = Vec::with_capacity(pending_entries.len());
         let mut lookup_keys = Vec::with_capacity(pending_entries.len());
@@ -291,13 +298,11 @@ impl<E: PendingLogEntryTrait> GenericSequencer<E> {
 
         // Zip the cache keys with the cache values, filtering out entries that
         // were not sequenced (e.g., due to rate limiting).
-        let result = lookup_keys
-            .iter()
+        lookup_keys
+            .into_iter()
             .zip(entries_metadata.iter())
-            .filter_map(|(key, value_opt)| value_opt.as_ref().map(|metadata| (key, metadata)))
-            .collect::<Vec<_>>();
-
-        Response::from_json(&result)
+            .filter_map(|(key, value_opt)| value_opt.map(|metadata| (key, metadata)))
+            .collect::<Vec<_>>()
     }
 
     fn fetch_metrics(&self) -> Result<Response> {

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -215,6 +215,7 @@ impl<E: PendingLogEntryTrait> GenericSequencer<E> {
             checkpoint_signers,
             sequence_interval,
             max_sequence_skips: params.max_sequence_skips,
+            disable_dedup: params.disable_dedup,
         });
         self.public_bucket = Some(ObjectBucket {
             bucket: load_public_bucket(&self.env, name)?,
@@ -283,6 +284,7 @@ impl<E: PendingLogEntryTrait> GenericSequencer<E> {
             let add_leaf_result = ctlog::add_leaf_to_pool(
                 &mut self.pool_state,
                 self.cache.as_ref().unwrap(),
+                self.config.as_ref().unwrap(),
                 pending_entry,
             );
 

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -207,7 +207,7 @@ impl<E: PendingLogEntryTrait> GenericSequencer<E> {
             origin: origin.to_string(),
             checkpoint_signers,
             sequence_interval,
-            max_pending_entry_holds: params.max_pending_entry_holds,
+            max_sequence_skips: params.max_sequence_skips,
         });
         self.public_bucket = Some(ObjectBucket {
             bucket: load_public_bucket(&self.env, name)?,

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -199,8 +199,7 @@ impl<E: PendingLogEntryTrait> GenericSequencer<E> {
             .trim_start_matches("http://")
             .trim_start_matches("https://")
             .trim_end_matches('/');
-
-        let sequence_interval = Duration::from_secs(params.sequence_interval_seconds);
+        let sequence_interval = Duration::from_millis(params.sequence_interval_millis);
         let checkpoint_signers = (self.key_loader)(&self.env, name, origin)?;
 
         self.config = Some(LogConfig {
@@ -211,7 +210,6 @@ impl<E: PendingLogEntryTrait> GenericSequencer<E> {
             max_pending_entry_holds: params.max_pending_entry_holds,
         });
         self.public_bucket = Some(ObjectBucket {
-            sequence_interval_seconds: params.sequence_interval_seconds,
             bucket: load_public_bucket(&self.env, name)?,
             metrics: Some(ObjectMetrics::new(&self.metrics.registry)),
         });

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -215,7 +215,7 @@ impl<E: PendingLogEntryTrait> GenericSequencer<E> {
             checkpoint_signers,
             sequence_interval,
             max_sequence_skips: params.max_sequence_skips,
-            disable_dedup: params.disable_dedup,
+            enable_dedup: params.enable_dedup,
             sequence_skip_threshold_millis: params.sequence_skip_threshold_millis,
         });
         self.public_bucket = Some(ObjectBucket {

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -216,6 +216,7 @@ impl<E: PendingLogEntryTrait> GenericSequencer<E> {
             sequence_interval,
             max_sequence_skips: params.max_sequence_skips,
             disable_dedup: params.disable_dedup,
+            sequence_skip_threshold_millis: params.sequence_skip_threshold_millis,
         });
         self.public_bucket = Some(ObjectBucket {
             bucket: load_public_bucket(&self.env, name)?,


### PR DESCRIPTION
c913c38 Fix comment about dropped channels

The value in the channel will persist even after the sender is dropped,
so remove the comment.  According to
https://docs.rs/tokio/latest/tokio/sync/watch/index.html#closing, "The
value in the channel will not be dropped until the sender and all
receivers have been dropped."

f721b0c Add breakdown of full vs partial tiles to metrics

a053648 Add ability to set a maximum timeout for skipped entries

When a pending entry has been queued for longer than the timeout, it
will be included in the next sequencing regardless of how many times it
has exceeded the number of allowed skipped sequencings.

859df92 Add option to disable deduplication checks

Add an option to the configuration to disable the deduplication cache,
which is useful for running tests and benchmarks against a log.

a16ee94 Add batcher parameters to log configuration, and allow setting zero batchers

- Add ability to set num_batchers to zero so the frontend worker
  connects directly to the sequencer.
- Remove MAX_IN_FLIGHT check from batcher. If we need some sort of
  rate-limiting in the batchers, we can add it later based on
  operational experience.

0f92d2a Allow skipping checkpoint creation when there are no entries to sequence

- Restore old log behavior by setting default 'max_sequence_skips' to 0
- Rework PoolState::take() to return an Option indicating whether or not
  we sequencing can be skipped are no new entries or entries that don't
  make up a full tile.
- Set additionalProperties:false in JSON schema

e9d76c0 Specify sequence interval in milliseconds instead of seconds