### PR TITLE
Find Durable Object name by iterating over config

### DIFF
--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -6,9 +6,7 @@
 use std::time::Duration;
 
 use crate::{load_signing_key, load_witness_key, CONFIG};
-use generic_log_worker::{
-    get_durable_object_name, load_public_bucket, GenericSequencer, SequencerConfig,
-};
+use generic_log_worker::{load_public_bucket, GenericSequencer, SequencerConfig};
 use prometheus::Registry;
 use static_ct_api::{StaticCTCheckpointSigner, StaticCTLogEntry};
 use tlog_tiles::{CheckpointSigner, Ed25519CheckpointSigner};
@@ -21,8 +19,15 @@ struct Sequencer(GenericSequencer<StaticCTLogEntry>);
 #[durable_object]
 impl DurableObject for Sequencer {
     fn new(state: State, env: Env) -> Self {
-        let (state, name) = get_durable_object_name(state).unwrap();
-        let params = &CONFIG.logs[&name];
+        // Find the Durable Object name by enumerating all possibilities.
+        // TODO after update to worker > 0.6.0 use ObjectId::equals for comparison.
+        let id = state.id().to_string();
+        let namespace = env.durable_object("SEQUENCER").unwrap();
+        let (name, params) = CONFIG
+            .logs
+            .iter()
+            .find(|(name, _)| id == namespace.id_from_name(name).unwrap().to_string())
+            .expect("unable to find sequencer name");
 
         // https://github.com/C2SP/C2SP/blob/main/static-ct-api.md#checkpoints
         // The origin line MUST be the submission prefix of the log as a schema-less URL with no trailing slashes.
@@ -37,8 +42,8 @@ impl DurableObject for Sequencer {
         let checkpoint_extension = Box::new(|_| vec![]);
 
         let checkpoint_signers: Vec<Box<dyn CheckpointSigner>> = {
-            let signing_key = load_signing_key(&env, &name).unwrap().clone();
-            let witness_key = load_witness_key(&env, &name).unwrap().clone();
+            let signing_key = load_signing_key(&env, name).unwrap().clone();
+            let witness_key = load_witness_key(&env, name).unwrap().clone();
 
             // Make the checkpoint signers from the secret keys and put them in a vec
             let signer = StaticCTCheckpointSigner::new(origin, signing_key)
@@ -50,11 +55,11 @@ impl DurableObject for Sequencer {
 
             vec![Box::new(signer), Box::new(witness)]
         };
-        let bucket = load_public_bucket(&env, &name).unwrap();
+        let bucket = load_public_bucket(&env, name).unwrap();
         let registry = Registry::new();
 
         let config = SequencerConfig {
-            name,
+            name: name.to_string(),
             origin: origin.to_string(),
             checkpoint_signers,
             checkpoint_extension,

--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -80,28 +80,6 @@ pub fn get_durable_object_stub(
     }
 }
 
-/// Retrieve the
-/// [name](https://developers.cloudflare.com/durable-objects/api/id/#name) that
-/// was used to create a Durable Object Id with `id_from_name`. The signature of
-/// this function is a little funny since the only way to access the `State`'s
-/// inner `DurableObjectState` is via the `_inner()` method which takes
-/// ownership of the state. Thus, we just re-derive the State from the inner
-/// state and return it in case the calling function still needs it.
-///
-/// # Errors
-///
-/// Returns an error if the 'name' property is not present, for example if the
-/// object was created with a random ID.
-pub fn get_durable_object_name(state: State) -> Result<(State, String)> {
-    let inner_state = state._inner();
-    let id = inner_state.id()?;
-    let obj = js_sys::Object::from(id);
-    let name = js_sys::Reflect::get(&obj, &"name".into())?
-        .as_string()
-        .unwrap_or_default();
-    Ok((State::from(inner_state), name))
-}
-
 /// Return a handle for the public R2 bucket from which to serve this log's
 /// static assets.
 ///

--- a/crates/generic_log_worker/src/sequencer_do.rs
+++ b/crates/generic_log_worker/src/sequencer_do.rs
@@ -56,13 +56,13 @@ pub struct SequencerConfig {
     pub enable_dedup: bool,
 }
 
-/// GET query structure for the sequencer's /prove_inclusion endpoint
+/// GET query structure for the sequencer's `/prove_inclusion` endpoint
 #[derive(Serialize, Deserialize)]
 pub struct ProveInclusionQuery {
     pub leaf_index: LeafIndex,
 }
 
-/// GET response structure for the sequencer's /prove_inclusion endpoint
+/// GET response structure for the sequencer's `/prove_inclusion` endpoint
 #[serde_as]
 #[derive(Serialize, Deserialize)]
 pub struct ProveInclusionResponse {
@@ -263,17 +263,6 @@ impl<L: LogEntry> GenericSequencer<L> {
             .zip(entries_metadata.iter())
             .filter_map(|(key, value_opt)| value_opt.map(|metadata| (key, metadata)))
             .collect::<Vec<_>>()
-    }
-
-    /// Returns the number of entries in this log
-    pub fn log_size(&self) -> Result<u64, WorkerError> {
-        if let Some(s) = self.sequence_state.as_ref() {
-            Ok(s.num_leaves())
-        } else {
-            Err(WorkerError::RustError(
-                "cannot get log size of a sequencer with no sequence state".to_string(),
-            ))
-        }
     }
 
     /// Loads the sequence state if it's not already loaded.

--- a/crates/mtc_worker/src/batcher_do.rs
+++ b/crates/mtc_worker/src/batcher_do.rs
@@ -1,7 +1,5 @@
 use crate::CONFIG;
-use generic_log_worker::{
-    get_durable_object_name, get_durable_object_stub, load_cache_kv, BatcherConfig, GenericBatcher,
-};
+use generic_log_worker::{get_durable_object_stub, load_cache_kv, BatcherConfig, GenericBatcher};
 use mtc_api::MtcPendingLogEntry;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
@@ -12,11 +10,27 @@ struct Batcher(GenericBatcher<MtcPendingLogEntry>);
 #[durable_object]
 impl DurableObject for Batcher {
     fn new(state: State, env: Env) -> Self {
-        let (_, object_name) = get_durable_object_name(state).unwrap();
-        // Get the log name from the batcher name (see 'get_durable_object_stub'
-        // for how the batcher name is derived).
-        let name = object_name.rsplit_once('_').unwrap().0;
-        let params = &CONFIG.logs[name];
+        // Find the Durable Object name by enumerating all possibilities.
+        // TODO after update to worker > 0.6.0 use ObjectId::equals for comparison.
+        let id = state.id().to_string();
+        let namespace = env.durable_object("BATCHER").unwrap();
+        let (name, params) = CONFIG
+            .logs
+            .iter()
+            .find(|(name, params)| {
+                for shard_id in 0..params.num_batchers {
+                    if id
+                        == namespace
+                            .id_from_name(&format!("{name}_{shard_id:x}"))
+                            .unwrap()
+                            .to_string()
+                    {
+                        return true;
+                    }
+                }
+                false
+            })
+            .expect("unable to find batcher name");
         let kv = load_cache_kv(&env, name).unwrap();
         let sequencer = get_durable_object_stub(
             &env,

--- a/crates/tlog_tiles/src/checkpoint.rs
+++ b/crates/tlog_tiles/src/checkpoint.rs
@@ -266,7 +266,7 @@ impl Checkpoint {
             &origin,
             n,
             hash,
-            &extensions.iter().map(|e| e.as_str()).collect::<Vec<_>>(),
+            &extensions.iter().map(String::as_str).collect::<Vec<_>>(),
         )
     }
 


### PR DESCRIPTION
Unfortunately, we can't use ctx.id.name to find a Durable Object's name within the DO itself (this previously worked only for local testing, but has been removed: https://github.com/cloudflare/workerd/pull/4351). Instead, we can iterate over all possible names for the durable object based on the app configuration until we find the correct one.

Also, clean up some clippy lint complaints.