### PR TITLE
Move PendingLogEntry and LogEntry traits to tlog_tiles crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,6 +2393,7 @@ name = "tlog_tiles"
 version = "0.2.0"
 dependencies = [
  "base64",
+ "length_prefixed",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -13,8 +13,9 @@ use log::{debug, warn, Level};
 use p256::pkcs8::EncodePublicKey;
 use serde::Serialize;
 use serde_with::{base64::Base64, serde_as};
-use static_ct_api::{AddChainRequest, GetRootsResponse, PendingLogEntryTrait, StaticCTLogEntry};
+use static_ct_api::{AddChainRequest, GetRootsResponse, StaticCTLogEntry};
 use std::str::FromStr;
+use tlog_tiles::PendingLogEntry;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 

--- a/crates/tlog_tiles/Cargo.toml
+++ b/crates/tlog_tiles/Cargo.toml
@@ -23,6 +23,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 base64.workspace = true
+length_prefixed.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/tlog_tiles/src/entries.rs
+++ b/crates/tlog_tiles/src/entries.rs
@@ -1,3 +1,13 @@
+use length_prefixed::{ReadLengthPrefixedBytesExt, WriteLengthPrefixedBytesExt};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    io::{Cursor, Read},
+    marker::PhantomData,
+};
+
+use crate::TlogError;
+
 pub const LOOKUP_KEY_LEN: usize = 16;
 pub type LookupKey = [u8; LOOKUP_KEY_LEN];
 
@@ -13,3 +23,155 @@ pub type LeafIndex = u64;
 /// `PendingLogEntry` to derive a `LogEntry`. This metadata is also transmitted
 /// from the sequencing backend to the frontend to return to the caller.
 pub type SequenceMetadata = (LeafIndex, UnixTimestamp);
