### PR TITLE
Refactor and deduplicate proof logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,6 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
- "serde_with",
  "sha2",
  "signed_note",
  "static_ct_api",

--- a/crates/generic_log_worker/Cargo.toml
+++ b/crates/generic_log_worker/Cargo.toml
@@ -42,4 +42,3 @@ thiserror.workspace = true
 tlog_tiles.workspace = true
 tokio.workspace = true
 worker.workspace = true
-serde_with.workspace = true

--- a/crates/generic_log_worker/src/sequencer_do.rs
+++ b/crates/generic_log_worker/src/sequencer_do.rs
@@ -17,11 +17,8 @@ use crate::{
 use futures_util::future::join_all;
 use log::{info, warn};
 use prometheus::{Registry, TextEncoder};
-use serde::{Deserialize, Serialize};
-use serde_with::base64::Base64;
-use serde_with::serde_as;
 use signed_note::KeyName;
-use tlog_tiles::{CheckpointSigner, LeafIndex, LogEntry, PendingLogEntryBlob, UnixTimestamp};
+use tlog_tiles::{CheckpointSigner, LogEntry, PendingLogEntryBlob, UnixTimestamp};
 use tokio::sync::Mutex;
 use worker::{Env, Error as WorkerError, Request, Response, State};
 
@@ -57,20 +54,6 @@ pub struct SequencerConfig {
     pub sequence_skip_threshold_millis: Option<u64>,
     pub enable_dedup: bool,
     pub location_hint: Option<String>,
-}
-
-/// GET query structure for the sequencer's `/prove_inclusion` endpoint
-#[derive(Serialize, Deserialize)]
-pub struct ProveInclusionQuery {
-    pub leaf_index: LeafIndex,
-}
-
-/// GET response structure for the sequencer's `/prove_inclusion` endpoint
-#[serde_as]
-#[derive(Serialize, Deserialize)]
-pub struct ProveInclusionResponse {
-    #[serde_as(as = "Vec<Base64>")]
-    pub proof: Vec<Vec<u8>>,
 }
 
 impl<L: LogEntry> GenericSequencer<L> {

--- a/crates/tlog_tiles/src/lib.rs
+++ b/crates/tlog_tiles/src/lib.rs
@@ -65,13 +65,13 @@ mod tests {
     }
 
     #[derive(Deserialize)]
-    struct CtRecordProof {
+    struct CtInclusionProof {
         #[serde(rename = "audit_path")]
         proof: Vec<Hash>,
     }
 
     #[derive(Deserialize)]
-    struct CtTreeProof {
+    struct CtConsistencyProof {
         consistency: Vec<Hash>,
     }
 
@@ -110,14 +110,14 @@ mod tests {
             root.size,
             form_urlencoded::byte_serialize(hash.to_string().as_bytes()).collect::<String>()
         );
-        let rp: CtRecordProof = http_get(&url);
+        let rp: CtInclusionProof = http_get(&url);
 
         tlog::check_inclusion(&rp.proof, root.size, root.hash, 10000, hash)?;
 
         let url = format!(
         "http://ct.googleapis.com/logs/argon2020/ct/v1/get-sth-consistency?first=3654490&second={}",
         root.size);
-        let tp: CtTreeProof = http_get(&url);
+        let tp: CtConsistencyProof = http_get(&url);
 
         let oh = Hash::parse_hash("AuIZ5V6sDUj1vn3Y1K85oOaQ7y+FJJKtyRTl1edIKBQ=")?;
         tlog::check_consistency(&tp.consistency, root.size, root.hash, 3_654_490, oh)?;


### PR DESCRIPTION
- Remove duplicate upload_issuers implementations.
- Make ObjectBackend methods parameters more flexible for convenience.
- Rename ProofPreparer -> TlogTileRecorder as this is now used for more than just proofs. (We probably want to move this and PreloadedTlogTileReader to tlog_tiles, but leaving that out of this PR to reduce the diff.)
- Rename SimpleTlogTileReader -> PreloadedTlogTileReader as more descriptive name
- Rename RecordProof -> InclusionProof for consistency with RFC9162 terminology
- Rename TreeProof -> ConsistencyProof for consistency with RFC9162 terminology
- Add `tile_reader_for_indexes` function to deduplicate logic across prove_inclusion, prove_consistency, and read_edge_tiles.
- Use TileHashReader::read_hashes to fetch edge tiles, removing the need for the `read_and_verify_tiles` function and aligning the code more closely to sunlight: https://github.com/FiloSottile/sunlight/blob/409a4d4913368c7e28d012118e567eb1f8c90900/internal/ctlog/ctlog.go#L243.
- Move ProveInclusionQuery/Response structs to mtc frontend worker. Now that prove-inclusion requests are handled without contacting the sequencer, these application-specific endpoints should be defined with the application.