### PR TITLE
Use bitcode instead of json serde, and remove generics from batcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +151,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bitcode"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf300f4aa6e66f3bdff11f1236a88c622fe47ea814524792240b4d554d9858ee"
+dependencies = [
+ "arrayvec",
+ "bitcode_derive",
+ "bytemuck",
+ "glam",
+ "serde",
+]
+
+[[package]]
+name = "bitcode_derive"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b6b4cb608b8282dc3b53d0f4c9ab404655d562674c682db7e6c0458cc83c23"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +206,12 @@ name = "bytecount"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
 name = "byteorder"
@@ -823,6 +859,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",
+ "bitcode",
  "byteorder",
  "console_error_panic_hook",
  "console_log",
@@ -839,7 +876,6 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
- "serde_json",
  "serde_with",
  "sha2",
  "signed_note",
@@ -880,6 +916,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glam"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a99dbe56b72736564cfa4b85bf9a33079f16ae8b74983ab06af3b1a3696b11"
 
 [[package]]
 name = "group"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ debug = 1
 [workspace.dependencies]
 anyhow = "1.0"
 base64 = "0.22"
+bitcode = { version = "0.6.6", features = ["serde"] }
 byteorder = "1.5"
 chrono = { version = "0.4", features = ["serde"] }
 console_error_panic_hook = "0.1.1"

--- a/crates/ct_worker/build.rs
+++ b/crates/ct_worker/build.rs
@@ -5,7 +5,6 @@
 
 use chrono::Months;
 use config::AppConfig;
-use serde_json::from_str;
 use std::env;
 use std::fs;
 use url::Url;
@@ -19,10 +18,10 @@ fn main() {
     });
 
     // Validate the config json against the schema.