+
+/// The functionality exposed by any data type that can be included in a Merkle tree
+pub trait PendingLogEntry: core::fmt::Debug + Serialize + DeserializeOwned {
+    /// The lookup key belonging to this pending log entry.
+    fn lookup_key(&self) -> LookupKey;
+
+    /// The labels this objects wants to be used when it appears in Prometheus logging messages.
+    fn logging_labels(&self) -> Vec<String>;
+}
+
+pub trait LogEntry: core::fmt::Debug + Sized {
+    /// The pending version of this log entry. Usually the same thing but doesn't have a timestamp or tree index
+    type Pending: PendingLogEntry;
+
+    /// The error type for [`Self::parse_from_tile_entry`]
+    type ParseError: std::error::Error + Send + Sync + 'static;
+
+    fn new(pending: Self::Pending, metadata: SequenceMetadata) -> Self;
+
+    /// Returns the underlying pending entry
+    fn inner(&self) -> &Self::Pending;
+
+    /// Returns a marshaled [RFC 6962 `MerkleTreeLeaf`](https://datatracker.ietf.org/doc/html/rfc6962#section-3.4).
+    fn merkle_tree_leaf(&self) -> Vec<u8>;
+
+    /// Returns a marshaled [static-ct-api `TileLeaf`](https://c2sp.org/static-ct-api#log-entries).
+    fn tile_leaf(&self) -> Vec<u8>;
+
+    /// Attempts to parse a `LogEntry` from a reader into a tile. The position of the reader is
+    /// expected to be the beginning of an entry. On success, returns a log entry.
+    ///
+    /// # Errors
+    ///
+    /// Errors if the log entry cannot be parsed from the reader.
+    fn parse_from_tile_entry<R: Read>(input: &mut R) -> Result<Self, Self::ParseError>;
+}
+
+/// An iterator over log entries in a data tile.
+pub struct TileIterator<L: LogEntry> {
+    s: Cursor<Vec<u8>>,
+    size: usize,
+    count: usize,
+    _marker: PhantomData<L>,
+}
+
+impl<L: LogEntry> std::iter::Iterator for TileIterator<L> {
+    type Item = Result<L, L::ParseError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.count == self.size {
+            return None;
+        }
+        self.count += 1;
+        Some(self.parse_next())
+    }
+}
+
+impl<L: LogEntry> TileIterator<L> {
+    /// Returns a new [`TileIterator`], which always attempts to parse exactly
+    /// 'size' entries before terminating.
+    pub fn new(tile: Vec<u8>, size: usize) -> Self {
+        Self {
+            s: Cursor::new(tile),
+            size,
+            count: 0,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Parse the next [`LogEntry`] from the internal buffer.
+    fn parse_next(&mut self) -> Result<L, L::ParseError> {
+        L::parse_from_tile_entry(&mut self.s)
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct TlogTilesPendingLogEntry {
+    data: Vec<u8>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct TlogTilesLogEntry {
+    inner: TlogTilesPendingLogEntry,
+}
+
+impl PendingLogEntry for TlogTilesPendingLogEntry {
+    fn lookup_key(&self) -> LookupKey {
+        let hash = Sha256::digest(&self.data);
+        let mut lookup_key = LookupKey::default();
+        lookup_key.copy_from_slice(&hash[..LOOKUP_KEY_LEN]);
+
+        lookup_key
+    }
+
+    fn logging_labels(&self) -> Vec<String> {
+        Vec::new()
+    }
+}
+
+impl LogEntry for TlogTilesLogEntry {
+    type Pending = TlogTilesPendingLogEntry;
+
+    type ParseError = TlogError;
+
+    fn new(pending: Self::Pending, _metadata: SequenceMetadata) -> Self {
+        Self { inner: pending }
+    }
+
+    fn inner(&self) -> &Self::Pending {
+        &self.inner
+    }
+
+    fn merkle_tree_leaf(&self) -> Vec<u8> {
+        self.inner.data.clone()
+    }
+
+    fn tile_leaf(&self) -> Vec<u8> {
+        let mut buffer = Vec::with_capacity(2 + self.inner.data.len());
+        buffer.write_length_prefixed(&self.inner.data, 2).unwrap();
+        buffer
+    }
+
+    /// Parse a tlog-tiles log entry from the reader into an entry bundle. Entry
+    /// bundles contain big-endian uint16 length-prefixed [log
+    /// entries](https://c2sp.org/tlog-tiles#log-entries).
+    fn parse_from_tile_entry<R: Read>(input: &mut R) -> Result<Self, Self::ParseError> {
+        Ok(Self {
+            inner: TlogTilesPendingLogEntry {
+                data: input.read_length_prefixed(2)?,
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_parse_tile_entry() {
+        let inner = TlogTilesPendingLogEntry { data: vec![1; 100] };
+        let entry = TlogTilesLogEntry::new(inner, (123, 456));
+        let tile: Vec<u8> = (0..5).flat_map(|_| entry.tile_leaf()).collect();
+        let mut tile_reader: &[u8] = tile.as_ref();
+
+        for _ in 0..5 {
+            let parsed_entry = TlogTilesLogEntry::parse_from_tile_entry(&mut tile_reader).unwrap();
+            assert_eq!(entry, parsed_entry);
+        }
+    }
+}

--- a/crates/tlog_tiles/src/tlog.rs
+++ b/crates/tlog_tiles/src/tlog.rs
@@ -465,6 +465,8 @@ pub enum TlogError {
     InvalidInput(String),
     #[error(transparent)]
     InvalidBase64(#[from] base64::DecodeError),
+    #[error(transparent)]
+    IO(#[from] std::io::Error),
 }
 
 /// Verifies that `p` is a valid proof that the tree of size `t` with hash `th` has an `n`'th


### PR DESCRIPTION
* Move PendingLogEntry and LogEntry to tlog_tiles crate
* Add implementation of above traits for tlog-tiles spec
* Remove 'as_bytes' from PendingLogEntry trait, as the LogEntry can access private fields of the PendingLogEntry directly as it is an associated type.