### PR TITLE
Make inclusion proof not depend on sequencer, fixes #61

### DIFF
--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -5,12 +5,10 @@
 
 use std::time::Duration;
 
-use crate::{load_signing_key, load_witness_key, CONFIG};
+use crate::{load_checkpoint_signers, load_origin, CONFIG};
 use generic_log_worker::{load_public_bucket, GenericSequencer, SequencerConfig};
 use prometheus::Registry;
-use signed_note::KeyName;
-use static_ct_api::{StaticCTCheckpointSigner, StaticCTLogEntry};
-use tlog_tiles::{CheckpointSigner, Ed25519CheckpointSigner};
+use static_ct_api::StaticCTLogEntry;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
@@ -29,36 +27,13 @@ impl DurableObject for Sequencer {
             .find(|(name, _)| id == namespace.id_from_name(name).unwrap().to_string())
             .expect("unable to find sequencer name");
 
-        // https://github.com/C2SP/C2SP/blob/main/static-ct-api.md#checkpoints
-        // The origin line MUST be the submission prefix of the log as a schema-less URL with no trailing slashes.
-        let origin = KeyName::new(
-            params
-                .submission_url
-                .trim_start_matches("http://")
-                .trim_start_matches("https://")
-                .trim_end_matches('/')
-                .to_string(),
-        )
-        .expect("invalid origin name");
+        let origin = load_origin(name);
         let sequence_interval = Duration::from_millis(params.sequence_interval_millis);
 
         // We don't use checkpoint extensions for CT
         let checkpoint_extension = Box::new(|_| vec![]);
 
-        let checkpoint_signers: Vec<Box<dyn CheckpointSigner>> = {
-            let signing_key = load_signing_key(&env, name).unwrap().clone();
-            let witness_key = load_witness_key(&env, name).unwrap().clone();
-
-            // Make the checkpoint signers from the secret keys and put them in a vec
-            let signer = StaticCTCheckpointSigner::new(origin.clone(), signing_key)
-                .map_err(|e| format!("could not create static-ct checkpoint signer: {e}"))
-                .unwrap();
-            let witness = Ed25519CheckpointSigner::new(origin.clone(), witness_key)
-                .map_err(|e| format!("could not create ed25519 checkpoint signer: {e}"))
-                .unwrap();
-
-            vec![Box::new(signer), Box::new(witness)]
-        };
+        let checkpoint_signers = load_checkpoint_signers(&env, name);
         let bucket = load_public_bucket(&env, name).unwrap();
         let registry = Registry::new();
 

--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -30,7 +30,6 @@ use worker::kv::KvStore;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
-pub const PROVE_INCLUSION_ENDPOINT: &str = "/prove_inclusion";
 const BATCH_ENDPOINT: &str = "/add_batch";
 pub const ENTRY_ENDPOINT: &str = "/add_entry";
 pub const METRICS_ENDPOINT: &str = "/metrics";


### PR DESCRIPTION
- Remove sequencer as dependency for inclusion proofs, as all that is needed is the log config and R2 bucket.
- Add load_origin and load_checkpoint_signer helper functions.

We can extend this functionality to generate subtree inclusion proofs with https://github.com/cloudflare/azul/issues/64.