### PR TITLE
Double-check that R2 object uploads are successful

### DIFF
--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -538,15 +538,38 @@ impl ObjectBackend for ObjectBucket {
             .as_ref()
             .inspect(|&m| m.upload_size_bytes.observe(value.len().as_f64()));
         self.bucket
-            .put(key.as_ref(), value)
+            .put(key.as_ref(), value.clone())
             .http_metadata(metadata)
             .execute()
             .await
             .inspect_err(|_| {
                 self.metrics
                     .as_ref()
-                    .inspect(|&m| m.errors.with_label_values(&["put"]).inc());
+                    .inspect(|&m| m.errors.with_label_values(&["put-failed"]).inc());
             })?;
+
+        // SAFETY: immediately fetch the uploaded object to make sure that it was persisted.
+        // TODO: sentry reporting
+        if let Some(fetched) = self.fetch(key.as_ref()).await? {
+            if fetched != value {
+                self.metrics
+                    .as_ref()
+                    .inspect(|&m| m.errors.with_label_values(&["wrong-contents"]).inc());
+                return Err(Error::RustError(format!(
+                    "tile persisted with wrong contents: {}",
+                    key.as_ref()
+                )));
+            }
+        } else {
+            self.metrics
+                .as_ref()
+                .inspect(|&m| m.errors.with_label_values(&["not-persisted"]).inc());
+            return Err(Error::RustError(format!(
+                "tile not persisted: {}",
+                key.as_ref()
+            )));
+        }
+
         self.metrics.as_ref().inspect(|&m| {
             m.duration
                 .with_label_values(&["put"])

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -716,7 +716,7 @@ pub(crate) async fn sequence<L: LogEntry>(
     .await
     {
         Ok(()) => {
-            metrics.seq_count.with_label_values(&["ok"]).inc();
+            metrics.seq_count.with_label_values(&["none"]).inc();
             Ok(())
         }
         Err(SequenceError::Fatal(e)) => {

--- a/crates/generic_log_worker/src/metrics.rs
+++ b/crates/generic_log_worker/src/metrics.rs
@@ -167,9 +167,9 @@ impl ObjectMetrics {
         )
         .unwrap();
         let errors = register_counter_vec_with_registry!(
-            "object_put_errors_total",
-            "Number of failed object storage operations, by method.",
-            &["method"],
+            "object_errors_total",
+            "Number of failed object storage operations, by description.",
+            &["desc"],
             r
         )
         .unwrap();


### PR DESCRIPTION
As a measure to prevent #84, immediately confirm that we can fetch the correct objects from R2 after they are uploaded.

I was having trouble getting the sentry integration working, so in the meantime update the Cleaner to just check that each full level-0 tile exists. This will stop progress indefinitely to allow us to detect if more tiles go missing.