### PR TITLE
Log checkpoint get set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,7 @@ dependencies = [
  "serde-wasm-bindgen 0.6.5",
  "serde_bytes",
  "serde_json",
+ "serde_with",
  "sha2",
  "signed_note",
  "static_ct_api",

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -10,13 +10,13 @@ use generic_log_worker::{
     get_durable_object_name, load_public_bucket, GenericSequencer, SequencerConfig,
 };
 use prometheus::Registry;
-use static_ct_api::{StaticCTCheckpointSigner, StaticCTLogEntry, StaticCTPendingLogEntry};
+use static_ct_api::{StaticCTCheckpointSigner, StaticCTLogEntry};
 use tlog_tiles::{CheckpointSigner, Ed25519CheckpointSigner};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
 #[durable_object]
-struct Sequencer(GenericSequencer<StaticCTPendingLogEntry>);
+struct Sequencer(GenericSequencer<StaticCTLogEntry>);
 
 #[durable_object]
 impl DurableObject for Sequencer {
@@ -72,6 +72,6 @@ impl DurableObject for Sequencer {
     }
 
     async fn alarm(&mut self) -> Result<Response> {
-        self.0.alarm::<StaticCTLogEntry>().await
+        self.0.alarm().await
     }
 }

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -33,6 +33,9 @@ impl DurableObject for Sequencer {
             .trim_end_matches('/');
         let sequence_interval = Duration::from_millis(params.sequence_interval_millis);
 
+        // We don't use checkpoint extensions for CT
+        let checkpoint_extension = Box::new(|_| vec![]);
+
         let checkpoint_signers: Vec<Box<dyn CheckpointSigner>> = {
             let signing_key = load_signing_key(&env, &name).unwrap().clone();
             let witness_key = load_witness_key(&env, &name).unwrap().clone();
@@ -54,6 +57,7 @@ impl DurableObject for Sequencer {
             name,
             origin: origin.to_string(),
             checkpoint_signers,
+            checkpoint_extension,
             sequence_interval,
             max_sequence_skips: params.max_sequence_skips,
             enable_dedup: params.enable_dedup,

--- a/crates/generic_log_worker/Cargo.toml
+++ b/crates/generic_log_worker/Cargo.toml
@@ -42,3 +42,4 @@ thiserror.workspace = true
 tlog_tiles.workspace = true
 tokio.workspace = true
 worker.workspace = true
+serde_with.workspace = true

--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -29,6 +29,7 @@ use worker::kv::KvStore;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
+pub const PROVE_INCLUSION_ENDPOINT: &str = "/prove_inclusion";
 const BATCH_ENDPOINT: &str = "/add_batch";
 pub const ENTRY_ENDPOINT: &str = "/add_entry";
 pub const METRICS_ENDPOINT: &str = "/metrics";

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -445,6 +445,16 @@ impl SequenceState {
         })
     }
 
+    /// Returns the current number of leaves in the tree
+    pub(crate) fn num_leaves(&self) -> u64 {
+        self.tree.size()
+    }
+
+    /// Returns the current tree hash
+    pub(crate) fn tree_hash(&self) -> &Hash {
+        self.tree.hash()
+    }
+
     /// Returns the current checkpoint
     pub(crate) fn checkpoint(&self) -> &[u8] {
         &self.checkpoint

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -539,8 +539,9 @@ impl SequenceState {
     }
 
     /// Returns the current number of leaves in the tree
-
-    /// Returns the current tree hash
+    pub(crate) fn num_leaves(&self) -> u64 {
+        self.tree.size()
+    }
 
     /// Returns the current checkpoint
     pub(crate) fn checkpoint(&self) -> &[u8] {

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -992,7 +992,7 @@ async fn sequence_entries<L: LogEntry>(
     // This is a critical error, since we don't know the state of the
     // checkpoint in the database at this point. Bail and let [SequenceState::load] get us
     // to a good state after restart.
-    swap_checkpoint(lock, &sequence_state.checkpoint(), &new_checkpoint)
+    swap_checkpoint(lock, sequence_state.checkpoint(), &new_checkpoint)
         .await
         .map_err(|e| {
             SequenceError::Fatal(format!("couldn't upload checkpoint to database: {e}"))

--- a/crates/generic_log_worker/src/sequencer_do.rs
+++ b/crates/generic_log_worker/src/sequencer_do.rs
@@ -263,6 +263,17 @@ impl<L: LogEntry> GenericSequencer<L> {
             .collect::<Vec<_>>()
     }
 
+    /// Returns the number of entires in this log
+    pub fn log_size(&self) -> Result<u64, WorkerError> {
+        if let Some(s) = self.sequence_state.as_ref() {
+            Ok(s.num_leaves())
+        } else {
+            Err(WorkerError::RustError(
+                "cannot get log size of a sequencer with no sequence state".to_string(),
+            ))
+        }
+    }
+
     /// Returns the latest checkpoint. This may only be called after the
     /// sequencer state has been loaded, i.e., after the first `alarm()` has
     /// triggered.

--- a/crates/generic_log_worker/src/sequencer_do.rs
+++ b/crates/generic_log_worker/src/sequencer_do.rs
@@ -3,19 +3,25 @@
 
 //! Sequencer is the 'brain' of the CT log, responsible for sequencing entries and maintaining log state.
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use crate::{
     log_ops::{self, CreateError, PoolState, SequenceState},
     metrics::{millis_diff_as_secs, ObjectMetrics, SequencerMetrics},
     util::now_millis,
-    DedupCache, LookupKey, MemoryCache, ObjectBucket, SequenceMetadata, BATCH_ENDPOINT,
-    ENTRY_ENDPOINT, METRICS_ENDPOINT,
+    DedupCache, LookupKey, MemoryCache, ObjectBackend, ObjectBucket, SequenceMetadata,
+    BATCH_ENDPOINT, ENTRY_ENDPOINT, METRICS_ENDPOINT, PROVE_INCLUSION_ENDPOINT,
 };
 use futures_util::future::join_all;
 use log::{info, warn};
 use prometheus::{Registry, TextEncoder};
-use tlog_tiles::{CheckpointSigner, LogEntry, PendingLogEntry, RecordProof};
+use serde::{Deserialize, Serialize};
+use serde_with::base64::Base64;
+use serde_with::serde_as;
+use tlog_tiles::{
+    prove_record, CheckpointSigner, LogEntry, PendingLogEntry, RecordProof, Tile, TileHashReader,
+    TileReader, TlogError, TlogTile,
+};
 use tokio::sync::Mutex;
 use worker::{Bucket, Error as WorkerError, Request, Response, State};
 
@@ -46,6 +52,20 @@ pub struct SequencerConfig {
     pub max_sequence_skips: usize,
     pub sequence_skip_threshold_millis: Option<u64>,
     pub enable_dedup: bool,
+}
+
+/// GET query structure for the sequencer's /prove_inclusion endpoint
+#[derive(Serialize, Deserialize)]
+pub struct ProveInclusionQuery {
+    pub leaf_index: u64,
+}
+
+/// GET response structure for the sequencer's /prove_inclusion endpoint
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+pub struct ProveInclusionResponse {
+    #[serde_as(as = "Vec<Base64>")]
+    pub proof: Vec<Vec<u8>>,
 }
 
 impl<E: PendingLogEntry> GenericSequencer<E> {
@@ -94,6 +114,17 @@ impl<E: PendingLogEntry> GenericSequencer<E> {
         let mut endpoint = path.trim_start_matches('/');
         let resp = match path.as_str() {
             METRICS_ENDPOINT => self.fetch_metrics(),
+            PROVE_INCLUSION_ENDPOINT => {
+                let ProveInclusionQuery { leaf_index } = req.query()?;
+                // Construct the proof and convert the hashes to Vec<u8>
+                let proof = self
+                    .prove_inclusion(leaf_index)
+                    .await?
+                    .into_iter()
+                    .map(|h| h.0.to_vec())
+                    .collect::<Vec<_>>();
+                Response::from_json(&ProveInclusionResponse { proof })
+            }
             ENTRY_ENDPOINT => {
                 let pending_entry: E = req.json().await?;
                 let lookup_key = pending_entry.lookup_key();
@@ -157,6 +188,55 @@ impl<E: PendingLogEntry> GenericSequencer<E> {
 
         Response::empty()
     }
+}
+
+/// A thin wrapper around a map of tlog tile ⇒ bytestring. Implements TileReader
+/// so we can use it for producing inclusion proofs.
+struct SimpleTlogTileReader(HashMap<TlogTile, Vec<u8>>);
+
+impl TileReader for SimpleTlogTileReader {
+    fn height(&self) -> u8 {
+        8
+    }
+
+    /// Converts the given tiles into tlog tiles, then reads them from the
+    /// internal hashmap.
+    ///
+    /// # Errors
+    /// Errors if any of given tiles hash height != 8, or is a data tile. Also
+    /// errors if the hash map is missing tiles from the input here.
+    fn read_tiles(&self, tiles: &[Tile]) -> Result<Vec<Vec<u8>>, TlogError> {
+        let mut buf = Vec::with_capacity(32 * (1 << self.height()));
+
+        for tile in tiles {
+            // Convert the tile to a tlog-tile, ie one where height=8 and data=false
+            if tile.height() != 8 {
+                return Err(TlogError::InvalidInput(
+                    "SimpleTlogTileReader cannot read tiles of height not equal to 8".to_string(),
+                ));
+            }
+            if tile.is_data() {
+                return Err(TlogError::InvalidInput(
+                    "SimpleTlogTileReader cannot read data tiles".to_string(),
+                ));
+            }
+            let tlog_tile = TlogTile::new(tile.level(), tile.level_index(), tile.width(), None);
+
+            // Record the tile's contents
+            let Some(contents) = self.0.get(&tlog_tile) else {
+                return Err(TlogError::InvalidInput(format!(
+                    "SimpleTlogTileReader cannot find {}",
+                    tlog_tile.path()
+                )));
+            };
+            buf.push(contents.clone());
+        }
+
+        Ok(buf)
+    }
+
+    // Do nothing; we only use this struct to read tiles
+    fn save_tiles(&self, _tiles: &[Tile], _data: &[Vec<u8>]) {}
 }
 
 impl<E: PendingLogEntry> GenericSequencer<E> {
@@ -252,6 +332,78 @@ impl<E: PendingLogEntry> GenericSequencer<E> {
     /// or setting storage failed.
     pub async fn swap_checkpoint(&self, old: &[u8], new: &[u8]) -> Result<(), WorkerError> {
         log_ops::swap_checkpoint(&self.do_state, old, new).await
+    }
+
+    /// Returns an inclusion proof for the given leaf index
+    ///
+    /// # Errors
+    /// Errors when sequencer state has not been loaded, or when the desired
+    /// tiles do not exist as bucket objects.
+    pub async fn prove_inclusion(&self, leaf_index: u64) -> Result<RecordProof, WorkerError> {
+        // Get the size of the tree
+        let (num_leaves, tree_hash) = if let Some(s) = self.sequence_state.as_ref() {
+            (s.num_leaves(), *s.tree_hash())
+        } else {
+            return Err(WorkerError::RustError(
+                "cannot prove inclusion in a sequencer with no sequence state".to_string(),
+            ));
+        };
+
+        if leaf_index >= num_leaves {
+            return Err(WorkerError::RustError(
+                "leaf index exceeds number of leaves in the tree".to_string(),
+            ));
+        }
+
+        let mut all_tile_data = HashMap::new();
+
+        // Get the leaf tile
+        let mut cur_tile = TlogTile::from_leaf_index(leaf_index);
+        // Set the correct width. from_leaf_index returns the least width, but
+        // our current tile might be larger if we've added more elements. This
+        // subtraction is ok because we checked that num_leaves > leaf_index
+        // above.
+        if num_leaves - leaf_index < 128 {
+            let last_partial_tile_width = (num_leaves % 128) as u32;
+            cur_tile = TlogTile::new(
+                cur_tile.level(),
+                cur_tile.level_index(),
+                last_partial_tile_width,
+                None,
+            );
+        }
+        // Collect the leaf tile
+        let Some(tile_data) = self.public_bucket.fetch(&cur_tile.path()).await? else {
+            return Err(WorkerError::RustError(format!(
+                "missing tile for inclusion proof {}",
+                cur_tile.path()
+            )));
+        };
+        all_tile_data.insert(cur_tile, tile_data);
+
+        // It suffices to grab all the tiles from the leaf to the root. This
+        // will contain the copath necessary for the inclusion proof
+        while let Some(parent) = cur_tile.parent(1, num_leaves) {
+            let Some(tile_data) = self.public_bucket.fetch(&parent.path()).await? else {
+                return Err(WorkerError::RustError(format!(
+                    "missing tile for inclusion proof {}",
+                    parent.path()
+                )));
+            };
+            all_tile_data.insert(parent, tile_data);
+
+            cur_tile = parent;
+        }
+
+        // Now make the proof
+        let proof = {
+            // Put the recorded tiles into the appropriate Reader structs for prove_record()
+            let tile_reader = SimpleTlogTileReader(all_tile_data);
+            let hash_reader = TileHashReader::new(num_leaves, tree_hash, &tile_reader);
+            prove_record(num_leaves, leaf_index, &hash_reader)
+                .map_err(|e| WorkerError::RustError(e.to_string()))?
+        };
+        Ok(proof)
     }
 
     /// Proves inclusion of the last leaf in the current tree. This may only be

--- a/crates/generic_log_worker/src/sequencer_do.rs
+++ b/crates/generic_log_worker/src/sequencer_do.rs
@@ -45,6 +45,9 @@ pub struct SequencerConfig {
     pub name: String,
     pub origin: String,
     pub checkpoint_signers: Vec<Box<dyn CheckpointSigner>>,
+    /// A function that takes a Unix timestamp in milliseconds and returns
+    /// extension lines to be included in the checkpoint
+    pub checkpoint_extension: Box<dyn Fn(u64) -> Vec<String>>,
     pub sequence_interval: Duration,
     pub max_sequence_skips: usize,
     pub sequence_skip_threshold_millis: Option<u64>,

--- a/crates/mtc_worker/src/sequencer_do.rs
+++ b/crates/mtc_worker/src/sequencer_do.rs
@@ -33,6 +33,9 @@ impl DurableObject for Sequencer {
             .trim_end_matches('/');
         let sequence_interval = Duration::from_millis(params.sequence_interval_millis);
 
+        // We don't use checkpoint extensions for MTC
+        let checkpoint_extension = Box::new(|_| vec![]);
+
         let checkpoint_signers: Vec<Box<dyn CheckpointSigner>> = {
             let signing_key = load_signing_key(&env, &name).unwrap().clone();
             let witness_key = load_witness_key(&env, &name).unwrap().clone();
@@ -54,6 +57,7 @@ impl DurableObject for Sequencer {
             name,
             origin: origin.to_string(),
             checkpoint_signers,
+            checkpoint_extension,
             sequence_interval,
             max_sequence_skips: params.max_sequence_skips,
             enable_dedup: params.enable_dedup,

--- a/crates/mtc_worker/src/sequencer_do.rs
+++ b/crates/mtc_worker/src/sequencer_do.rs
@@ -9,14 +9,14 @@ use crate::{load_signing_key, load_witness_key, CONFIG};
 use generic_log_worker::{
     get_durable_object_name, load_public_bucket, GenericSequencer, SequencerConfig,
 };
-use mtc_api::{MtcLogEntry, MtcPendingLogEntry};
+use mtc_api::MtcLogEntry;
 use prometheus::Registry;
 use tlog_tiles::{CheckpointSigner, Ed25519CheckpointSigner};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
 #[durable_object]
-struct Sequencer(GenericSequencer<MtcPendingLogEntry>);
+struct Sequencer(GenericSequencer<MtcLogEntry>);
 
 #[durable_object]
 impl DurableObject for Sequencer {
@@ -72,6 +72,6 @@ impl DurableObject for Sequencer {
     }
 
     async fn alarm(&mut self) -> Result<Response> {
-        self.0.alarm::<MtcLogEntry>().await
+        self.0.alarm().await
     }
 }

--- a/crates/tlog_tiles/src/checkpoint.rs
+++ b/crates/tlog_tiles/src/checkpoint.rs
@@ -152,7 +152,8 @@ impl Checkpoint {
         &self.extension
     }
 
-    /// Return a new checkpoint with the given arguments.
+    /// Return a new checkpoint with the given arguments. The items in
+    /// `extensions` MUST NOT contain a newline.
     ///
     /// # Errors
     ///
@@ -162,29 +163,27 @@ impl Checkpoint {
         origin: &str,
         size: u64,
         hash: Hash,
-        extension: &str,
+        extensions: &[&str],
     ) -> Result<Self, MalformedCheckpointError> {
         if origin.is_empty() {
             return Err(MalformedCheckpointError);
         }
 
-        let mut rest = extension;
-        while !rest.is_empty() {
-            if let Some((before, after)) = rest.split_once('\n') {
-                if before.is_empty() {
-                    return Err(MalformedCheckpointError);
-                }
-                rest = after;
-            } else {
-                return Err(MalformedCheckpointError);
-            }
+        if extensions.iter().any(|e| e.is_empty()) {
+            return Err(MalformedCheckpointError);
         }
+
+        let extension = if extensions.is_empty() {
+            String::new()
+        } else {
+            extensions.join("\n") + "\n"
+        };
 
         Ok(Self {
             origin: origin.to_string(),
             size,
             hash,
-            extension: extension.to_string(),
+            extension,
         })
     }
 
@@ -251,11 +250,6 @@ impl Checkpoint {
                 Err(_) => return Err(MalformedCheckpointError),
             }
         }
-        let extension = if extensions.is_empty() {
-            String::new()
-        } else {
-            extensions.join("\n") + "\n"
-        };
 
         let Ok(n) = n_str.parse::<u64>() else {
             return Err(MalformedCheckpointError);
@@ -268,7 +262,12 @@ impl Checkpoint {
             return Err(MalformedCheckpointError);
         };
 
-        Self::new(&origin, n, hash, &extension)
+        Self::new(
+            &origin,
+            n,
+            hash,
+            &extensions.iter().map(|e| e.as_str()).collect::<Vec<_>>(),
+        )
     }
 
     /// Returns an encoded checkpoint.
@@ -456,14 +455,10 @@ impl TreeWithTimestamp {
     /// # Errors
     ///
     /// Returns an error if signing fails.
-    ///
-    /// # Panics
-    ///
-    /// Panics if writing to the internal buffer fails, which should never happen.
     pub fn sign(
         &self,
         origin: &str,
-        extension: &str,
+        extensions: &[&str],
         signers: &[&dyn CheckpointSigner],
         rng: &mut impl Rng,
     ) -> Result<Vec<u8>, TlogError> {
@@ -472,7 +467,7 @@ impl TreeWithTimestamp {
         signers.shuffle(rng);
 
         // Construct the checkpoint with no extension lines
-        let checkpoint = Checkpoint::new(origin, self.size, self.hash, extension)?;
+        let checkpoint = Checkpoint::new(origin, self.size, self.hash, extensions)?;
 
         // Sign the checkpoint with the given signers
         let sigs = signers
@@ -542,7 +537,7 @@ mod tests {
             "example.com/origin",
             123,
             record_hash(b"hello world"),
-            "abc\ndef\n",
+            &["abc", "def"],
         )
         .unwrap();
         let c2 = Checkpoint::from_bytes(&c.to_bytes()).unwrap();
@@ -639,7 +634,7 @@ mod tests {
             let sk = Ed25519SigningKey::generate(&mut rng);
             Ed25519CheckpointSigner::new("my-signer", sk).unwrap()
         };
-        let checkpoint = tree.sign(origin, "", &[&signer], &mut rng).unwrap();
+        let checkpoint = tree.sign(origin, &[], &[&signer], &mut rng).unwrap();
 
         // Now verify the signed checkpoint
         let verifier = signer.verifier();

--- a/crates/tlog_tiles/src/tile.rs
+++ b/crates/tlog_tiles/src/tile.rs
@@ -440,6 +440,14 @@ impl TlogTile {
         TlogTile(Tile::from_index(Self::HEIGHT, index))
     }
 
+    /// Returns the tile of fixed height `h = 8`
+    /// and least width storing the given leaf index.
+    pub fn from_leaf_index(leaf_index: u64) -> Self {
+        // Convert from leaf index to hash storage index on level 0
+        let hash_index = stored_hash_index(0, leaf_index);
+        Self::from_index(hash_index)
+    }
+
     /// Returns the coordinates of the tiles of height `h = 8` that must be
     /// published when publishing from a tree of size `new_tree_size` to replace
     /// a tree of size `old_tree_size`.  (No tiles need to be published for a


### PR DESCRIPTION
Sorry for the huge commit. This does a bunch of stuff:
1. Adds support for user-defined extensions on checkpoints
2. Adds inclusion proofs. Specifically adds the ability to prove inclusion of the last element without any fetches (using just edge tiles), and inclusion of other elements by fetching. The way this is done is a little janky: it has to make a fake tile reader called `ProofPreparer` that only records the tiles it's asked for. We then fetch those tiles and produce a proof using that data.
3. Adds consistency proofs for the last added element without fetches.
4. Extends `Checkpoint::new` to accept `&[&str]` for the extensions section
5. Makes `GenericSequencer` generic over `LogEntry` rather than `PendingLogEntry`.  This was just so that `load_sequence_state` could be defined (since it requires knowledge of the log entry type)

Some issues I ran into:
1. One thing I need for my use case is to have my sequencer wait until the new checkpoint has been created, and then ask for a cosignature on it. Unfortunately simply doing `fetch("/add-entry").await` and then calling `seq.checkpoint()` does not work. This is because the fetch completes when the item is sequenced by the DO `alarm()`, and this occurs before the alarm gets to update the checkpoint. So I need a way of awaiting the full sequencing operation, including the checkpoint update. Any ideas on this? My first thought is to make an `/add-entry` optional field that tells it to only return when the checkpoint is updated, and have that in turn initialize an optional channel that gets terminated once the checkpoint is updated.
2. It seems that the `Checkpoint` type does not permit signature lines. This is odd because a checkpoint is just a special kind of signed note. I'll go ahead and make this fix separately.