### PR TITLE
Add cosignature support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,11 +1395,14 @@ name = "mtc_api"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "byteorder",
  "der",
+ "ed25519-dalek",
  "length_prefixed",
  "serde",
  "serde_with",
  "sha2",
+ "signed_note",
  "thiserror 2.0.12",
  "tlog_tiles",
  "x509-verify",
@@ -1431,7 +1434,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
- "static_ct_api",
  "tlog_tiles",
  "url",
  "worker",
@@ -1443,7 +1445,6 @@ dependencies = [
 name = "mtc_worker_config"
 version = "0.2.0"
 dependencies = [
- "chrono",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
+ "signed_note",
  "static_ct_api",
  "tlog_tiles",
  "url",
@@ -1399,6 +1400,7 @@ dependencies = [
  "der",
  "ed25519-dalek",
  "length_prefixed",
+ "rand",
  "serde",
  "serde_with",
  "sha2",
@@ -1434,6 +1436,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
+ "signed_note",
  "tlog_tiles",
  "url",
  "worker",
@@ -2249,6 +2252,7 @@ name = "signed_note"
 version = "0.2.0"
 dependencies = [
  "base64",
+ "byteorder",
  "criterion",
  "ed25519-dalek",
  "rand",
@@ -2474,6 +2478,7 @@ name = "tlog_tiles"
 version = "0.2.0"
 dependencies = [
  "base64",
+ "byteorder",
  "ed25519-dalek",
  "length_prefixed",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ jsonschema = "0.30"
 length_prefixed = { path = "crates/length_prefixed" }
 libfuzzer-sys = "0.4"
 log = { version = "0.4" }
+mtc_api = { version = "0.2.0", path = "crates/mtc_api" }
 p256 = { version = "0.13", features = ["ecdsa"] }
 parking_lot = "0.12"
 prometheus = "0.14"

--- a/crates/ct_worker/Cargo.toml
+++ b/crates/ct_worker/Cargo.toml
@@ -52,6 +52,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 sha2.workspace = true
 static_ct_api.workspace = true
+signed_note.workspace = true
 tlog_tiles.workspace = true
 worker.workspace = true
 x509-verify.workspace = true

--- a/crates/ct_worker/Cargo.toml
+++ b/crates/ct_worker/Cargo.toml
@@ -18,10 +18,6 @@ release = false
 [package.metadata.wasm-pack.profile.dev.wasm-bindgen]
 dwarf-debug-info = true
 
-# https://github.com/rustwasm/wasm-pack/issues/1247
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = false
-
 [lib]
 crate-type = ["cdylib"]
 

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -745,6 +745,13 @@ pub(crate) async fn sequence<L: LogEntry>(
     let old =
         unwrap_or_load_sequence_state::<L>(sequence_state, config, object, lock, metrics).await?;
 
+    // Add the log's initial entry if needed.
+    if old.tree.size() == 0 {
+        if let Some(entry) = L::initial_entry() {
+            pool_state.add(entry.lookup_key(), entry);
+        }
+    }
+
     let Some(entries) = pool_state.take(
         old.tree.size(),
         config.max_sequence_skips,

--- a/crates/generic_log_worker/src/sequencer_do.rs
+++ b/crates/generic_log_worker/src/sequencer_do.rs
@@ -18,6 +18,7 @@ use prometheus::{Registry, TextEncoder};
 use serde::{Deserialize, Serialize};
 use serde_with::base64::Base64;
 use serde_with::serde_as;
+use signed_note::KeyName;
 use tlog_tiles::{
     CheckpointSigner, LeafIndex, LogEntry, PendingLogEntry, RecordProof, UnixTimestamp,
 };
@@ -45,7 +46,7 @@ pub struct GenericSequencer<L: LogEntry> {
 /// Configuration for a CT log.
 pub struct SequencerConfig {
     pub name: String,
-    pub origin: String,
+    pub origin: KeyName,
     pub checkpoint_signers: Vec<Box<dyn CheckpointSigner>>,
     /// A function that takes a Unix timestamp in milliseconds and returns
     /// extension lines to be included in the checkpoint

--- a/crates/mtc_api/Cargo.toml
+++ b/crates/mtc_api/Cargo.toml
@@ -11,11 +11,14 @@ description.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+byteorder.workspace = true
 der.workspace = true
+ed25519-dalek.workspace = true
 length_prefixed.workspace = true
 serde.workspace = true
 serde_with.workspace = true
 sha2.workspace = true
+signed_note.workspace = true
 thiserror.workspace = true
 tlog_tiles.workspace = true
 x509-verify.workspace = true

--- a/crates/mtc_api/Cargo.toml
+++ b/crates/mtc_api/Cargo.toml
@@ -15,6 +15,7 @@ byteorder.workspace = true
 der.workspace = true
 ed25519-dalek.workspace = true
 length_prefixed.workspace = true
+rand.workspace = true
 serde.workspace = true
 serde_with.workspace = true
 sha2.workspace = true

--- a/crates/mtc_api/src/lib.rs
+++ b/crates/mtc_api/src/lib.rs
@@ -1,5 +1,9 @@
 use anyhow::{anyhow, bail, ensure};
-use der::{asn1::BitString, oid::db::rfc5280, Decode, Encode, Sequence, ValueOrd};
+use der::{
+    asn1::BitString,
+    oid::{db::rfc5280, ObjectIdentifier},
+    Decode, Encode, Sequence, ValueOrd,
+};
 use length_prefixed::WriteLengthPrefixedBytesExt;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
@@ -27,6 +31,11 @@ use x509_verify::{
         Certificate, TbsCertificate,
     },
 };
+
+// https://www.ietf.org/archive/id/draft-davidben-tls-merkle-tree-certs-05.html#name-log-ids
+//pub const ID_RDNA_TRUSTANCHOR_ID: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.6.1.5.5.7.TBD1.TBD2");
+pub const ID_RDNA_TRUSTANCHOR_ID: ObjectIdentifier =
+    ObjectIdentifier::new_unwrap("1.3.6.1.4.1.44363.47.1");
 
 /// Add-entry request. Chain is a certificate from which to bootstrap the
 /// request in the same format as RFC6962 add-chain requests.

--- a/crates/mtc_api/src/lib.rs
+++ b/crates/mtc_api/src/lib.rs
@@ -1,3 +1,9 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+mod subtree_cosignature;
+pub use subtree_cosignature::*;
+
 use anyhow::{anyhow, bail, ensure};
 use der::{
     asn1::BitString,

--- a/crates/mtc_api/src/subtree_cosignature.rs
+++ b/crates/mtc_api/src/subtree_cosignature.rs
@@ -1,0 +1,243 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+use byteorder::{BigEndian, WriteBytesExt};
+use ed25519_dalek::{
+    ed25519::signature::{self, Signer},
+    SigningKey as Ed25519SigningKey, Verifier as Ed25519Verifier,
+    VerifyingKey as Ed25519VerifyingKey,
+};
+use length_prefixed::WriteLengthPrefixedBytesExt;
+use signed_note::{compute_key_id, KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
+use tlog_tiles::{Checkpoint, CheckpointSigner, Hash, LeafIndex, UnixTimestamp};
+
+#[derive(Clone)]
+pub struct TrustAnchorID(pub Vec<u8>);
+pub struct MTCSubtreeCosigner {
+    v: MTCSubtreeNoteVerifier,
+    k: Ed25519SigningKey,
+}
+
+impl MTCSubtreeCosigner {
+    pub fn new(
+        cosigner_id: TrustAnchorID,
+        log_id: TrustAnchorID,
+        name: KeyName,
+        k: Ed25519SigningKey,
+    ) -> Self {
+        Self {
+            v: MTCSubtreeNoteVerifier::new(cosigner_id, log_id, name, k.verifying_key()),
+            k,
+        }
+    }
+}
+
+impl MTCSubtreeCosigner {
+    /// Compute an Ed25519 subtree cosignature as defined in
+    /// <https://www.ietf.org/archive/id/draft-davidben-tls-merkle-tree-certs-05.html#name-signature-format>.
+    ///
+    /// # Errors
+    ///
+    /// Will return `signature::Error` if signing fails. This cannot happen for
+    /// Ed25519 signatures, but might for other signature types.
+    pub fn sign_subtree(
+        &self,
+        start: LeafIndex,
+        end: LeafIndex,
+        root_hash: &Hash,
+    ) -> Result<Vec<u8>, signature::Error> {
+        let serialized = serialize_mtc_subtree_signature_input(
+            &self.v.cosigner_id,
+            &self.v.log_id,
+            start,
+            end,
+            root_hash,
+        );
+
+        Ok(self.k.try_sign(&serialized)?.to_vec())
+    }
+}
+
+impl CheckpointSigner for MTCSubtreeCosigner {
+    fn name(&self) -> &KeyName {
+        self.v.name()
+    }
+
+    fn key_id(&self) -> u32 {
+        self.v.key_id()
+    }
+
+    fn sign(
+        &self,
+        _timestamp_unix_millis: UnixTimestamp,
+        checkpoint: &tlog_tiles::Checkpoint,
+    ) -> Result<NoteSignature, NoteError> {
+        let sig = self.sign_subtree(0, checkpoint.size(), checkpoint.hash())?;
+        Ok(NoteSignature::new(self.name().clone(), self.key_id(), sig))
+    }
+
+    fn verifier(&self) -> Box<dyn NoteVerifier> {
+        Box::new(self.v.clone())
+    }
+}
+
+/// [`MTCSubtreeNoteVerifier`] is the verifier for subtree cosignatures defined in <https://www.ietf.org/archive/id/draft-davidben-tls-merkle-tree-certs-05.html#name-cosigners>
+/// It currently supports only Ed25519 signatures.
+#[derive(Clone)]
+pub struct MTCSubtreeNoteVerifier {
+    cosigner_id: TrustAnchorID,
+    log_id: TrustAnchorID,
+    name: KeyName,
+    id: u32,
+    verifying_key: Ed25519VerifyingKey,
+}
+
+impl MTCSubtreeNoteVerifier {
+    pub fn new(
+        cosigner_id: TrustAnchorID,
+        log_id: TrustAnchorID,
+        name: KeyName,
+        verifying_key: Ed25519VerifyingKey,
+    ) -> Self {
+        let id = {
+            // TODO what signature algorithm to use for mtc-subtree/v1?
+            let pubkey = [
+                &[SignatureType::Undefined as u8],
+                verifying_key.to_bytes().as_slice(),
+            ]
+            .concat();
+            compute_key_id(&name, &pubkey)
+        };
+        Self {
+            cosigner_id,
+            log_id,
+            name,
+            id,
+            verifying_key,
+        }
+    }
+}
+
+impl NoteVerifier for MTCSubtreeNoteVerifier {
+    fn name(&self) -> &KeyName {
+        &self.name
+    }
+
+    fn key_id(&self) -> u32 {
+        self.id
+    }
+
+    fn verify(&self, msg: &[u8], sig: &[u8]) -> bool {
+        // The message itself should be a valid checkpoint.
+        let Ok(checkpoint) = Checkpoint::from_bytes(msg) else {
+            return false;
+        };
+        // Ed25519 signature (no prepended timestamp)
+        let sig_bytes: [u8; ed25519_dalek::SIGNATURE_LENGTH] = match sig.try_into() {
+            Ok(ok) => ok,
+            Err(_) => return false,
+        };
+
+        // Construct message to be signed from <https://www.ietf.org/archive/id/draft-davidben-tls-merkle-tree-certs-05.html#name-signature-format>.
+        let msg = serialize_mtc_subtree_signature_input(
+            &self.cosigner_id,
+            &self.log_id,
+            0,
+            checkpoint.size(),
+            checkpoint.hash(),
+        );
+
+        self.verifying_key
+            .verify(&msg, &ed25519_dalek::Signature::from_bytes(&sig_bytes))
+            .is_ok()
+    }
+
+    fn extract_timestamp_millis(&self, _sig: &[u8]) -> Result<Option<u64>, NoteError> {
+        // No timestamp for subtree signatures.
+        Ok(None)
+    }
+}
+
+/// Serializes the passed in parameters into the correct format for signing
+/// according to <https://datatracker.ietf.org/doc/draft-davidben-tls-merkle-tree-certs/>.
+/// ```text
+///
+/// opaque HashValue[HASH_SIZE];
+///
+/// struct {
+///     TrustAnchorID log_id;
+///     uint64 start;
+///     uint64 end;
+///     HashValue hash;
+/// } MTCSubtree;
+///
+/// struct {
+///     uint8 label[14] = "mtc-subtree/v1";
+///     uint8 separator = 0;
+///     TrustAnchorID cosigner_id;
+///     MTCSubtree subtree;
+/// } MTCSubtreeSignatureInput;
+/// ```
+///
+/// # Panics
+///
+/// Panics if writing to an internal buffer fails, which should never happen.
+fn serialize_mtc_subtree_signature_input(
+    cosigner_id: &TrustAnchorID,
+    log_id: &TrustAnchorID,
+    start: LeafIndex,
+    end: LeafIndex,
+    root_hash: &Hash,
+) -> Vec<u8> {
+    let mut buffer: Vec<u8> = b"mtc-subtree/v1\x00".to_vec();
+    buffer.write_length_prefixed(&cosigner_id.0, 1).unwrap();
+    buffer.write_length_prefixed(&log_id.0, 1).unwrap();
+    buffer.write_u64::<BigEndian>(start).unwrap();
+    buffer.write_u64::<BigEndian>(end).unwrap();
+    buffer.extend(root_hash.0);
+
+    buffer
+}
+
+#[cfg(test)]
+mod tests {
+
+    use tlog_tiles::{open_checkpoint, record_hash, TreeWithTimestamp};
+
+    use super::*;
+    use rand::rngs::OsRng;
+    use signed_note::VerifierList;
+
+    #[test]
+    fn test_cosignature_v1_sign_verify() {
+        let mut rng = OsRng;
+
+        let origin = "example.com/origin";
+        let timestamp = 100;
+        let tree_size = 4;
+
+        // Make a tree head and sign it
+        let tree = TreeWithTimestamp::new(tree_size, record_hash(b"hello world"), timestamp);
+        let signer = {
+            let sk = Ed25519SigningKey::generate(&mut rng);
+            let name = KeyName::new("my-signer".into()).unwrap();
+            MTCSubtreeCosigner::new(
+                TrustAnchorID(vec![0, 1, 2]),
+                TrustAnchorID(vec![3, 4, 5]),
+                name,
+                sk,
+            )
+        };
+        let checkpoint = tree.sign(origin, &[], &[&signer], &mut rng).unwrap();
+
+        // Now verify the signed checkpoint
+        let verifier = signer.verifier();
+        open_checkpoint(
+            origin,
+            &VerifierList::new(vec![verifier]),
+            timestamp,
+            &checkpoint,
+        )
+        .unwrap();
+    }
+}

--- a/crates/mtc_api/src/subtree_cosignature.rs
+++ b/crates/mtc_api/src/subtree_cosignature.rs
@@ -39,7 +39,7 @@ impl MTCSubtreeCosigner {
     /// # Errors
     ///
     /// Will return `signature::Error` if signing fails. This cannot happen for
-    /// Ed25519 signatures, but might for other signature types.
+    /// Ed25519 signatures, but might for other signature types added in the future.
     pub fn sign_subtree(
         &self,
         start: LeafIndex,
@@ -58,6 +58,7 @@ impl MTCSubtreeCosigner {
     }
 }
 
+/// Support signing tlog-checkpoint with the subtree cosigner.
 impl CheckpointSigner for MTCSubtreeCosigner {
     fn name(&self) -> &KeyName {
         self.v.name()
@@ -67,6 +68,7 @@ impl CheckpointSigner for MTCSubtreeCosigner {
         self.v.key_id()
     }
 
+    /// Sign a checkpoint with the subtree cosigner. For checkpoints, the start index is always 0.
     fn sign(
         &self,
         _timestamp_unix_millis: UnixTimestamp,

--- a/crates/mtc_worker/Cargo.toml
+++ b/crates/mtc_worker/Cargo.toml
@@ -30,6 +30,7 @@ chrono.workspace = true
 config = { path = "./config", package = "mtc_worker_config" }
 generic_log_worker.workspace = true
 jsonschema.workspace = true
+mtc_api.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 url.workspace = true
@@ -55,13 +56,12 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 sha2.workspace = true
-static_ct_api.workspace = true
 tlog_tiles.workspace = true
 worker.workspace = true
 x509-verify.workspace = true
 x509_util.workspace = true
 prometheus.workspace = true
-mtc_api = { version = "0.2.0", path = "../mtc_api" }
+mtc_api.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/crates/mtc_worker/Cargo.toml
+++ b/crates/mtc_worker/Cargo.toml
@@ -52,6 +52,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 sha2.workspace = true
+signed_note.workspace = true
 tlog_tiles.workspace = true
 worker.workspace = true
 x509-verify.workspace = true

--- a/crates/mtc_worker/Cargo.toml
+++ b/crates/mtc_worker/Cargo.toml
@@ -18,10 +18,6 @@ release = false
 [package.metadata.wasm-pack.profile.dev.wasm-bindgen]
 dwarf-debug-info = true
 
-# https://github.com/rustwasm/wasm-pack/issues/1247
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = false
-
 [lib]
 crate-type = ["cdylib"]
 

--- a/crates/mtc_worker/config.dev.json
+++ b/crates/mtc_worker/config.dev.json
@@ -3,13 +3,13 @@
     "logs": {
         "dev1": {
             "description": "MTCA Dev1",
-            "issuer_rdn": "CN=dev1",
+            "log_id": "1.3.3.3.5.1",
             "submission_url": "http://localhost:8787/logs/dev1/",
             "location_hint": "enam"
         },
         "dev2": {
             "description": "MTCA Dev2",
-            "issuer_rdn": "CN=dev2",
+            "log_id": "1.3.3.3.5.2",
             "submission_url": "http://localhost:8787/logs/dev2/",
             "location_hint": "enam"
         }

--- a/crates/mtc_worker/config.schema.json
+++ b/crates/mtc_worker/config.schema.json
@@ -26,9 +26,9 @@
                             "type": "string",
                             "description": "Description of the log."
                         },
-                        "issuer_rdn": {
+                        "log_id": {
                             "type": "string",
-                            "description": "The Relative Distinguish Name to use as the CA's issuer."
+                            "description": "The log name (a trust anchor ID) in dotted decimal notation (e.g., 32473.1)."
                         },
                         "validity_interval_seconds": {
                             "type": "integer",
@@ -91,7 +91,7 @@
                         }
                     },
                     "required": [
-                        "issuer_rdn",
+                        "log_id",
                         "submission_url"
                     ]
                 }

--- a/crates/mtc_worker/config/Cargo.toml
+++ b/crates/mtc_worker/config/Cargo.toml
@@ -11,5 +11,4 @@ repository.workspace = true
 description = "Configuration for mtc_worker"
 
 [dependencies]
-chrono.workspace = true
 serde.workspace = true

--- a/crates/mtc_worker/config/src/lib.rs
+++ b/crates/mtc_worker/config/src/lib.rs
@@ -14,7 +14,7 @@ pub struct AppConfig {
 #[derive(Deserialize, Debug)]
 pub struct LogParams {
     pub description: Option<String>,
-    pub issuer_rdn: String,
+    pub log_id: String,
     #[serde(default = "default_u64::<604_800>")]
     pub validity_interval_seconds: u64,
     #[serde(default)]

--- a/crates/mtc_worker/src/batcher_do.rs
+++ b/crates/mtc_worker/src/batcher_do.rs
@@ -1,11 +1,11 @@
 use crate::CONFIG;
 use generic_log_worker::{get_durable_object_stub, load_cache_kv, BatcherConfig, GenericBatcher};
-use mtc_api::MtcPendingLogEntry;
+use mtc_api::MerkleTreeCertPendingLogEntry;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
 #[durable_object]
-struct Batcher(GenericBatcher<MtcPendingLogEntry>);
+struct Batcher(GenericBatcher<MerkleTreeCertPendingLogEntry>);
 
 #[durable_object]
 impl DurableObject for Batcher {

--- a/crates/mtc_worker/src/batcher_do.rs
+++ b/crates/mtc_worker/src/batcher_do.rs
@@ -1,11 +1,11 @@
 use crate::CONFIG;
 use generic_log_worker::{get_durable_object_stub, load_cache_kv, BatcherConfig, GenericBatcher};
-use mtc_api::MerkleTreeCertPendingLogEntry;
+use mtc_api::BootstrapMtcPendingLogEntry;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
 #[durable_object]
-struct Batcher(GenericBatcher<MerkleTreeCertPendingLogEntry>);
+struct Batcher(GenericBatcher<BootstrapMtcPendingLogEntry>);
 
 #[durable_object]
 impl DurableObject for Batcher {

--- a/crates/mtc_worker/src/frontend_worker.rs
+++ b/crates/mtc_worker/src/frontend_worker.rs
@@ -13,7 +13,7 @@ use generic_log_worker::{
     ObjectBucket, ENTRY_ENDPOINT, METRICS_ENDPOINT,
 };
 use log::{debug, info, warn};
-use mtc_api::{AddEntryRequest, AddEntryResponse};
+use mtc_api::{AddEntryRequest, AddEntryResponse, ID_RDNA_TRUSTANCHOR_ID};
 use p256::pkcs8::EncodePublicKey;
 use serde::Serialize;
 use serde_with::{base64::Base64, serde_as};
@@ -22,9 +22,14 @@ use tlog_tiles::PendingLogEntry;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 use x509_verify::{
-    der::asn1::UtcTime,
+    der::{
+        asn1::{SetOfVec, UtcTime},
+        Any,
+    },
+    spki::ObjectIdentifier,
     x509_cert::{
-        name::RdnSequence,
+        attr::AttributeTypeAndValue,
+        name::{RdnSequence, RelativeDistinguishedName},
         time::{Time, Validity},
     },
 };
@@ -135,7 +140,14 @@ async fn add_entry(mut req: Request, env: &Env, name: &str) -> Result<Response> 
     let params = &CONFIG.logs[name];
     let req: AddEntryRequest = req.json().await?;
 
-    let issuer = RdnSequence::from_str(&params.issuer_rdn).map_err(|e| e.to_string())?;
+    let issuer = RdnSequence::from(vec![RelativeDistinguishedName(
+        SetOfVec::from_iter([AttributeTypeAndValue {
+            oid: ID_RDNA_TRUSTANCHOR_ID,
+            // TODO: switch to RelativeOidRef after https://github.com/RustCrypto/formats/issues/1875
+            value: Any::from(ObjectIdentifier::from_str(&params.log_id).unwrap()),
+        }])
+        .unwrap(),
+    )]);
 
     let now = Duration::from_millis(now_millis());
     let validity = Validity {

--- a/crates/mtc_worker/src/sequencer_do.rs
+++ b/crates/mtc_worker/src/sequencer_do.rs
@@ -7,14 +7,14 @@ use std::time::Duration;
 
 use crate::{load_signing_key, load_witness_key, CONFIG};
 use generic_log_worker::{load_public_bucket, GenericSequencer, SequencerConfig};
-use mtc_api::MtcLogEntry;
+use mtc_api::MerkleTreeCertLogEntry;
 use prometheus::Registry;
 use tlog_tiles::{CheckpointSigner, Ed25519CheckpointSigner};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
 #[durable_object]
-struct Sequencer(GenericSequencer<MtcLogEntry>);
+struct Sequencer(GenericSequencer<MerkleTreeCertLogEntry>);
 
 #[durable_object]
 impl DurableObject for Sequencer {

--- a/crates/mtc_worker/src/sequencer_do.rs
+++ b/crates/mtc_worker/src/sequencer_do.rs
@@ -7,7 +7,7 @@ use std::{str::FromStr, time::Duration};
 
 use crate::{load_signing_key, load_witness_key, CONFIG};
 use generic_log_worker::{load_public_bucket, GenericSequencer, SequencerConfig};
-use mtc_api::{MTCSubtreeCosigner, MerkleTreeCertLogEntry, TrustAnchorID};
+use mtc_api::{BootstrapMtcLogEntry, MTCSubtreeCosigner, TrustAnchorID};
 use prometheus::Registry;
 use signed_note::KeyName;
 use tlog_tiles::{CheckpointSigner, CosignatureV1CheckpointSigner};
@@ -16,7 +16,7 @@ use worker::*;
 use x509_verify::spki::ObjectIdentifier;
 
 #[durable_object]
-struct Sequencer(GenericSequencer<MerkleTreeCertLogEntry>);
+struct Sequencer(GenericSequencer<BootstrapMtcLogEntry>);
 
 #[durable_object]
 impl DurableObject for Sequencer {

--- a/crates/mtc_worker/src/sequencer_do.rs
+++ b/crates/mtc_worker/src/sequencer_do.rs
@@ -46,11 +46,12 @@ impl DurableObject for Sequencer {
             let witness_key = load_witness_key(&env, name).unwrap().clone();
 
             // Make the checkpoint signers from the secret keys and put them in a vec
+            // TODO: use cosignature/v1 for log signature
             let signer = Ed25519CheckpointSigner::new(origin, signing_key)
-                .map_err(|e| format!("could not create static-ct checkpoint signer: {e}"))
+                .map_err(|e| format!("could not create ed25519 log cosigner: {e}"))
                 .unwrap();
             let witness = Ed25519CheckpointSigner::new(origin, witness_key)
-                .map_err(|e| format!("could not create ed25519 checkpoint signer: {e}"))
+                .map_err(|e| format!("could not create ed25519 witness cosigner: {e}"))
                 .unwrap();
 
             vec![Box::new(signer), Box::new(witness)]

--- a/crates/mtc_worker/src/sequencer_do.rs
+++ b/crates/mtc_worker/src/sequencer_do.rs
@@ -3,15 +3,17 @@
 
 //! Sequencer is the 'brain' of the CT log, responsible for sequencing entries and maintaining log state.
 
-use std::time::Duration;
+use std::{str::FromStr, time::Duration};
 
 use crate::{load_signing_key, load_witness_key, CONFIG};
 use generic_log_worker::{load_public_bucket, GenericSequencer, SequencerConfig};
-use mtc_api::MerkleTreeCertLogEntry;
+use mtc_api::{MTCSubtreeCosigner, MerkleTreeCertLogEntry, TrustAnchorID};
 use prometheus::Registry;
-use tlog_tiles::{CheckpointSigner, Ed25519CheckpointSigner};
+use signed_note::KeyName;
+use tlog_tiles::{CheckpointSigner, CosignatureV1CheckpointSigner};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
+use x509_verify::spki::ObjectIdentifier;
 
 #[durable_object]
 struct Sequencer(GenericSequencer<MerkleTreeCertLogEntry>);
@@ -31,28 +33,36 @@ impl DurableObject for Sequencer {
 
         // https://github.com/C2SP/C2SP/blob/main/static-ct-api.md#checkpoints
         // The origin line MUST be the submission prefix of the log as a schema-less URL with no trailing slashes.
-        let origin = params
-            .submission_url
-            .trim_start_matches("http://")
-            .trim_start_matches("https://")
-            .trim_end_matches('/');
+        let origin = KeyName::new(
+            params
+                .submission_url
+                .trim_start_matches("http://")
+                .trim_start_matches("https://")
+                .trim_end_matches('/')
+                .to_string(),
+        )
+        .expect("invalid origin name");
         let sequence_interval = Duration::from_millis(params.sequence_interval_millis);
 
-        // We don't use checkpoint extensions for MTC
+        // We don't use checkpoint extensions for MTC.
         let checkpoint_extension = Box::new(|_| vec![]);
+
+        // TODO parse log ID as a RelativeOid after https://github.com/RustCrypto/formats/issues/1875
+        let log_id_relative_oid = ObjectIdentifier::from_str(&params.log_id).unwrap();
+
+        // Get the BER/DER serialization of the content bytes, as described in <https://datatracker.ietf.org/doc/html/draft-ietf-tls-trust-anchor-ids-01#name-trust-anchor-identifiers>.
+        let log_id = TrustAnchorID(log_id_relative_oid.as_bytes().to_vec());
+
+        // TODO should the CA cosigner have a different ID than the log itself?
+        let cosigner_id = log_id.clone();
 
         let checkpoint_signers: Vec<Box<dyn CheckpointSigner>> = {
             let signing_key = load_signing_key(&env, name).unwrap().clone();
             let witness_key = load_witness_key(&env, name).unwrap().clone();
 
-            // Make the checkpoint signers from the secret keys and put them in a vec
-            // TODO: use cosignature/v1 for log signature
-            let signer = Ed25519CheckpointSigner::new(origin, signing_key)
-                .map_err(|e| format!("could not create ed25519 log cosigner: {e}"))
-                .unwrap();
-            let witness = Ed25519CheckpointSigner::new(origin, witness_key)
-                .map_err(|e| format!("could not create ed25519 witness cosigner: {e}"))
-                .unwrap();
+            // Make the checkpoint signers from the secret keys and put them in a vec.
+            let signer = MTCSubtreeCosigner::new(cosigner_id, log_id, origin.clone(), signing_key);
+            let witness = CosignatureV1CheckpointSigner::new(origin.clone(), witness_key);
 
             vec![Box::new(signer), Box::new(witness)]
         };
@@ -61,7 +71,7 @@ impl DurableObject for Sequencer {
 
         let config = SequencerConfig {
             name: name.to_string(),
-            origin: origin.to_string(),
+            origin,
             checkpoint_signers,
             checkpoint_extension,
             sequence_interval,

--- a/crates/mtc_worker/wrangler.jsonc
+++ b/crates/mtc_worker/wrangler.jsonc
@@ -16,21 +16,21 @@
             "workers_dev": true,
             "kv_namespaces": [
                 {
-                    "id": "3a23691917c844d59aea47fdf964850f", // REPLACE ME
+                    "id": "8d57aa29bcc646e6959d6bbcbca415d2",
                     "binding": "cache_dev1"
                 },
                 {
-                    "id": "38045c90369140b091b3b68451dc6c29", // REPLACE ME
+                    "id": "4f1c6619ffa8444ea8e78a05e70d36e6",
                     "binding": "cache_dev2"
                 }
             ],
             "r2_buckets": [
                 {
-                    "bucket_name": "static-ct-public-dev1",
+                    "bucket_name": "mtc-public-dev1",
                     "binding": "public_dev1"
                 },
                 {
-                    "bucket_name": "static-ct-public-dev2",
+                    "bucket_name": "mtc-public-dev2",
                     "binding": "public_dev2"
                 }
             ],

--- a/crates/signed_note/Cargo.toml
+++ b/crates/signed_note/Cargo.toml
@@ -23,6 +23,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 base64.workspace = true
+byteorder.workspace = true
 ed25519-dalek = { workspace = true, features=["alloc", "rand_core"] }
 rand_core.workspace = true
 sha2.workspace = true

--- a/crates/signed_note/benches/benchmark_verify.rs
+++ b/crates/signed_note/benches/benchmark_verify.rs
@@ -23,7 +23,7 @@ fn benchmark_verify(c: &mut Criterion) {
                \n\
                — PeterNeumann x08go/ZJkuBS9UG/SffcvIAQxVBtiFupLLr8pAcElZInNIuGUgYN1FFYC2pZSNXgKvqfqdngotpRZb6KE6RyyBwJnAM=\n".as_bytes();
 
-    let verifier = Ed25519NoteVerifier::new(vkey).unwrap();
+    let verifier = Ed25519NoteVerifier::new_from_encoded_key(vkey).unwrap();
 
     c.bench_function("Sig0", |b| {
         b.iter(|| {

--- a/crates/signed_note/src/ed25519.rs
+++ b/crates/signed_note/src/ed25519.rs
@@ -1,0 +1,238 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+use crate::{compute_key_id, KeyName, NoteError, NoteSigner, NoteVerifier, SignatureType};
+use base64::prelude::*;
+use ed25519_dalek::{
+    Signer as Ed25519Signer, SigningKey as Ed25519SigningKey, Verifier as Ed25519Verifier,
+    VerifyingKey as Ed25519VerifyingKey,
+};
+use rand_core::CryptoRngCore;
+
+/// [`Ed25519NoteVerifier`] is the verifier for the ordinary (non-timestamped) Ed25519 signature type defined in <https://c2sp.org/signed-note>.
+#[derive(Clone)]
+pub struct Ed25519NoteVerifier {
+    pub(crate) name: KeyName,
+    pub(crate) id: u32,
+    pub(crate) verifying_key: Ed25519VerifyingKey,
+}
+
+impl NoteVerifier for Ed25519NoteVerifier {
+    fn name(&self) -> &KeyName {
+        &self.name
+    }
+
+    fn key_id(&self) -> u32 {
+        self.id
+    }
+
+    fn verify(&self, msg: &[u8], sig: &[u8]) -> bool {
+        let sig_bytes: [u8; ed25519_dalek::SIGNATURE_LENGTH] = match sig.try_into() {
+            Ok(ok) => ok,
+            Err(_) => return false,
+        };
+        self.verifying_key
+            .verify(msg, &ed25519_dalek::Signature::from_bytes(&sig_bytes))
+            .is_ok()
+    }
+
+    fn extract_timestamp_millis(&self, _sig: &[u8]) -> Result<Option<u64>, NoteError> {
+        // Ed25519NoteVerifier (alg type 0x01) has no timestamp in the signature
+        Ok(None)
+    }
+}
+
+impl Ed25519NoteVerifier {
+    pub fn new(name: KeyName, verifying_key: Ed25519VerifyingKey) -> Self {
+        let id = {
+            let pubkey = [
+                &[SignatureType::Ed25519 as u8],
+                verifying_key.to_bytes().as_slice(),
+            ]
+            .concat();
+            compute_key_id(&name, &pubkey)
+        };
+        Self {
+            name,
+            id,
+            verifying_key,
+        }
+    }
+    /// Construct a new [Verifier] from an encoded verifier key.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`NoteError`] if `vkey` is malformed or otherwise invalid.
+    pub fn new_from_encoded_key(vkey: &str) -> Result<Self, NoteError> {
+        let (name, vkey) = vkey.split_once('+').ok_or(NoteError::Format)?;
+        let Ok(name) = KeyName::new(name.into()) else {
+            return Err(NoteError::Format);
+        };
+        let (id16, key64) = vkey.split_once('+').ok_or(NoteError::Format)?;
+
+        let id = u32::from_str_radix(id16, 16).map_err(|_| NoteError::Format)?;
+        let key = BASE64_STANDARD
+            .decode(key64)
+            .map_err(|_| NoteError::Format)?;
+
+        if id16.len() != 8 || key.is_empty() {
+            return Err(NoteError::Format);
+        }
+
+        if id != compute_key_id(&name, &key) {
+            return Err(NoteError::Id);
+        }
+
+        let alg = key[0];
+        let key = &key[1..];
+        match SignatureType::try_from(alg) {
+            Ok(SignatureType::Ed25519) => {
+                let key_bytes: &[u8; ed25519_dalek::PUBLIC_KEY_LENGTH] =
+                    &key.try_into().map_err(|_| NoteError::Format)?;
+                let verifying_key = ed25519_dalek::VerifyingKey::from_bytes(key_bytes)
+                    .map_err(|_| NoteError::Format)?;
+                Ok(Self {
+                    name,
+                    id,
+                    verifying_key,
+                })
+            }
+            _ => Err(NoteError::Alg),
+        }
+    }
+}
+
+/// [`Ed25519NoteSigner`] is the signer for the ordinary (non-timestamped) Ed25519 signature type
+#[derive(Clone)]
+pub struct Ed25519NoteSigner {
+    pub(crate) name: KeyName,
+    pub(crate) id: u32,
+    pub(crate) signing_key: Ed25519SigningKey,
+}
+
+impl NoteSigner for Ed25519NoteSigner {
+    fn name(&self) -> &KeyName {
+        &self.name
+    }
+    fn key_id(&self) -> u32 {
+        self.id
+    }
+    fn sign(&self, msg: &[u8]) -> Result<Vec<u8>, signature::Error> {
+        let sig = self.signing_key.try_sign(msg)?;
+        Ok(sig.to_vec())
+    }
+}
+
+impl Ed25519NoteSigner {
+    pub fn new(name: KeyName, signing_key: Ed25519SigningKey) -> Self {
+        let id = {
+            let pubkey = [
+                &[SignatureType::Ed25519 as u8],
+                signing_key.verifying_key().to_bytes().as_slice(),
+            ]
+            .concat();
+            compute_key_id(&name, &pubkey)
+        };
+        Self {
+            name,
+            id,
+            signing_key,
+        }
+    }
+    /// Construct a new [Signer] from an encoded signer key.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`NoteError`] if `skey` is malformed or otherwise invalid.
+    pub fn new_from_encoded_key(skey: &str) -> Result<Self, NoteError> {
+        let (priv1, skey) = skey.split_once('+').ok_or(NoteError::Format)?;
+        let (priv2, skey) = skey.split_once('+').ok_or(NoteError::Format)?;
+        let (name, skey) = skey.split_once('+').ok_or(NoteError::Format)?;
+        let (id16, key64) = skey.split_once('+').ok_or(NoteError::Format)?;
+
+        let Ok(name) = KeyName::new(name.into()) else {
+            return Err(NoteError::Format);
+        };
+
+        let id = u32::from_str_radix(id16, 16).map_err(|_| NoteError::Format)?;
+        let key = BASE64_STANDARD
+            .decode(key64)
+            .map_err(|_| NoteError::Format)?;
+
+        if priv1 != "PRIVATE" || priv2 != "KEY" || id16.len() != 8 || key.is_empty() {
+            return Err(NoteError::Format);
+        }
+
+        // Note: id is the hash of the public key and we have the private key.
+        let alg = key[0];
+        let key = &key[1..];
+        match SignatureType::try_from(alg) {
+            Ok(SignatureType::Ed25519) => {
+                let signing_key =
+                    ed25519_dalek::SigningKey::try_from(key).map_err(|_| NoteError::Format)?;
+
+                let pubkey = [
+                    &[SignatureType::Ed25519 as u8],
+                    ed25519_dalek::VerifyingKey::from(&signing_key)
+                        .to_bytes()
+                        .as_slice(),
+                ]
+                .concat();
+
+                // Must verify id after deriving public key.
+                if id != compute_key_id(&name, &pubkey) {
+                    return Err(NoteError::Id);
+                }
+
+                Ok(Self {
+                    name,
+                    id,
+                    signing_key,
+                })
+            }
+            _ => Err(NoteError::Alg),
+        }
+    }
+}
+
+/// Generates a signer and verifier key pair for a named server.
+/// The signer key skey is private and must be kept secret.
+pub fn generate_encoded_ed25519_key<R: CryptoRngCore + ?Sized>(
+    csprng: &mut R,
+    name: &KeyName,
+) -> (String, String) {
+    let signing_key = ed25519_dalek::SigningKey::generate(csprng);
+
+    let pubkey = [
+        &[SignatureType::Ed25519 as u8],
+        signing_key.verifying_key().to_bytes().as_slice(),
+    ]
+    .concat();
+    let privkey = [
+        &[SignatureType::Ed25519 as u8],
+        signing_key.to_bytes().as_slice(),
+    ]
+    .concat();
+    let skey = format!(
+        "PRIVATE+KEY+{}+{:08x}+{}",
+        name,
+        compute_key_id(name, &pubkey),
+        BASE64_STANDARD.encode(privkey)
+    );
+    let vkey = new_encoded_ed25519_verifier_key(name, &signing_key.verifying_key());
+
+    (skey, vkey)
+}
+
+/// Returns an encoded verifier key using the given name and Ed25519 public key.
+pub fn new_encoded_ed25519_verifier_key(
+    name: &KeyName,
+    key: &ed25519_dalek::VerifyingKey,
+) -> String {
+    let pubkey = [&[SignatureType::Ed25519 as u8], key.to_bytes().as_slice()].concat();
+    format!(
+        "{}+{:08x}+{}",
+        name,
+        compute_key_id(name, &pubkey),
+        BASE64_STANDARD.encode(&pubkey)
+    )
+}

--- a/crates/signed_note/src/lib.rs
+++ b/crates/signed_note/src/lib.rs
@@ -25,7 +25,7 @@
 //! non-empty, well-formed UTF-8 containing neither Unicode spaces nor plus (U+002B).
 //!
 //! A server signs texts using public key cryptography.  A given server may have multiple public
-//! keys, each identified by a 32-bit ID of the public key.  The [`key_id`] function computes the
+//! keys, each identified by a 32-bit ID of the public key.  The [`compute_key_id`] function computes the
 //! key ID as RECOMMENDED by the [spec](https://c2sp.org/signed-note#signatures).
 //! ```text
 //! key ID = SHA-256(key name || 0x0A || signature type || public key)[:4]
@@ -53,7 +53,7 @@
 //! name of the server and the uint32 ID of the key, and it can verify a purported signature by
 //! that key.
 //!
-//! The standard implementation of a Verifier is constructed by [`Ed25519NoteVerifier::new`] starting
+//! The standard implementation of a Verifier is constructed by [`Ed25519NoteVerifier::new_from_encoded_key`] starting
 //! from a verifier key, which is a plain text string of the form `<name>+<id>+<keydata>`.
 //!
 //! A [`Verifiers`] allows looking up a Verifier by the combination of server name and key ID.
@@ -69,7 +69,7 @@
 //! A [`Signer`] allows signing a text with a given key. It can report the name of the server and the
 //! ID of the key and can sign a raw text using that key.
 //!
-//! The standard implementation of a Signer is constructed by [`Ed25519NoteSigner::new`] starting from
+//! The standard implementation of a Signer is constructed by [`Ed25519NoteSigner::new_from_encoded_key`] starting from
 //! an encoded signer key, which is a plain text string of the form
 //! `PRIVATE+KEY+<name>+<id>+<keydata>`.  Anyone with an encoded signer key can sign messages using
 //! that key, so it must be kept secret. The encoding begins with the literal text `PRIVATE+KEY` to
@@ -123,7 +123,7 @@
 //! let text = "If you think cryptography is the answer to your problem,\n\
 //!             then you don't know what your problem is.\n";
 //!
-//! let signer = Ed25519NoteSigner::new(skey).unwrap();
+//! let signer = Ed25519NoteSigner::new_from_encoded_key(skey).unwrap();
 //! let mut n = Note::new(text.as_bytes(), &[]).unwrap();
 //! n.add_sigs(&[&signer]).unwrap();
 //!
@@ -151,7 +151,7 @@
 //!            \n\
 //!            — PeterNeumann x08go/ZJkuBS9UG/SffcvIAQxVBtiFupLLr8pAcElZInNIuGUgYN1FFYC2pZSNXgKvqfqdngotpRZb6KE6RyyBwJnAM=\n";
 //!
-//! let verifier = Ed25519NoteVerifier::new(vkey).unwrap();
+//! let verifier = Ed25519NoteVerifier::new_from_encoded_key(vkey).unwrap();
 //! let n = Note::from_bytes(msg.as_bytes()).unwrap();
 //! let (verified_sigs, _) = n.verify(&VerifierList::new(vec![Box::new(verifier.clone())])).unwrap();
 //!
@@ -167,7 +167,7 @@
 //!
 //! ### Sign and add signatures
 //! ```
-//! use signed_note::{Note, Ed25519NoteSigner, Ed25519NoteVerifier, VerifierList};
+//! use signed_note::{Note, Ed25519NoteSigner, Ed25519NoteVerifier, VerifierList, KeyName};
 //!
 //! let vkey = "PeterNeumann+c74f20a3+ARpc2QcUPDhMQegwxbzhKqiBfsVkmqq/LDE4izWy10TW";
 //! let msg = "If you think cryptography is the answer to your problem,\n\
@@ -179,7 +179,7 @@
 //!
 //! let mut n = Note::from_bytes(msg.as_bytes()).unwrap();
 //!
-//! let verifier = Ed25519NoteVerifier::new(vkey).unwrap();
+//! let verifier = Ed25519NoteVerifier::new_from_encoded_key(vkey).unwrap();
 //! let (verified_sigs, unverified_sigs) = n.verify(&VerifierList::new(vec![Box::new(verifier.clone())])).unwrap();
 //! assert_eq!(verified_sigs.len(), 1);
 //! assert!(unverified_sigs.is_empty());
@@ -209,8 +209,8 @@
 //!
 //! impl rand_core::CryptoRng for ZeroRng {}
 //!
-//! let (skey, _) = signed_note::generate_key(&mut ZeroRng{}, "EnochRoot");
-//! let signer = Ed25519NoteSigner::new(&skey).unwrap();
+//! let (skey, _) = signed_note::generate_encoded_ed25519_key(&mut ZeroRng{}, &KeyName::new("EnochRoot".into()).unwrap());
+//! let signer = Ed25519NoteSigner::new_from_encoded_key(&skey).unwrap();
 //! n.add_sigs(&[&signer]).unwrap();
 //!
 //! let got = n.to_bytes();
@@ -225,23 +225,74 @@
 //! ```
 
 use base64::prelude::*;
-use ed25519_dalek::{
-    Signer as Ed25519Signer, SigningKey as Ed25519SigningKey, Verifier as Ed25519Verifier,
-    VerifyingKey as Ed25519VerifyingKey,
-};
-use rand_core::CryptoRngCore;
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeSet, HashMap};
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt,
+};
 use thiserror::Error;
+
+mod ed25519;
+pub use ed25519::*;
 
 const MAX_NOTE_SIZE: usize = 1_000_000;
 const MAX_NOTE_SIGNATURES: usize = 100;
 
+#[repr(u8)]
+pub enum SignatureType {
+    Ed25519 = 0x01,
+    CosignatureV1 = 0x04,
+    RFC6962TreeHead = 0x05,
+    Undefined = 0xff,
+}
+
+impl TryFrom<u8> for SignatureType {
+    type Error = NoteError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x01 => Ok(SignatureType::Ed25519),
+            0x04 => Ok(SignatureType::CosignatureV1),
+            0x05 => Ok(SignatureType::RFC6962TreeHead),
+            0xff => Ok(SignatureType::Undefined),
+            _ => Err(NoteError::UnknownSignatureType),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialOrd, Ord, Hash, PartialEq, Clone)]
+pub struct KeyName(String);
+
+impl KeyName {
+    /// Return a valid key name according to <https://c2sp.org/signed-note#format>.
+    /// It must be non-empty and not have any Unicode spaces or pluses.
+    ///
+    /// # Errors
+    /// Will return `Err` if the key name is empty or has Unicode spaces or pluses.
+    pub fn new(name: String) -> Result<Self, NoteError> {
+        if name.is_empty() || name.chars().any(char::is_whitespace) || name.contains('+') {
+            Err(NoteError::InvalidKeyName)
+        } else {
+            Ok(Self(name))
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for KeyName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// A Verifier verifies messages signed with a specific key.
 pub trait NoteVerifier {
     /// Returns the server name associated with the key.
-    /// The name must be non-empty and not have any Unicode spaces or pluses.
-    fn name(&self) -> &str;
+    /// The name is guaranteed to be valid.
+    fn name(&self) -> &KeyName;
 
     /// Returns the key ID.
     fn key_id(&self) -> u32;
@@ -254,14 +305,14 @@ pub trait NoteVerifier {
     /// # Errors
     ///
     /// Errors if the signature is malformed.
-    fn extract_timestamp_millis(&self, sig: &[u8]) -> Result<Option<u64>, VerificationError>;
+    fn extract_timestamp_millis(&self, sig: &[u8]) -> Result<Option<u64>, NoteError>;
 }
 
 /// A Signer signs messages using a specific key.
 pub trait NoteSigner {
     /// Returns the server name associated with the key.
     /// The name must be non-empty and not have any Unicode spaces or pluses.
-    fn name(&self) -> &str;
+    fn name(&self) -> &KeyName;
 
     /// Returns the key ID.
     fn key_id(&self) -> u32;
@@ -276,9 +327,9 @@ pub trait NoteSigner {
 
 /// Computes the key ID for the given server name and encoded public key
 /// as RECOMMENDED at <https://c2sp.org/signed-note#signatures>.
-pub fn key_id(name: &str, key: &[u8]) -> u32 {
+pub fn compute_key_id(name: &KeyName, key: &[u8]) -> u32 {
     let mut hasher = Sha256::new();
-    hasher.update(name.as_bytes());
+    hasher.update(name.0.as_bytes());
     hasher.update(b"\n");
     hasher.update(key);
     let result = hasher.finalize();
@@ -288,233 +339,6 @@ pub fn key_id(name: &str, key: &[u8]) -> u32 {
     u32::from_be_bytes(u32_bytes)
 }
 
-/// An error returned from the [`Ed25519NoteVerifier::new`] function when
-/// constructing a [`Ed25519NoteVerifier`] from an encoded verifier key.
-#[derive(Error, Debug)]
-pub enum VerifierError {
-    #[error("malformed verifier key")]
-    Format,
-    #[error("unknown verifier algorithm")]
-    Alg,
-    #[error("invalid verifier ID")]
-    Id,
-}
-
-const ALG_ED25519: u8 = 1;
-
-// Reports whether name is valid according to <https://c2sp.org/signed-note#format>.
-// It must be non-empty and not have any Unicode spaces or pluses.
-pub fn is_key_name_valid(name: &str) -> bool {
-    !(name.is_empty() || name.chars().any(char::is_whitespace) || name.contains('+'))
-}
-
-/// [`Ed25519NoteVerifier`] is the verifier for the ordinary (non-timestamped) Ed25519 signature type
-#[derive(Clone)]
-pub struct Ed25519NoteVerifier {
-    name: String,
-    id: u32,
-    verifying_key: Ed25519VerifyingKey,
-}
-
-impl NoteVerifier for Ed25519NoteVerifier {
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn key_id(&self) -> u32 {
-        self.id
-    }
-
-    fn verify(&self, msg: &[u8], sig: &[u8]) -> bool {
-        let sig_bytes: [u8; ed25519_dalek::SIGNATURE_LENGTH] = match sig.try_into() {
-            Ok(ok) => ok,
-            Err(_) => return false,
-        };
-        self.verifying_key
-            .verify(msg, &ed25519_dalek::Signature::from_bytes(&sig_bytes))
-            .is_ok()
-    }
-
-    fn extract_timestamp_millis(&self, _sig: &[u8]) -> Result<Option<u64>, VerificationError> {
-        // Ed25519NoteVerifier (alg type 0x01) has no timestamp in the signature
-        Ok(None)
-    }
-}
-
-impl Ed25519NoteVerifier {
-    /// Construct a new [Verifier] from an encoded verifier key.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`VerifierError`] if `vkey` is malformed or otherwise invalid.
-    pub fn new(vkey: &str) -> Result<Self, VerifierError> {
-        let (name, vkey) = vkey.split_once('+').ok_or(VerifierError::Format)?;
-        let (id16, key64) = vkey.split_once('+').ok_or(VerifierError::Format)?;
-
-        let id = u32::from_str_radix(id16, 16).map_err(|_| VerifierError::Format)?;
-        let key = BASE64_STANDARD
-            .decode(key64)
-            .map_err(|_| VerifierError::Format)?;
-
-        if id16.len() != 8 || !is_key_name_valid(name) || key.is_empty() {
-            return Err(VerifierError::Format);
-        }
-
-        if id != key_id(name, &key) {
-            return Err(VerifierError::Id);
-        }
-
-        let alg = key[0];
-        let key = &key[1..];
-        match alg {
-            ALG_ED25519 => {
-                let key_bytes: &[u8; ed25519_dalek::PUBLIC_KEY_LENGTH] =
-                    &key.try_into().map_err(|_| VerifierError::Format)?;
-                let verifying_key = ed25519_dalek::VerifyingKey::from_bytes(key_bytes)
-                    .map_err(|_| VerifierError::Format)?;
-                Ok(Self {
-                    name: name.to_owned(),
-                    id,
-                    verifying_key,
-                })
-            }
-            _ => Err(VerifierError::Alg),
-        }
-    }
-}
-
-/// An error returned from the [`Ed25519NoteSigner::new`] function when
-/// constructing a [`Ed25519NoteSigner`] from an encoded signer key.
-#[derive(Error, Debug)]
-pub enum SignerError {
-    #[error("malformed verifier key")]
-    Format,
-    #[error("unknown verifier algorithm")]
-    Alg,
-    #[error("invalid verifier ID")]
-    Id,
-}
-
-/// [`Ed25519NoteSigner`] is the signer for the ordinary (non-timestamped) Ed25519 signature type
-#[derive(Clone)]
-pub struct Ed25519NoteSigner {
-    name: String,
-    id: u32,
-    signing_key: Ed25519SigningKey,
-}
-
-impl NoteSigner for Ed25519NoteSigner {
-    fn name(&self) -> &str {
-        &self.name
-    }
-    fn key_id(&self) -> u32 {
-        self.id
-    }
-    fn sign(&self, msg: &[u8]) -> Result<Vec<u8>, signature::Error> {
-        let sig = self.signing_key.try_sign(msg)?;
-        Ok(sig.to_vec())
-    }
-}
-
-impl Ed25519NoteSigner {
-    /// Construct a new [Signer] from an encoded signer key.
-    ///
-    /// # Errors
-    ///
-    /// Returns a [`SignerError`] if `skey` is malformed or otherwise invalid.
-    pub fn new(skey: &str) -> Result<Self, SignerError> {
-        let (priv1, skey) = skey.split_once('+').ok_or(SignerError::Format)?;
-        let (priv2, skey) = skey.split_once('+').ok_or(SignerError::Format)?;
-        let (name, skey) = skey.split_once('+').ok_or(SignerError::Format)?;
-        let (id16, key64) = skey.split_once('+').ok_or(SignerError::Format)?;
-
-        let id = u32::from_str_radix(id16, 16).map_err(|_| SignerError::Format)?;
-        let key = BASE64_STANDARD
-            .decode(key64)
-            .map_err(|_| SignerError::Format)?;
-
-        if priv1 != "PRIVATE"
-            || priv2 != "KEY"
-            || id16.len() != 8
-            || !is_key_name_valid(name)
-            || key.is_empty()
-        {
-            return Err(SignerError::Format);
-        }
-
-        // Note: id is the hash of the public key and we have the private key.
-        // Must verify id after deriving public key.
-
-        let signer: Ed25519NoteSigner;
-        let pubkey: Vec<u8>;
-
-        let alg = key[0];
-        let key = &key[1..];
-        match alg {
-            ALG_ED25519 => {
-                let signing_key =
-                    ed25519_dalek::SigningKey::try_from(key).map_err(|_| SignerError::Format)?;
-
-                pubkey = [
-                    &[ALG_ED25519],
-                    ed25519_dalek::VerifyingKey::from(&signing_key)
-                        .to_bytes()
-                        .as_slice(),
-                ]
-                .concat();
-
-                signer = Self {
-                    name: name.to_owned(),
-                    id,
-                    signing_key,
-                };
-            }
-            _ => {
-                return Err(SignerError::Alg);
-            }
-        }
-
-        if id != key_id(name, &pubkey) {
-            return Err(SignerError::Id);
-        }
-
-        Ok(signer)
-    }
-}
-
-/// Generates a signer and verifier key pair for a named server.
-/// The signer key skey is private and must be kept secret.
-pub fn generate_key<R: CryptoRngCore + ?Sized>(csprng: &mut R, name: &str) -> (String, String) {
-    let signing_key = ed25519_dalek::SigningKey::generate(csprng);
-
-    let pubkey = [
-        &[ALG_ED25519],
-        signing_key.verifying_key().to_bytes().as_slice(),
-    ]
-    .concat();
-    let privkey = [&[ALG_ED25519], signing_key.to_bytes().as_slice()].concat();
-    let skey = format!(
-        "PRIVATE+KEY+{}+{:08x}+{}",
-        name,
-        key_id(name, &pubkey),
-        BASE64_STANDARD.encode(privkey)
-    );
-    let vkey = new_ed25519_verifier_key(name, &signing_key.verifying_key());
-
-    (skey, vkey)
-}
-
-/// Returns an encoded verifier key using the given name and Ed25519 public key.
-pub fn new_ed25519_verifier_key(name: &str, key: &ed25519_dalek::VerifyingKey) -> String {
-    let pubkey = [&[ALG_ED25519], key.to_bytes().as_slice()].concat();
-    format!(
-        "{}+{:08x}+{}",
-        name,
-        key_id(name, &pubkey),
-        BASE64_STANDARD.encode(&pubkey)
-    )
-}
-
 /// [`Verifiers`] is a collection of known verifier keys.
 pub trait Verifiers {
     /// Returns the [`Verifier`] associated with the key identified by the name and
@@ -522,41 +346,30 @@ pub trait Verifiers {
     ///
     /// # Errors
     ///
-    /// If the (name, id) pair is unknown, return a [`VerificationError::UnknownKey`].
-    fn verifier(&self, name: &str, id: u32) -> Result<&dyn NoteVerifier, VerificationError>;
+    /// If the (name, id) pair is unknown, return a [`NoteError::UnknownKey`].
+    fn verifier(&self, name: &KeyName, id: u32) -> Result<&dyn NoteVerifier, NoteError>;
 }
 
-type VerifierMap = HashMap<(String, u32), Vec<Box<dyn NoteVerifier>>>;
+type VerifierMap = HashMap<(KeyName, u32), Vec<Box<dyn NoteVerifier>>>;
 
 /// [`VerifierList`] is a [Verifiers] implementation that uses the given list of verifiers.
 pub struct VerifierList {
     map: VerifierMap,
 }
 
-/// An error returned from a Verifier when verifying a signature.
-#[derive(Error, Debug)]
-pub enum VerificationError {
-    #[error("unknown key {name}+{id:08x}")]
-    UnknownKey { name: String, id: u32 },
-    #[error("ambiguous key {name}+{id:08x}")]
-    AmbiguousKey { name: String, id: u32 },
-    #[error("malformed timestamp")]
-    Timestamp,
-}
-
 impl Verifiers for VerifierList {
-    fn verifier(&self, name: &str, id: u32) -> Result<&dyn NoteVerifier, VerificationError> {
+    fn verifier(&self, name: &KeyName, id: u32) -> Result<&dyn NoteVerifier, NoteError> {
         match self.map.get(&(name.to_owned(), id)) {
             Some(verifiers) => {
                 if verifiers.len() > 1 {
-                    return Err(VerificationError::AmbiguousKey {
+                    return Err(NoteError::AmbiguousKey {
                         name: name.to_owned(),
                         id,
                     });
                 }
                 Ok(&*verifiers[0])
             }
-            None => Err(VerificationError::UnknownKey {
+            None => Err(NoteError::UnknownKey {
                 name: name.to_owned(),
                 id,
             }),
@@ -569,7 +382,7 @@ impl VerifierList {
     pub fn new(list: Vec<Box<dyn NoteVerifier>>) -> Self {
         let mut map: VerifierMap = HashMap::new();
         for verifier in list {
-            map.entry((verifier.name().to_owned(), verifier.key_id()))
+            map.entry((verifier.name().clone(), verifier.key_id()))
                 .or_default()
                 .push(verifier);
         }
@@ -595,7 +408,7 @@ pub struct Note {
 #[derive(Debug, PartialEq, Clone)]
 pub struct NoteSignature {
     /// Name for the key that generated the signature.
-    name: String,
+    name: KeyName,
     /// Key ID for the key that generated the signature.
     id: u32,
     /// The signature bytes.
@@ -609,11 +422,8 @@ impl NoteSignature {
     ///
     /// Returns [`NoteError::MalformedNote`] if the name is invalid according to [`is_key_name_valid`].
     ///
-    pub fn new(name: String, id: u32, sig: Vec<u8>) -> Result<Self, NoteError> {
-        if !is_key_name_valid(&name) {
-            return Err(NoteError::MalformedNote);
-        }
-        Ok(Self { name, id, sig })
+    pub fn new(name: KeyName, id: u32, sig: Vec<u8>) -> Self {
+        Self { name, id, sig }
     }
 
     /// Parse a signature line into a [Signature].
@@ -637,11 +447,15 @@ impl NoteSignature {
         }
         let id = u32::from_be_bytes(sig[..4].try_into().unwrap());
         let sig = &sig[4..];
-        NoteSignature::new(name.to_owned(), id, sig.to_owned())
+        Ok(NoteSignature::new(
+            KeyName::new(name.to_owned())?,
+            id,
+            sig.to_owned(),
+        ))
     }
 
     /// Return a signature's name.
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &KeyName {
         &self.name
     }
 
@@ -659,7 +473,7 @@ impl NoteSignature {
     pub fn to_bytes(&self) -> Vec<u8> {
         let hbuf = self.id.to_be_bytes();
         let base64 = BASE64_STANDARD.encode([&hbuf, self.sig.as_slice()].concat());
-        format!("— {} {}\n", self.name, base64).into()
+        format!("— {} {base64}\n", self.name).into()
     }
 }
 
@@ -670,14 +484,28 @@ pub enum NoteError {
     MalformedNote,
     #[error("invalid signer")]
     InvalidSigner,
+    #[error("invalid key name")]
+    InvalidKeyName,
     #[error("invalid signature for key {name}+{id:08x}")]
-    InvalidSignature { name: String, id: u32 },
+    InvalidSignature { name: KeyName, id: u32 },
+    #[error("unknown signature type")]
+    UnknownSignatureType,
     #[error("verifier name or id doesn't match signature")]
     MismatchedVerifier,
     #[error("note has no verifiable signatures")]
     UnverifiedNote,
-    #[error(transparent)]
-    VerificationError(#[from] VerificationError),
+    #[error("unknown key {name}+{id:08x}")]
+    UnknownKey { name: KeyName, id: u32 },
+    #[error("ambiguous key {name}+{id:08x}")]
+    AmbiguousKey { name: KeyName, id: u32 },
+    #[error("malformed timestamp")]
+    Timestamp,
+    #[error("malformed verifier key")]
+    Format,
+    #[error("unknown verifier algorithm")]
+    Alg,
+    #[error("invalid verifier ID")]
+    Id,
     #[error(transparent)]
     SignatureError(#[from] signature::Error),
 }
@@ -765,7 +593,7 @@ impl Note {
     /// For each signature in the message, [`Note::verify`] calls known.verifier to find a verifier.
     /// If known.verifier returns a verifier and the verifier accepts the signature,
     /// [`Note::verify`] includes the signature in the returned list of verified signatures.
-    /// If known.verifier returns a [`VerificationError::UnknownKey`],
+    /// If known.verifier returns a [`NoteError::UnknownKey`],
     /// [`Note::verify`] includes the signature in the returned list of unverified signatures.
     ///
     /// # Errors
@@ -787,13 +615,13 @@ impl Note {
         for sig in &self.sigs {
             match known.verifier(&sig.name, sig.id) {
                 Ok(verifier) => {
-                    if verifier.name() != sig.name || verifier.key_id() != sig.id {
+                    if verifier.name() != sig.name() || verifier.key_id() != sig.id {
                         return Err(NoteError::MismatchedVerifier);
                     }
-                    if seen.contains(&(&sig.name, sig.id)) {
+                    if seen.contains(&(sig.name.as_str(), sig.id)) {
                         continue;
                     }
-                    seen.insert((&sig.name, sig.id));
+                    seen.insert((sig.name.as_str(), sig.id));
                     if !verifier.verify(&self.text, &sig.sig) {
                         return Err(NoteError::InvalidSignature {
                             name: sig.name.clone(),
@@ -802,7 +630,7 @@ impl Note {
                     }
                     verified_sigs.push(sig.clone());
                 }
-                Err(VerificationError::UnknownKey { name: _, id: _ }) => {
+                Err(NoteError::UnknownKey { name: _, id: _ }) => {
                     // Drop repeated identical unverified signatures.
                     if seen_unverified.contains(&sig.to_bytes()) {
                         continue;
@@ -810,7 +638,7 @@ impl Note {
                     seen_unverified.insert(sig.to_bytes());
                     unverified_sigs.push(sig.clone());
                 }
-                Err(e) => return Err(e.into()),
+                Err(e) => return Err(e),
             }
         }
         if verified_sigs.is_empty() {
@@ -836,11 +664,8 @@ impl Note {
             let name = s.name();
             let id = s.key_id();
             have.insert((name, id));
-            if !is_key_name_valid(name) {
-                return Err(NoteError::InvalidSigner);
-            }
             let sig = s.sign(&self.text)?;
-            new_sigs.push(NoteSignature::new(name.to_owned(), id, sig)?);
+            new_sigs.push(NoteSignature::new(name.clone(), id, sig));
         }
 
         // Remove existing signatures that have been replaced by new ones.
@@ -873,11 +698,17 @@ mod tests {
 
     use super::*;
     use rand::rngs::OsRng;
-    static NAME: &str = "EnochRoot";
+    use std::sync::LazyLock;
 
-    fn test_signer_and_verifier(name: &str, signer: &dyn NoteSigner, verifier: &dyn NoteVerifier) {
-        assert_eq!(&name, &signer.name());
-        assert_eq!(&name, &verifier.name());
+    static NAME: LazyLock<KeyName> = LazyLock::new(|| KeyName::new("EnochRoot".into()).unwrap());
+
+    fn test_signer_and_verifier(
+        name: &KeyName,
+        signer: &dyn NoteSigner,
+        verifier: &dyn NoteVerifier,
+    ) {
+        assert_eq!(name, signer.name());
+        assert_eq!(name, verifier.name());
         assert_eq!(signer.key_id(), verifier.key_id());
 
         let msg: &[u8] = b"hi";
@@ -887,12 +718,12 @@ mod tests {
 
     #[test]
     fn test_generate_key() {
-        let (skey, vkey) = generate_key(&mut OsRng, NAME);
+        let (skey, vkey) = generate_encoded_ed25519_key(&mut OsRng, &NAME);
 
-        let signer = Ed25519NoteSigner::new(&skey).unwrap();
-        let verifier = Ed25519NoteVerifier::new(&vkey).unwrap();
+        let signer = Ed25519NoteSigner::new_from_encoded_key(&skey).unwrap();
+        let verifier = Ed25519NoteVerifier::new_from_encoded_key(&vkey).unwrap();
 
-        test_signer_and_verifier(NAME, &signer, &verifier);
+        test_signer_and_verifier(&NAME, &signer, &verifier);
     }
 
     #[test]
@@ -900,14 +731,14 @@ mod tests {
         let signing_key = ed25519_dalek::SigningKey::generate(&mut OsRng);
 
         let pubkey = [
-            &[ALG_ED25519],
+            &[SignatureType::Ed25519 as u8],
             signing_key.verifying_key().to_bytes().as_slice(),
         ]
         .concat();
-        let id = key_id(NAME, &pubkey);
+        let id = compute_key_id(&NAME, &pubkey);
 
-        let vkey = new_ed25519_verifier_key(NAME, &signing_key.verifying_key());
-        let verifier = Ed25519NoteVerifier::new(&vkey).unwrap();
+        let vkey = new_encoded_ed25519_verifier_key(&NAME, &signing_key.verifying_key());
+        let verifier = Ed25519NoteVerifier::new_from_encoded_key(&vkey).unwrap();
 
         let signer = Ed25519NoteSigner {
             name: NAME.to_owned(),
@@ -915,23 +746,7 @@ mod tests {
             signing_key,
         };
 
-        test_signer_and_verifier(NAME, &signer, &verifier);
-    }
-
-    struct BadSigner {
-        s: Box<dyn NoteSigner>,
-    }
-
-    impl NoteSigner for BadSigner {
-        fn name(&self) -> &'static str {
-            "bad name"
-        }
-        fn key_id(&self) -> u32 {
-            self.s.key_id()
-        }
-        fn sign(&self, msg: &[u8]) -> Result<Vec<u8>, signature::Error> {
-            self.s.sign(msg)
-        }
+        test_signer_and_verifier(&NAME, &signer, &verifier);
     }
 
     struct ErrSigner {
@@ -939,7 +754,7 @@ mod tests {
     }
 
     impl NoteSigner for ErrSigner {
-        fn name(&self) -> &str {
+        fn name(&self) -> &KeyName {
             self.s.name()
         }
         fn key_id(&self) -> u32 {
@@ -956,7 +771,7 @@ mod tests {
         let text = b"If you think cryptography is the answer to your problem,\n\
                     then you don't know what your problem is.\n";
 
-        let signer = Ed25519NoteSigner::new(skey).unwrap();
+        let signer = Ed25519NoteSigner::new_from_encoded_key(skey).unwrap();
 
         let mut n = Note::new(text, &[]).unwrap();
         n.add_sigs(&[&signer]).unwrap();
@@ -970,7 +785,11 @@ mod tests {
         // Check that existing signature is replaced by new one.
         let mut n = Note::new(
             text,
-            &[NoteSignature::new("PeterNeumann".into(), 0xc74f_20a3, vec![]).unwrap()],
+            &[NoteSignature::new(
+                KeyName::new("PeterNeumann".into()).unwrap(),
+                0xc74f_20a3,
+                vec![],
+            )],
         )
         .unwrap();
         n.add_sigs(&[&signer]).unwrap();
@@ -982,18 +801,9 @@ mod tests {
         let err = Note::new(b"abc", &[]).unwrap_err();
         assert!(matches!(err, NoteError::MalformedNote));
 
-        // Attempt to create signature with bad name.
-        let err = NoteSignature::new("a+b".into(), 0, vec![]).unwrap_err();
-        assert!(matches!(err, NoteError::MalformedNote));
-
-        // Attempt to sign with bad signer.
-        let err = Note::new(text, &[])
-            .unwrap()
-            .add_sigs(&[&BadSigner {
-                s: Box::new(signer.clone()),
-            }])
-            .unwrap_err();
-        assert!(matches!(err, NoteError::InvalidSigner));
+        // Attempt to create invalid key name.
+        let err = KeyName::new("a+b".into()).unwrap_err();
+        assert!(matches!(err, NoteError::InvalidKeyName));
 
         let err = Note::new(text, &[])
             .unwrap()
@@ -1009,7 +819,7 @@ mod tests {
     }
 
     impl Verifiers for FixedVerifier {
-        fn verifier(&self, _name: &str, _id: u32) -> Result<&dyn NoteVerifier, VerificationError> {
+        fn verifier(&self, _name: &KeyName, _id: u32) -> Result<&dyn NoteVerifier, NoteError> {
             Ok(&*self.v)
         }
     }
@@ -1017,10 +827,10 @@ mod tests {
     #[test]
     fn test_open() {
         let peter_key = "PeterNeumann+c74f20a3+ARpc2QcUPDhMQegwxbzhKqiBfsVkmqq/LDE4izWy10TW";
-        let peter_verifier = Ed25519NoteVerifier::new(peter_key).unwrap();
+        let peter_verifier = Ed25519NoteVerifier::new_from_encoded_key(peter_key).unwrap();
 
         let enoch_key = "EnochRoot+af0cfe78+ATtqJ7zOtqQtYqOo0CpvDXNlMhV3HeJDpjrASKGLWdop";
-        let enoch_verifier = Ed25519NoteVerifier::new(enoch_key).unwrap();
+        let enoch_verifier = Ed25519NoteVerifier::new_from_encoded_key(enoch_key).unwrap();
 
         let text = "If you think cryptography is the answer to your problem,\n\
                     then you don't know what your problem is.\n";

--- a/crates/static_ct_api/src/lib.rs
+++ b/crates/static_ct_api/src/lib.rs
@@ -16,8 +16,6 @@ pub enum StaticCTError {
     #[error(transparent)]
     Note(#[from] signed_note::NoteError),
     #[error(transparent)]
-    Verification(#[from] signed_note::VerificationError),
-    #[error(transparent)]
     IO(#[from] std::io::Error),
     #[error(transparent)]
     Der(#[from] der::Error),
@@ -25,8 +23,6 @@ pub enum StaticCTError {
     X509(#[from] x509_verify::spki::Error),
     #[error("unexpected extension")]
     UnexpectedExtension,
-    #[error(transparent)]
-    Signer(#[from] signed_note::SignerError),
     #[error("malformed")]
     Malformed,
     #[error("missing leaf_index extension")]

--- a/crates/static_ct_api/src/rfc6962.rs
+++ b/crates/static_ct_api/src/rfc6962.rs
@@ -251,7 +251,7 @@ impl_newtype!(CTPrecertPoison, Null);
 /// ```
 fn is_link_valid(child: &Certificate, issuer: &Certificate) -> bool {
     if let Ok(key) = VerifyingKey::try_from(issuer) {
-        key.verify(child).is_ok()
+        key.verify_strict(child).is_ok()
     } else {
         false
     }

--- a/crates/static_ct_api/src/static_ct.rs
+++ b/crates/static_ct_api/src/static_ct.rs
@@ -118,8 +118,7 @@ use p256::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use signed_note::{
-    NoteError, NoteVerifier, Signature as NoteSignature, SignerError, VerificationError,
-    VerifierError,
+    NoteError, NoteSignature, NoteVerifier, SignerError, VerificationError, VerifierError,
 };
 use std::io::Read;
 use tlog_tiles::{

--- a/crates/static_ct_api/src/static_ct.rs
+++ b/crates/static_ct_api/src/static_ct.rs
@@ -282,9 +282,11 @@ impl StaticCTLogEntry {
 impl LogEntry for StaticCTLogEntry {
     const REQUIRE_CHECKPOINT_TIMESTAMP: bool = true;
     type Pending = StaticCTPendingLogEntry;
-
-    // The error type for parse_from_tile_entry
     type ParseError = StaticCTError;
+
+    fn initial_entry() -> Option<Self::Pending> {
+        None
+    }
 
     fn new(pending: StaticCTPendingLogEntry, metadata: SequenceMetadata) -> Self {
         StaticCTLogEntry {

--- a/crates/tlog_tiles/Cargo.toml
+++ b/crates/tlog_tiles/Cargo.toml
@@ -23,6 +23,7 @@ crate-type = ["rlib"]
 
 [dependencies]
 base64.workspace = true
+byteorder.workspace = true
 ed25519-dalek.workspace = true
 length_prefixed.workspace = true
 rand.workspace = true

--- a/crates/tlog_tiles/src/checkpoint.rs
+++ b/crates/tlog_tiles/src/checkpoint.rs
@@ -35,8 +35,7 @@ use ed25519_dalek::{Signer, SigningKey as Ed25519SigningKey};
 use rand::{seq::SliceRandom, Rng};
 use sha2::{Digest, Sha256};
 use signed_note::{
-    Ed25519NoteVerifier, Note, NoteError, NoteVerifier, Signature as NoteSignature, VerifierList,
-    Verifiers,
+    Ed25519NoteVerifier, Note, NoteError, NoteSignature, NoteVerifier, VerifierList, Verifiers,
 };
 use std::{
     fmt,

--- a/crates/tlog_tiles/src/cosignature_v1.rs
+++ b/crates/tlog_tiles/src/cosignature_v1.rs
@@ -1,0 +1,177 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use ed25519_dalek::{
+    Signer as Ed25519Signer, SigningKey as Ed25519SigningKey, Verifier as Ed25519Verifier,
+    VerifyingKey as Ed25519VerifyingKey,
+};
+use signed_note::{compute_key_id, KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
+
+use crate::{Checkpoint, CheckpointSigner, UnixTimestamp};
+
+/// Implementation of [`CheckpointSigner`] that produces a timestamped Ed25519 cosignature/v1 (alg 0x04 from <c2sp.org/signed-note>).
+pub struct CosignatureV1CheckpointSigner {
+    v: CosignatureV1NoteVerifier,
+    k: Ed25519SigningKey,
+}
+
+impl CosignatureV1CheckpointSigner {
+    /// Returns a new `CosignatureV1CheckpointSigner`.
+    pub fn new(name: KeyName, k: Ed25519SigningKey) -> Self {
+        Self {
+            v: CosignatureV1NoteVerifier::new(name, k.verifying_key()),
+            k,
+        }
+    }
+}
+
+impl CheckpointSigner for CosignatureV1CheckpointSigner {
+    fn name(&self) -> &KeyName {
+        self.v.name()
+    }
+
+    fn key_id(&self) -> u32 {
+        self.v.key_id()
+    }
+
+    fn sign(
+        &self,
+        timestamp_unix_millis: UnixTimestamp,
+        checkpoint: &Checkpoint,
+    ) -> Result<NoteSignature, NoteError> {
+        // Timestamp is in seconds.
+        let timestamp_unix_secs = timestamp_unix_millis / 1000;
+        let mut msg = format!("cosignature/v1\ntime {timestamp_unix_secs}\n").into_bytes();
+        msg.extend(checkpoint.to_bytes());
+
+        // Ed25519 signing cannot fail
+        let sig = self.k.try_sign(&msg).unwrap();
+
+        // Now format the final signature according to <https://github.com/C2SP/C2SP/blob/main/tlog-cosignature.md#format>.
+        // struct timestamped_signature {
+        //     u64 timestamp;
+        //     u8 signature[64];
+        // }
+        let mut note_sig = Vec::new();
+        note_sig
+            .write_u64::<BigEndian>(timestamp_unix_secs)
+            .unwrap();
+        note_sig.extend(&sig.to_bytes());
+
+        // Return the note signature.
+        Ok(NoteSignature::new(
+            self.name().clone(),
+            self.key_id(),
+            note_sig,
+        ))
+    }
+
+    fn verifier(&self) -> Box<dyn NoteVerifier> {
+        Box::new(self.v.clone())
+    }
+}
+
+/// [`CosignatureV1NoteVerifier`] is the verifier for the timestamped Ed25519 cosignature type defined in <https://c2sp.org/tlog-cosignature>.
+#[derive(Clone)]
+pub struct CosignatureV1NoteVerifier {
+    name: KeyName,
+    id: u32,
+    verifying_key: Ed25519VerifyingKey,
+}
+
+impl CosignatureV1NoteVerifier {
+    pub fn new(name: KeyName, verifying_key: Ed25519VerifyingKey) -> Self {
+        let id = {
+            let pubkey = [
+                &[SignatureType::CosignatureV1 as u8],
+                verifying_key.to_bytes().as_slice(),
+            ]
+            .concat();
+            compute_key_id(&name, &pubkey)
+        };
+        Self {
+            name,
+            id,
+            verifying_key,
+        }
+    }
+}
+
+impl NoteVerifier for CosignatureV1NoteVerifier {
+    fn name(&self) -> &KeyName {
+        &self.name
+    }
+
+    fn key_id(&self) -> u32 {
+        self.id
+    }
+
+    fn verify(&self, msg: &[u8], mut sig: &[u8]) -> bool {
+        // The message itself should be a valid checkpoint.
+        let Ok(checkpoint) = Checkpoint::from_bytes(msg) else {
+            return false;
+        };
+        // timestamped_signature.timestamp
+        let Ok(sig_timestamp) = sig.read_u64::<BigEndian>() else {
+            return false;
+        };
+        // timestamped_signature.signature
+        let sig_bytes: [u8; ed25519_dalek::SIGNATURE_LENGTH] = match sig.try_into() {
+            Ok(ok) => ok,
+            Err(_) => return false,
+        };
+
+        // Construct message to be signed from <https://github.com/C2SP/C2SP/blob/main/tlog-cosignature.md#signed-message>.
+        let mut msg = format!("cosignature/v1\ntime {sig_timestamp}\n").into_bytes();
+        msg.extend(checkpoint.to_bytes());
+        self.verifying_key
+            .verify(&msg, &ed25519_dalek::Signature::from_bytes(&sig_bytes))
+            .is_ok()
+    }
+
+    fn extract_timestamp_millis(&self, mut sig: &[u8]) -> Result<Option<u64>, NoteError> {
+        // The timestamp is the first 8 bytes of the signature, and is in seconds.
+        let ts = sig
+            .read_u64::<BigEndian>()
+            .map_err(|_| NoteError::Timestamp)?;
+        Ok(Some(ts * 1000))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use crate::{open_checkpoint, record_hash, TreeWithTimestamp};
+
+    use super::*;
+    use rand::rngs::OsRng;
+    use signed_note::VerifierList;
+
+    #[test]
+    fn test_cosignature_v1_sign_verify() {
+        let mut rng = OsRng;
+
+        let origin = "example.com/origin";
+        let timestamp = 100;
+        let tree_size = 4;
+
+        // Make a tree head and sign it
+        let tree = TreeWithTimestamp::new(tree_size, record_hash(b"hello world"), timestamp);
+        let signer = {
+            let sk = Ed25519SigningKey::generate(&mut rng);
+            let name = KeyName::new("my-signer".into()).unwrap();
+            CosignatureV1CheckpointSigner::new(name, sk)
+        };
+        let checkpoint = tree.sign(origin, &[], &[&signer], &mut rng).unwrap();
+
+        // Now verify the signed checkpoint
+        let verifier = signer.verifier();
+        open_checkpoint(
+            origin,
+            &VerifierList::new(vec![verifier]),
+            timestamp,
+            &checkpoint,
+        )
+        .unwrap();
+    }
+}

--- a/crates/tlog_tiles/src/entries.rs
+++ b/crates/tlog_tiles/src/entries.rs
@@ -50,6 +50,11 @@ pub trait LogEntry: core::fmt::Debug + Sized {
     /// The error type for [`Self::parse_from_tile_entry`]
     type ParseError: std::error::Error + Send + Sync + 'static;
 
+    /// Returns an optional initial entry to add into the log. This is used for
+    /// the initial `null_entry` in Merkle Tree Certificates, but likely not
+    /// useful anywhere else.
+    fn initial_entry() -> Option<Self::Pending>;
+
     fn new(pending: Self::Pending, metadata: SequenceMetadata) -> Self;
 
     /// Returns the Merkle tree leaf hash for this entry. For tlog-tiles, this is the Merkle Tree Hash
@@ -143,6 +148,10 @@ impl LogEntry for TlogTilesLogEntry {
     const REQUIRE_CHECKPOINT_TIMESTAMP: bool = false;
     type Pending = TlogTilesPendingLogEntry;
     type ParseError = TlogError;
+
+    fn initial_entry() -> Option<Self::Pending> {
+        None
+    }
 
     fn new(pending: Self::Pending, _metadata: SequenceMetadata) -> Self {
         Self { inner: pending }

--- a/crates/tlog_tiles/src/lib.rs
+++ b/crates/tlog_tiles/src/lib.rs
@@ -17,11 +17,13 @@
 //! - [ct_test.go](https://cs.opensource.google/go/x/mod/+/refs/tags/v0.21.0:sumdb/tlog/ct_test.go)
 
 pub mod checkpoint;
+pub mod cosignature_v1;
 pub mod entries;
 pub mod tile;
 pub mod tlog;
 
 pub use checkpoint::*;
+pub use cosignature_v1::*;
 pub use entries::*;
 pub use tile::*;
 pub use tlog::*;

--- a/crates/tlog_tiles/src/tlog.rs
+++ b/crates/tlog_tiles/src/tlog.rs
@@ -474,10 +474,6 @@ pub enum TlogError {
     #[error(transparent)]
     MalformedCheckpoint(#[from] crate::MalformedCheckpointError),
     #[error(transparent)]
-    Verification(#[from] signed_note::VerificationError),
-    #[error(transparent)]
-    Verifier(#[from] signed_note::VerifierError),
-    #[error(transparent)]
     InvalidBase64(#[from] base64::DecodeError),
     #[error(transparent)]
     IO(#[from] std::io::Error),


### PR DESCRIPTION
Add cosignature support

- Add support for cosignature/v1 signatures from tlog-cosignature
- Add support for subtree_signatures from current MTC draft.  This is
  currently limited to signing checkpoints but not arbitrary subtrees.

Other changes (hopefully improvements):
- Consolidate signed_note error types into NoteError
- Add new() functions for Ed25519NoteSigner/Verifier to avoid needing to go through text format
- Add KeyName wrapper around string that enforces that key names are valid according to signed_note spec
- Move Ed25519 signer/verifier to separate file in signed_note
- Add enum for signed_note signature types

Clean up config

* Update wrangler KV and R2 resources for MTC dev deploy
* Re-enable wasm-opt (see https://github.com/cloudflare/workers-rs/pull/767)

Rename Signature -> NoteSignature to avoid naming conflicts

Add support for parsing the log ID as a ObjectIdentifier

This is not compatibile with the current MTC draft which uses RELATIVE-OID, but will do until https://github.com/RustCrypto/formats/issues/1875 is handled.

Add support for MTC's initial log entry

In MTCs, the certificate serial number is its index in the log. Since
X.509 serial numbers must be non-zero, MTCs adds an initial 'null_entry'
at index 0 to help avoid off-by-one errors in consumers of the log.

Align MTC implementation closer to spec