-    let json = from_str(config_contents).unwrap_or_else(|e| {
+    let json = serde_json::from_str(config_contents).unwrap_or_else(|e| {
         panic!("failed to deserialize JSON config '{config_file}': {e}");
     });
-    let schema = from_str(include_str!("config.schema.json")).unwrap_or_else(|e| {
+    let schema = serde_json::from_str(include_str!("config.schema.json")).unwrap_or_else(|e| {
         panic!("failed to deserialize JSON schema 'config.schema.json': {e}");
     });
     jsonschema::validate(&schema, &json).unwrap_or_else(|e| {

--- a/crates/ct_worker/src/batcher_do.rs
+++ b/crates/ct_worker/src/batcher_do.rs
@@ -1,11 +1,10 @@
 use crate::CONFIG;
 use generic_log_worker::{get_durable_object_stub, load_cache_kv, BatcherConfig, GenericBatcher};
-use static_ct_api::StaticCTPendingLogEntry;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
-#[durable_object]
-struct Batcher(GenericBatcher<StaticCTPendingLogEntry>);
+#[durable_object(fetch)]
+struct Batcher(GenericBatcher);
 
 impl DurableObject for Batcher {
     fn new(state: State, env: Env) -> Self {

--- a/crates/ct_worker/src/lib.rs
+++ b/crates/ct_worker/src/lib.rs
@@ -10,7 +10,7 @@ use signed_note::KeyName;
 use static_ct_api::StaticCTCheckpointSigner;
 use std::collections::HashMap;
 use std::sync::{LazyLock, OnceLock};
-use tlog_tiles::{CheckpointSigner, Ed25519CheckpointSigner, LookupKey, SequenceMetadata};
+use tlog_tiles::{CheckpointSigner, Ed25519CheckpointSigner, SequenceMetadata};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 use x509_cert::Certificate;

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -12,7 +12,7 @@ use static_ct_api::StaticCTLogEntry;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
-#[durable_object]
+#[durable_object(alarm)]
 struct Sequencer(GenericSequencer<StaticCTLogEntry>);
 
 impl DurableObject for Sequencer {

--- a/crates/generic_log_worker/Cargo.toml
+++ b/crates/generic_log_worker/Cargo.toml
@@ -22,6 +22,7 @@ static_ct_api.workspace = true
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
+bitcode.workspace = true
 byteorder.workspace = true
 console_error_panic_hook.workspace = true
 console_log.workspace = true
@@ -35,7 +36,6 @@ rand.workspace = true
 serde-wasm-bindgen.workspace = true
 serde.workspace = true
 serde_bytes.workspace = true
-serde_json.workspace = true
 sha2.workspace = true
 signed_note.workspace = true
 thiserror.workspace = true

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -1114,7 +1114,7 @@ async fn apply_staged_uploads(
     if staged_size != size || staged_hash != hash {
         bail!("staging bundle does not match current tree");
     }
-    let uploads: Vec<UploadAction> = serde_json::from_slice(&staged_uploads[8 + HASH_SIZE..])?;
+    let uploads = bitcode::deserialize::<Vec<UploadAction>>(&staged_uploads[8 + HASH_SIZE..])?;
     let upload_futures: Vec<_> = uploads
         .iter()
         .map(|u| object.upload(&u.key, &u.data, &u.opts))
@@ -1339,7 +1339,7 @@ fn marshal_staged_uploads(
         .to_be_bytes()
         .into_iter()
         .chain(hash.0.iter().copied())
-        .chain(serde_json::to_vec(uploads)?)
+        .chain(bitcode::serialize(uploads)?)
         .collect::<Vec<_>>())
 }
 

--- a/crates/mtc_worker/build.rs
+++ b/crates/mtc_worker/build.rs
@@ -7,7 +7,6 @@ use config::AppConfig;
 use der::{asn1::SetOfVec, Any, Tag};
 use mtc_api::RelativeOid;
 use mtc_api::ID_RDNA_TRUSTANCHOR_ID;
-use serde_json::from_str;
 use std::env;
 use std::fs;
 use std::str::FromStr;
@@ -26,10 +25,10 @@ fn main() {
     });
 
     // Validate the config json against the schema.
-    let json = from_str(config_contents).unwrap_or_else(|e| {
+    let json = serde_json::from_str(config_contents).unwrap_or_else(|e| {
         panic!("failed to deserialize JSON config '{config_file}': {e}");
     });
-    let schema = from_str(include_str!("config.schema.json")).unwrap_or_else(|e| {
+    let schema = serde_json::from_str(include_str!("config.schema.json")).unwrap_or_else(|e| {
         panic!("failed to deserialize JSON schema 'config.schema.json': {e}");
     });
     jsonschema::validate(&schema, &json).unwrap_or_else(|e| {

--- a/crates/mtc_worker/src/batcher_do.rs
+++ b/crates/mtc_worker/src/batcher_do.rs
@@ -1,11 +1,10 @@
 use crate::CONFIG;
 use generic_log_worker::{get_durable_object_stub, load_cache_kv, BatcherConfig, GenericBatcher};
-use mtc_api::BootstrapMtcPendingLogEntry;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
-#[durable_object]
-struct Batcher(GenericBatcher<BootstrapMtcPendingLogEntry>);
+#[durable_object(fetch)]
+struct Batcher(GenericBatcher);
 
 impl DurableObject for Batcher {
     fn new(state: State, env: Env) -> Self {

--- a/crates/mtc_worker/src/lib.rs
+++ b/crates/mtc_worker/src/lib.rs
@@ -11,7 +11,7 @@ use signed_note::KeyName;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::{LazyLock, OnceLock};
-use tlog_tiles::{CheckpointSigner, CosignatureV1CheckpointSigner, LookupKey, SequenceMetadata};
+use tlog_tiles::{CheckpointSigner, CosignatureV1CheckpointSigner, SequenceMetadata};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 use x509_cert::Certificate;

--- a/crates/mtc_worker/src/sequencer_do.rs
+++ b/crates/mtc_worker/src/sequencer_do.rs
@@ -13,7 +13,7 @@ use signed_note::KeyName;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
-#[durable_object]
+#[durable_object(alarm)]
 struct Sequencer(GenericSequencer<BootstrapMtcLogEntry>);
 
 impl DurableObject for Sequencer {

--- a/crates/tlog_tiles/Cargo.toml
+++ b/crates/tlog_tiles/Cargo.toml
@@ -21,6 +21,9 @@ wasm-opt = false
 [lib]
 crate-type = ["rlib"]
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [dependencies]
 base64.workspace = true
 byteorder.workspace = true
@@ -28,7 +31,6 @@ ed25519-dalek.workspace = true
 length_prefixed.workspace = true
 rand.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 sha2.workspace = true
 signed_note.workspace = true
 thiserror.workspace = true

--- a/crates/tlog_tiles/src/entries.rs
+++ b/crates/tlog_tiles/src/entries.rs
@@ -21,6 +21,14 @@ pub type LeafIndex = u64;
 /// from the sequencing backend to the frontend to return to the caller.
 pub type SequenceMetadata = (LeafIndex, UnixTimestamp);
 
+/// An opaque `PendingLogEntry` that can be passed around without requiring full
+/// deserialization.
+#[derive(Serialize, Deserialize)]
+pub struct PendingLogEntryBlob {
+    pub lookup_key: LookupKey,
+    pub data: Vec<u8>,
+}
+
 /// The functionality exposed by any data type that can be included in a Merkle tree
 pub trait PendingLogEntry: core::fmt::Debug + Clone + Serialize + DeserializeOwned {
     /// The path to write data tiles in the object store, which is 'entries' for tlog-tiles.


### PR DESCRIPTION
- Use bitcode instead of json for more efficient serialization for communication across Workers and DOs. This is an intermediate step short of full RPC support (#3).
- Use bitcode instead of json for serializing the staging bundle.
- Introduce `PendingLogEntryBlob` struct that wraps the serialized bytes and lookup key of a `PendingLogEntry` so that the Batcher doesn't need to fully deserialize entries as all it needs is the lookup key. This allows us to remote the generic type from the Batcher altogether (fixes #67).

Other:
- Pass argument to durable_object macro to reduce generated code size (Batchers only need fetch methods, and Sequencers need fetch and alarm, but not websocket.)
- Clean up code in various places.