### PR TITLE
Update to worker 0.6.0, addressing breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
@@ -837,7 +837,7 @@ dependencies = [
  "prometheus",
  "rand",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_bytes",
  "serde_json",
  "serde_with",
@@ -2115,17 +2115,6 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
@@ -3008,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727789ca7eff9733efbea9d0e97779edc1cf1926e98aee7d7d8afe32805458aa"
+checksum = "7f6ac1566a3005b790b974f0621d77431e2a47e5f481276485f5ac0485775de2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3023,7 +3012,7 @@ dependencies = [
  "matchit",
  "pin-project",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -3039,24 +3028,24 @@ dependencies = [
 
 [[package]]
 name = "worker-kv"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f06d4d1416a9f8346ee9123b0d9a11b3cfa38e6cfb5a139698017d1597c4d41"
+checksum = "b0d30eb90e8db0657414129624c0d12c6cb480574bc2ddd584822db196cb9a52"
 dependencies = [
  "js-sys",
  "serde",
- "serde-wasm-bindgen 0.5.0",
+ "serde-wasm-bindgen",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "worker-macros"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d625c24570ba9207a2617476013335f28a95cbe513e59bb814ffba092a18058"
+checksum = "5ba7478759843ae3d56dc7ba2445e7a514a5d043eaa98cebac2789f7ab5221ee"
 dependencies = [
  "async-trait",
  "proc-macro2",
@@ -3070,9 +3059,9 @@ dependencies = [
 
 [[package]]
 name = "worker-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34563340d41016b4381257c5a16b0d2bc590dbe00500ecfbebcaa16f5f85ce90"
+checksum = "eb4d7a3273dd584b9526aec77bbcf815c51d1a0e17407b1a390cf5a39b6d4fbd"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ thiserror = "2.0"
 tlog_tiles = { path = "crates/tlog_tiles", version = "0.2.0" }
 tokio = { version = "1", features = ["sync"] }
 url = "2.2"
-worker = "0.5.0"
+worker = "0.6.0"
 x509-cert = "0.2.5"
 x509-verify = { version = "0.4.4", features = [
     "md2",

--- a/crates/ct_worker/src/batcher_do.rs
+++ b/crates/ct_worker/src/batcher_do.rs
@@ -7,7 +7,6 @@ use worker::*;
 #[durable_object]
 struct Batcher(GenericBatcher<StaticCTPendingLogEntry>);
 
-#[durable_object]
 impl DurableObject for Batcher {
     fn new(state: State, env: Env) -> Self {
         // Find the Durable Object name by enumerating all possibilities.
@@ -52,7 +51,7 @@ impl DurableObject for Batcher {
         Batcher(GenericBatcher::new(config, kv, sequencer))
     }
 
-    async fn fetch(&mut self, req: Request) -> Result<Response> {
+    async fn fetch(&self, req: Request) -> Result<Response> {
         self.0.fetch(req).await
     }
 }

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -300,7 +300,7 @@ fn batcher_id_from_lookup_key(key: &LookupKey, num_batchers: u8) -> u8 {
 }
 
 fn headers_from_http_metadata(meta: HttpMetadata) -> Headers {
-    let mut h = Headers::new();
+    let h = Headers::new();
     if let Some(hdr) = meta.cache_control {
         h.append("Cache-Control", &hdr).unwrap();
     }

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -17,7 +17,6 @@ use worker::*;
 #[durable_object]
 struct Sequencer(GenericSequencer<StaticCTLogEntry>);
 
-#[durable_object]
 impl DurableObject for Sequencer {
     fn new(state: State, env: Env) -> Self {
         // Find the Durable Object name by enumerating all possibilities.
@@ -77,11 +76,11 @@ impl DurableObject for Sequencer {
         Sequencer(GenericSequencer::new(config, state, bucket, registry))
     }
 
-    async fn fetch(&mut self, req: Request) -> Result<Response> {
+    async fn fetch(&self, req: Request) -> Result<Response> {
         self.0.fetch(req).await
     }
 
-    async fn alarm(&mut self) -> Result<Response> {
+    async fn alarm(&self) -> Result<Response> {
         self.0.alarm().await
     }
 }

--- a/crates/mtc_worker/src/batcher_do.rs
+++ b/crates/mtc_worker/src/batcher_do.rs
@@ -7,7 +7,6 @@ use worker::*;
 #[durable_object]
 struct Batcher(GenericBatcher<BootstrapMtcPendingLogEntry>);
 
-#[durable_object]
 impl DurableObject for Batcher {
     fn new(state: State, env: Env) -> Self {
         // Find the Durable Object name by enumerating all possibilities.
@@ -52,7 +51,7 @@ impl DurableObject for Batcher {
         Batcher(GenericBatcher::new(config, kv, sequencer))
     }
 
-    async fn fetch(&mut self, req: Request) -> Result<Response> {
+    async fn fetch(&self, req: Request) -> Result<Response> {
         self.0.fetch(req).await
     }
 }

--- a/crates/mtc_worker/src/frontend_worker.rs
+++ b/crates/mtc_worker/src/frontend_worker.rs
@@ -284,7 +284,7 @@ fn batcher_id_from_lookup_key(key: &LookupKey, num_batchers: u8) -> u8 {
 }
 
 fn headers_from_http_metadata(meta: HttpMetadata) -> Headers {
-    let mut h = Headers::new();
+    let h = Headers::new();
     if let Some(hdr) = meta.cache_control {
         h.append("Cache-Control", &hdr).unwrap();
     }

--- a/crates/mtc_worker/src/sequencer_do.rs
+++ b/crates/mtc_worker/src/sequencer_do.rs
@@ -17,7 +17,6 @@ use worker::*;
 #[durable_object]
 struct Sequencer(GenericSequencer<BootstrapMtcLogEntry>);
 
-#[durable_object]
 impl DurableObject for Sequencer {
     fn new(state: State, env: Env) -> Self {
         // Find the Durable Object name by enumerating all possibilities.
@@ -82,11 +81,11 @@ impl DurableObject for Sequencer {
         Sequencer(GenericSequencer::new(config, state, bucket, registry))
     }
 
-    async fn fetch(&mut self, req: Request) -> Result<Response> {
+    async fn fetch(&self, req: Request) -> Result<Response> {
         self.0.fetch(req).await
     }
 
-    async fn alarm(&mut self) -> Result<Response> {
+    async fn alarm(&self) -> Result<Response> {
         self.0.alarm().await
     }
 }

--- a/crates/tlog_tiles/src/checkpoint.rs
+++ b/crates/tlog_tiles/src/checkpoint.rs
@@ -407,7 +407,7 @@ pub fn open_checkpoint(
 }
 
 /// A transparency log tree with a timestamp.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct TreeWithTimestamp {
     size: u64,
     hash: Hash,


### PR DESCRIPTION
- Durable Object methods no longer take a mutable reference, so we need to use interior mutability (RefCell) to update state, as recommended by the workers-rs maintainers. The tricky part is avoiding passing a borrowed Ref to an async function, as that could cause a panic if, for example, a concurrent async operation attempts to borrow an already-mutably-borrowed value.
- To simplify the above change, remove the Option wrapper from the GenericSequencer's 'sequence_state' field. Instead of loading the sequencer state just-in-time for the first sequencing, load it during the DO initialization (which happens after the first fetch or alarm). Similarly, when there is a fatal sequencing error requiring reloading the sequence state, load the state right away rather than waiting for the next sequencing.