### PR TITLE
Do not reuse stubs across calls from batcher to sequencer

### DIFF
--- a/crates/ct_worker/src/batcher_do.rs
+++ b/crates/ct_worker/src/batcher_do.rs
@@ -25,7 +25,7 @@ impl DurableObject for Batcher {
             enable_dedup: params.enable_dedup,
             location_hint: params.location_hint.clone(),
         };
-        Batcher(GenericBatcher::new(&env, config))
+        Batcher(GenericBatcher::new(env, config))
     }
 
     async fn fetch(&self, req: Request) -> Result<Response> {

--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -29,9 +29,10 @@ use std::str::FromStr;
 use std::sync::Once;
 use tlog_tiles::{LookupKey, PendingLogEntry, SequenceMetadata};
 use util::now_millis;
-use worker::kv::KvStore;
-#[allow(clippy::wildcard_imports)]
-use worker::*;
+use worker::{
+    js_sys, kv, kv::KvStore, wasm_bindgen, Bucket, Env, Error, HttpMetadata, Result, State,
+    Storage, Stub,
+};
 
 pub const SEQUENCER_BINDING: &str = "SEQUENCER";
 pub const BATCHER_BINDING: &str = "BATCHER";

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -1553,7 +1553,7 @@ mod tests {
             let prev_tree_size = rng.gen_range(1..n);
             let new_tree_size = rng.gen_range(prev_tree_size + 1..=n);
             let consistency_proof = block_on(prove_consistency(
-                tree_hashes[new_tree_size as usize],
+                tree_hashes[usize::try_from(new_tree_size).unwrap()],
                 new_tree_size,
                 prev_tree_size,
                 &log.object,
@@ -1562,9 +1562,9 @@ mod tests {
             check_tree(
                 &consistency_proof,
                 new_tree_size,
-                tree_hashes[new_tree_size as usize],
+                tree_hashes[usize::try_from(new_tree_size).unwrap()],
                 prev_tree_size,
-                tree_hashes[prev_tree_size as usize],
+                tree_hashes[usize::try_from(prev_tree_size).unwrap()],
             )
             .unwrap();
         }

--- a/crates/mtc_worker/src/batcher_do.rs
+++ b/crates/mtc_worker/src/batcher_do.rs
@@ -25,7 +25,7 @@ impl DurableObject for Batcher {
             enable_dedup: params.enable_dedup,
             location_hint: params.location_hint.clone(),
         };
-        Batcher(GenericBatcher::new(&env, config))
+        Batcher(GenericBatcher::new(env, config))
     }
 
     async fn fetch(&self, req: Request) -> Result<Response> {


### PR DESCRIPTION
From the docs (https://developers.cloudflare.com/durable-objects/api/stub/):

If an exception is thrown by a Durable Object stub all in-flight calls and future calls will fail with exceptions. To continue invoking methods on a remote Durable Object a Worker must recreate the stub.