### PR TITLE
Clean up parsing in static_ct_api

### DIFF
--- a/crates/ct_worker/src/lib.rs
+++ b/crates/ct_worker/src/lib.rs
@@ -19,11 +19,10 @@ use p256::{ecdsa::SigningKey as EcdsaSigningKey, pkcs8::DecodePrivateKey};
 use serde::Deserialize;
 use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
-use static_ct_api::LookupKey;
 use std::collections::{HashMap, VecDeque};
 use std::io::Write;
 use std::sync::{LazyLock, OnceLock};
-use tlog_tiles::SequenceMetadata;
+use tlog_tiles::{LookupKey, SequenceMetadata};
 use util::now_millis;
 #[allow(clippy::wildcard_imports)]
 use worker::*;

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -7,15 +7,15 @@ use crate::{
     ctlog, load_public_bucket, load_signing_key, load_witness_key,
     metrics::{millis_diff_as_secs, AsF64, Metrics, ObjectMetrics},
     util::{self, now_millis},
-    DedupCache, MemoryCache, ObjectBucket, QueryParams, SequenceMetadata, BATCH_ENDPOINT, CONFIG,
-    ENTRY_ENDPOINT, METRICS_ENDPOINT, ROOTS,
+    DedupCache, LookupKey, MemoryCache, ObjectBucket, QueryParams, SequenceMetadata,
+    BATCH_ENDPOINT, CONFIG, ENTRY_ENDPOINT, METRICS_ENDPOINT, ROOTS,
 };
 use ctlog::{CreateError, LogConfig, PoolState, SequenceState};
 use futures_util::future::join_all;
 use log::{info, warn, Level};
 use static_ct_api::{
-    LogEntryTrait, LookupKey, PendingLogEntryTrait, StandardEd25519CheckpointSigner,
-    StaticCTCheckpointSigner, StaticCTLogEntry, StaticCTPendingLogEntry,
+    LogEntryTrait, PendingLogEntryTrait, StandardEd25519CheckpointSigner, StaticCTCheckpointSigner,
+    StaticCTLogEntry, StaticCTPendingLogEntry,
 };
 use std::str::FromStr;
 use std::time::Duration;


### PR DESCRIPTION
* Use '&[u8]' (which implements Read) instead of Cursor where applicable
* Clean up SCT extensions parsing
* Clean up chain_fingerprints parsing
* Add enum for EntryType (X509Cert or Precert) and use where applicable
* Create PrecertData wrapper around fields that are only present in precerts, put an optional in StaticCTPendingLogEntry. The presence of the optional indicates whether the entry is a cert or precert.
* Make validate_chain return a StaticCTPendingLogEntry and remove ValidatedChain struct. And there's no need for validate_chain to return the raw issuers since the caller already has the raw chain.
* Use tlog_tiles::LookupKey instead of static_ct_api::LookupKey