### PR TITLE
Rename tlog funcs to align with RFC9162 terminology

### DIFF
--- a/crates/tlog_tiles/src/lib.rs
+++ b/crates/tlog_tiles/src/lib.rs
@@ -112,7 +112,7 @@ mod tests {
         );
         let rp: CtRecordProof = http_get(&url);
 
-        tlog::check_record(&rp.proof, root.size, root.hash, 10000, hash)?;
+        tlog::check_inclusion(&rp.proof, root.size, root.hash, 10000, hash)?;
 
         let url = format!(
         "http://ct.googleapis.com/logs/argon2020/ct/v1/get-sth-consistency?first=3654490&second={}",
@@ -120,7 +120,7 @@ mod tests {
         let tp: CtTreeProof = http_get(&url);
 
         let oh = Hash::parse_hash("AuIZ5V6sDUj1vn3Y1K85oOaQ7y+FJJKtyRTl1edIKBQ=")?;
-        tlog::check_tree(&tp.consistency, root.size, root.hash, 3_654_490, oh)?;
+        tlog::check_consistency(&tp.consistency, root.size, root.hash, 3_654_490, oh)?;
 
         Ok(())
     }

--- a/crates/tlog_tiles/src/tile.rs
+++ b/crates/tlog_tiles/src/tile.rs
@@ -16,7 +16,7 @@
 //! - [tile_test.go](https://cs.opensource.google/go/x/mod/+/refs/tags/v0.21.0:sumdb/tlog/tile_test.go)
 
 use crate::tlog::{
-    node_hash, split_stored_hash_index, stored_hash_index, sub_tree_index, Hash, HashReader,
+    node_hash, split_stored_hash_index, stored_hash_index, subtree_indices, Hash, HashReader,
     TlogError, HASH_SIZE,
 };
 use std::cmp::max;
@@ -566,7 +566,7 @@ impl HashReader for TileHashReader<'_> {
 
         // Plan to fetch tiles necessary to recompute tree hash.
         // If it matches, those tiles are authenticated.
-        let stx = sub_tree_index(0, self.tree_size, vec![]);
+        let stx = subtree_indices(0, self.tree_size, vec![]);
         let mut stx_tile_order = vec![0; stx.len()];
 
         for (i, &x) in stx.iter().enumerate() {


### PR DESCRIPTION
Use terminology that's more familiar for the various proof types: record/leaf proof -> inclusion proof, tree proof -> consistency proof, etc.

This PR also exposes the `prove_subtree_inclusion` function from the tlog library, and changes the rustdocs so that they appear in VS Code when I hover over them.