### PR TITLE
Add 'RELATIVE OID' support with fork of 'der' crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
  "tlog_tiles",
  "url",
  "worker",
- "x509-verify",
+ "x509-cert",
  "x509_util",
 ]
 
@@ -515,8 +515,7 @@ dependencies = [
 [[package]]
 name = "der"
 version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+source = "git+https://github.com/lukevalenta/formats?branch=relative-oid-tag-v0.7.10#895775339c03f7dc42529c131d578751406870a4"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -1407,7 +1406,7 @@ dependencies = [
  "signed_note",
  "thiserror 2.0.12",
  "tlog_tiles",
- "x509-verify",
+ "x509-cert",
  "x509_util",
 ]
 
@@ -1417,6 +1416,7 @@ version = "0.2.0"
 dependencies = [
  "base64",
  "chrono",
+ "der",
  "ed25519-dalek",
  "futures-executor",
  "futures-util",
@@ -1440,7 +1440,7 @@ dependencies = [
  "tlog_tiles",
  "url",
  "worker",
- "x509-verify",
+ "x509-cert",
  "x509_util",
 ]
 
@@ -2326,6 +2326,7 @@ dependencies = [
  "signed_note",
  "thiserror 2.0.12",
  "tlog_tiles",
+ "x509-cert",
  "x509-verify",
  "x509_util",
 ]
@@ -2487,6 +2488,27 @@ dependencies = [
  "signed_note",
  "thiserror 2.0.12",
  "url",
+]
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3073,6 +3095,7 @@ dependencies = [
  "const-oid",
  "der",
  "spki",
+ "tls_codec",
 ]
 
 [[package]]
@@ -3120,7 +3143,7 @@ name = "x509_util"
 version = "0.2.0"
 dependencies = [
  "der",
- "x509-verify",
+ "x509-cert",
 ]
 
 [[package]]
@@ -3193,6 +3216,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ console_error_panic_hook = "0.1.1"
 console_log = { version = "1.0" }
 criterion = { version = "0.5", features = ["html_reports"] }
 generic_log_worker = { path = "crates/generic_log_worker", version = "0.2.0" }
-der = "0.7.9"
+der = "0.7.10"
 ed25519-dalek = { version = "2.1.1", features = ["pem"] }
 futures-executor = "0.3.31"
 futures-util = "0.3.31"
@@ -69,6 +69,7 @@ tlog_tiles = { path = "crates/tlog_tiles", version = "0.2.0" }
 tokio = { version = "1", features = ["sync"] }
 url = "2.2"
 worker = "0.5.0"
+x509-cert = "0.2.5"
 x509-verify = { version = "0.4.4", features = [
     "md2",
     "md5",
@@ -86,3 +87,6 @@ x509-verify = { version = "0.4.4", features = [
     "pem",
 ] }
 x509_util = { path = "crates/x509_util" }
+
+[patch.crates-io]
+der = { git = "https://github.com/lukevalenta/formats", branch = "relative-oid-tag-v0.7.10" }

--- a/crates/ct_worker/Cargo.toml
+++ b/crates/ct_worker/Cargo.toml
@@ -29,7 +29,7 @@ jsonschema.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 url.workspace = true
-x509-verify.workspace = true
+x509-cert.workspace = true
 
 [dev-dependencies]
 rand = { workspace = true, features = ["small_rng"] }
@@ -55,7 +55,7 @@ static_ct_api.workspace = true
 signed_note.workspace = true
 tlog_tiles.workspace = true
 worker.workspace = true
-x509-verify.workspace = true
+x509-cert.workspace = true
 x509_util.workspace = true
 prometheus.workspace = true
 

--- a/crates/ct_worker/build.rs
+++ b/crates/ct_worker/build.rs
@@ -9,7 +9,7 @@ use serde_json::from_str;
 use std::env;
 use std::fs;
 use url::Url;
-use x509_verify::x509_cert::Certificate;
+use x509_cert::Certificate;
 
 fn main() {
     let env = env::var("DEPLOY_ENV").unwrap_or_else(|_| "dev".to_string());

--- a/crates/ct_worker/src/lib.rs
+++ b/crates/ct_worker/src/lib.rs
@@ -11,8 +11,8 @@ use std::sync::{LazyLock, OnceLock};
 use tlog_tiles::{LookupKey, SequenceMetadata};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
+use x509_cert::Certificate;
 use x509_util::CertPool;
-use x509_verify::x509_cert::Certificate;
 
 mod batcher_do;
 mod frontend_worker;

--- a/crates/mtc_api/Cargo.toml
+++ b/crates/mtc_api/Cargo.toml
@@ -22,5 +22,5 @@ sha2.workspace = true
 signed_note.workspace = true
 thiserror.workspace = true
 tlog_tiles.workspace = true
-x509-verify.workspace = true
+x509-cert.workspace = true
 x509_util.workspace = true

--- a/crates/mtc_api/src/relative_oid.rs
+++ b/crates/mtc_api/src/relative_oid.rs
@@ -1,0 +1,68 @@
+use crate::MtcError;
+use std::str::FromStr;
+
+/// ASN.1 `RELATIVE OID`.
+///
+/// TODO upstream this to the `der` crate.
+pub struct RelativeOid {
+    ber: Vec<u8>,
+}
+
+impl RelativeOid {
+    fn from_arcs(arcs: &[u32]) -> Result<Self, MtcError> {
+        let mut ber = Vec::new();
+        for arc in arcs {
+            for j in (0..=4).rev() {
+                #[allow(clippy::cast_possible_truncation)]
+                let cur = (arc >> (j * 7)) as u8;
+
+                if cur != 0 || j == 0 {
+                    let mut to_write = cur & 0x7f; // lower 7 bits
+
+                    if j != 0 {
+                        to_write |= 0x80;
+                    }
+                    ber.push(to_write);
+                }
+            }
+        }
+        if ber.len() > 255 {
+            return Err(MtcError::InvalidRelativeOID);
+        }
+        Ok(Self { ber })
+    }
+
+    /// Returns the DER-encoded content bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.ber
+    }
+}
+
+impl FromStr for RelativeOid {
+    type Err = MtcError;
+    /// Parse the [`RelativeOid`] from a decimal-dotted string.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.split('.');
+        let mut arcs = Vec::new();
+        for part in parts {
+            let i = part.parse::<u32>()?;
+            arcs.push(i);
+        }
+        Self::from_arcs(&arcs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use der::{Any, Encode, Tag};
+
+    use super::*;
+
+    #[test]
+    fn encode_decode() {
+        let relative_oid = RelativeOid::from_str("13335.2").unwrap();
+        let any = Any::new(Tag::RelativeOid, relative_oid.as_bytes()).unwrap();
+        assert_eq!(any.to_der().unwrap(), b"\x0d\x03\xe8\x17\x02");
+    }
+}

--- a/crates/mtc_worker/Cargo.toml
+++ b/crates/mtc_worker/Cargo.toml
@@ -30,7 +30,8 @@ mtc_api.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 url.workspace = true
-x509-verify.workspace = true
+x509-cert.workspace = true
+der.workspace = true
 
 [dev-dependencies]
 rand = { workspace = true, features = ["small_rng"] }
@@ -41,6 +42,7 @@ futures-executor.workspace = true
 [dependencies]
 base64.workspace = true
 config = { path = "./config", package = "mtc_worker_config" }
+der.workspace = true
 generic_log_worker.workspace = true
 ed25519-dalek.workspace = true
 futures-util.workspace = true
@@ -55,7 +57,7 @@ sha2.workspace = true
 signed_note.workspace = true
 tlog_tiles.workspace = true
 worker.workspace = true
-x509-verify.workspace = true
+x509-cert.workspace = true
 x509_util.workspace = true
 prometheus.workspace = true
 mtc_api.workspace = true

--- a/crates/mtc_worker/build.rs
+++ b/crates/mtc_worker/build.rs
@@ -4,20 +4,18 @@
 // Build script to include per-environment configuration and trusted roots.
 
 use config::AppConfig;
+use der::{asn1::SetOfVec, Any, Tag};
+use mtc_api::RelativeOid;
 use mtc_api::ID_RDNA_TRUSTANCHOR_ID;
 use serde_json::from_str;
 use std::env;
 use std::fs;
 use std::str::FromStr;
 use url::Url;
-use x509_verify::{
-    der::{asn1::SetOfVec, Any},
-    spki::ObjectIdentifier,
-    x509_cert::{
-        attr::AttributeTypeAndValue,
-        name::{RdnSequence, RelativeDistinguishedName},
-        Certificate,
-    },
+use x509_cert::{
+    attr::AttributeTypeAndValue,
+    name::{RdnSequence, RelativeDistinguishedName},
+    Certificate,
 };
 
 fn main() {
@@ -44,11 +42,11 @@ fn main() {
     });
     for (name, params) in conf.logs {
         // Make sure we can create the RDN sequence for the issuer log ID.
+        let relative_oid = RelativeOid::from_str(&params.log_id).unwrap();
         let _ = RdnSequence::from(vec![RelativeDistinguishedName(
             SetOfVec::from_iter([AttributeTypeAndValue {
                 oid: ID_RDNA_TRUSTANCHOR_ID,
-                // TODO: switch to RelativeOidRef after https://github.com/RustCrypto/formats/issues/1875
-                value: Any::from(ObjectIdentifier::from_str(&params.log_id).unwrap()),
+                value: Any::new(Tag::RelativeOid, relative_oid.as_bytes()).unwrap(),
             }])
             .unwrap(),
         )]);

--- a/crates/mtc_worker/config.dev.json
+++ b/crates/mtc_worker/config.dev.json
@@ -3,14 +3,14 @@
     "logs": {
         "dev1": {
             "description": "MTCA Dev1",
-            "log_id": "1.3.3.3.5.1",
+            "log_id": "13335.1",
             "submission_url": "http://localhost:8787/logs/dev1/",
             "location_hint": "enam",
             "enable_dedup": false
         },
         "dev2": {
             "description": "MTCA Dev2",
-            "log_id": "1.3.3.3.5.2",
+            "log_id": "13335.2",
             "submission_url": "http://localhost:8787/logs/dev2/",
             "location_hint": "enam",
             "enable_dedup": false

--- a/crates/mtc_worker/src/lib.rs
+++ b/crates/mtc_worker/src/lib.rs
@@ -11,8 +11,8 @@ use std::sync::{LazyLock, OnceLock};
 use tlog_tiles::{LookupKey, SequenceMetadata};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
+use x509_cert::Certificate;
 use x509_util::CertPool;
-use x509_verify::x509_cert::Certificate;
 
 mod batcher_do;
 mod frontend_worker;

--- a/crates/static_ct_api/Cargo.toml
+++ b/crates/static_ct_api/Cargo.toml
@@ -38,5 +38,6 @@ signature.workspace = true
 signed_note.workspace = true
 thiserror.workspace = true
 tlog_tiles.workspace = true
+x509-cert.workspace = true
 x509-verify.workspace = true
 x509_util.workspace = true

--- a/crates/static_ct_api/src/rfc6962.rs
+++ b/crates/static_ct_api/src/rfc6962.rs
@@ -33,18 +33,16 @@ use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 use sha2::{Digest, Sha256};
 use tlog_tiles::UnixTimestamp;
-use x509_util::CertPool;
-use x509_verify::{
-    x509_cert::{
-        der::{Decode, Encode},
-        ext::{
-            pkix::{AuthorityKeyIdentifier, BasicConstraints, ExtendedKeyUsage},
-            Extension,
-        },
-        impl_newtype, Certificate, TbsCertificate,
+use x509_cert::{
+    der::{Decode, Encode},
+    ext::{
+        pkix::{AuthorityKeyIdentifier, BasicConstraints, ExtendedKeyUsage},
+        Extension,
     },
-    VerifyingKey,
+    impl_newtype, Certificate, TbsCertificate,
 };
+use x509_util::CertPool;
+use x509_verify::VerifyingKey;
 
 // Data structures for the [Static CT Submission APIs](https://github.com/C2SP/C2SP/blob/main/static-ct-api.md#submission-apis),
 // a subset of the APIs from [RFC 6962](https://datatracker.ietf.org/doc/html/rfc6962).

--- a/crates/x509_util/Cargo.toml
+++ b/crates/x509_util/Cargo.toml
@@ -11,4 +11,4 @@ description.workspace = true
 
 [dependencies]
 der.workspace = true
-x509-verify.workspace = true
+x509-cert.workspace = true

--- a/crates/x509_util/src/lib.rs
+++ b/crates/x509_util/src/lib.rs
@@ -1,6 +1,6 @@
 use der::{Encode, Error as DerError};
 use std::collections::HashMap;
-use x509_verify::x509_cert::{
+use x509_cert::{
     ext::pkix::{AuthorityKeyIdentifier, SubjectKeyIdentifier},
     Certificate,
 };


### PR DESCRIPTION
- Clean up some dependencies, using x509-cert and der directly where applicable instead of re-exports from x509-verify crate.
- Add basic 'RELATIVE OID' parsing support. Eventually, we should upstream this.
- Bump 'der' dependency to '0.7.10', and switch to fork that has 'RELATIVE OID' tag support. PR to upstream support is at https://github.com/RustCrypto/formats/pull/1942.