### PR TITLE
Rename `Checkpoint` to `CheckpointText`

### DIFF
--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -1261,7 +1261,7 @@ mod tests {
         PrecertData, StaticCTCheckpointSigner, StaticCTLogEntry, StaticCTPendingLogEntry,
     };
     use std::time::Duration;
-    use tlog_tiles::{Checkpoint, CheckpointSigner, Ed25519CheckpointSigner, TlogTile};
+    use tlog_tiles::{CheckpointSigner, CheckpointText, Ed25519CheckpointSigner, TlogTile};
 
     #[test]
     fn test_sequence_one_leaf_short() {
@@ -2421,7 +2421,7 @@ mod tests {
                 .map_err(|e| anyhow!(e))?
                 .unwrap();
 
-            let c = Checkpoint::from_bytes(n.text()).map_err(|e| anyhow!(e))?;
+            let c = CheckpointText::from_bytes(n.text()).map_err(|e| anyhow!(e))?;
 
             assert_eq!(c.origin(), "example.com/TestLog");
             assert_eq!(c.extension(), "");
@@ -2440,7 +2440,7 @@ mod tests {
                     .extract_timestamp_millis(verified_sigs[0].signature())
                     .map_err(|e| anyhow!(e))?
                     .unwrap();
-                let c1 = Checkpoint::from_bytes(n.text()).map_err(|e| anyhow!(e))?;
+                let c1 = CheckpointText::from_bytes(n.text()).map_err(|e| anyhow!(e))?;
 
                 ensure!(c1.origin() == c.origin());
                 ensure!(c1.extension() == c.extension());

--- a/crates/mtc_api/src/subtree_cosignature.rs
+++ b/crates/mtc_api/src/subtree_cosignature.rs
@@ -9,7 +9,7 @@ use ed25519_dalek::{
 };
 use length_prefixed::WriteLengthPrefixedBytesExt;
 use signed_note::{compute_key_id, KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
-use tlog_tiles::{Checkpoint, CheckpointSigner, Hash, LeafIndex, UnixTimestamp};
+use tlog_tiles::{CheckpointText, CheckpointSigner, Hash, LeafIndex, UnixTimestamp};
 
 #[derive(Clone)]
 pub struct TrustAnchorID(pub Vec<u8>);
@@ -72,7 +72,7 @@ impl CheckpointSigner for MTCSubtreeCosigner {
     fn sign(
         &self,
         _timestamp_unix_millis: UnixTimestamp,
-        checkpoint: &tlog_tiles::Checkpoint,
+        checkpoint: &tlog_tiles::CheckpointText,
     ) -> Result<NoteSignature, NoteError> {
         let sig = self.sign_subtree(0, checkpoint.size(), checkpoint.hash())?;
         Ok(NoteSignature::new(self.name().clone(), self.key_id(), sig))
@@ -132,7 +132,7 @@ impl NoteVerifier for MTCSubtreeNoteVerifier {
 
     fn verify(&self, msg: &[u8], sig: &[u8]) -> bool {
         // The message itself should be a valid checkpoint.
-        let Ok(checkpoint) = Checkpoint::from_bytes(msg) else {
+        let Ok(checkpoint) = CheckpointText::from_bytes(msg) else {
             return false;
         };
         // Ed25519 signature (no prepended timestamp)

--- a/crates/static_ct_api/src/static_ct.rs
+++ b/crates/static_ct_api/src/static_ct.rs
@@ -120,7 +120,7 @@ use sha2::{Digest, Sha256};
 use signed_note::{KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
 use std::io::Read;
 use tlog_tiles::{
-    Checkpoint, CheckpointSigner, Hash, LeafIndex, LogEntry, LookupKey, PathElem, PendingLogEntry,
+    CheckpointText, CheckpointSigner, Hash, LeafIndex, LogEntry, LookupKey, PathElem, PendingLogEntry,
     SequenceMetadata, UnixTimestamp,
 };
 
@@ -536,7 +536,7 @@ impl NoteVerifier for RFC6962NoteVerifier {
     }
 
     fn verify(&self, msg: &[u8], mut sig: &[u8]) -> bool {
-        let Ok(checkpoint) = Checkpoint::from_bytes(msg) else {
+        let Ok(checkpoint) = CheckpointText::from_bytes(msg) else {
             return false;
         };
         if !checkpoint.extension().is_empty() {
@@ -717,7 +717,7 @@ impl CheckpointSigner for StaticCTCheckpointSigner {
     fn sign(
         &self,
         timestamp_unix_millis: UnixTimestamp,
-        checkpoint: &Checkpoint,
+        checkpoint: &CheckpointText,
     ) -> Result<NoteSignature, NoteError> {
         // RFC 6962-type signatures do not sign extension lines. If this checkpoint has extension lines, this is an error.
         if !checkpoint.extension().is_empty() {

--- a/crates/tlog_tiles/src/cosignature_v1.rs
+++ b/crates/tlog_tiles/src/cosignature_v1.rs
@@ -7,7 +7,7 @@ use ed25519_dalek::{
 };
 use signed_note::{compute_key_id, KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
 
-use crate::{Checkpoint, CheckpointSigner, UnixTimestamp};
+use crate::{CheckpointText, CheckpointSigner, UnixTimestamp};
 
 /// Implementation of [`CheckpointSigner`] that produces a timestamped Ed25519 cosignature/v1 (alg 0x04 from <c2sp.org/signed-note>).
 pub struct CosignatureV1CheckpointSigner {
@@ -37,7 +37,7 @@ impl CheckpointSigner for CosignatureV1CheckpointSigner {
     fn sign(
         &self,
         timestamp_unix_millis: UnixTimestamp,
-        checkpoint: &Checkpoint,
+        checkpoint: &CheckpointText,
     ) -> Result<NoteSignature, NoteError> {
         // Timestamp is in seconds.
         let timestamp_unix_secs = timestamp_unix_millis / 1000;
@@ -108,7 +108,7 @@ impl NoteVerifier for CosignatureV1NoteVerifier {
 
     fn verify(&self, msg: &[u8], mut sig: &[u8]) -> bool {
         // The message itself should be a valid checkpoint.
-        let Ok(checkpoint) = Checkpoint::from_bytes(msg) else {
+        let Ok(checkpoint) = CheckpointText::from_bytes(msg) else {
             return false;
         };
         // timestamped_signature.timestamp

--- a/crates/tlog_tiles/src/tlog.rs
+++ b/crates/tlog_tiles/src/tlog.rs
@@ -495,7 +495,7 @@ pub enum TlogError {
     #[error(transparent)]
     Note(#[from] signed_note::NoteError),
     #[error(transparent)]
-    MalformedCheckpoint(#[from] crate::MalformedCheckpointError),
+    MalformedCheckpoint(#[from] crate::MalformedCheckpointTextError),
     #[error(transparent)]
     InvalidBase64(#[from] base64::DecodeError),
     #[error(transparent)]

--- a/fuzz/fuzz_targets/fuzz_parse_checkpoint.rs
+++ b/fuzz/fuzz_targets/fuzz_parse_checkpoint.rs
@@ -15,8 +15,8 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use tlog_tiles::checkpoint::Checkpoint;
+use tlog_tiles::checkpoint::CheckpointText;
 
 fuzz_target!(|data: &[u8]| {
-    let _ = Checkpoint::from_bytes(data);
+    let _ = CheckpointText::from_bytes(data);
 });


### PR DESCRIPTION
Pretty small change. Checkpoints as defined in in [the spec](https://github.com/C2SP/C2SP/blob/main/tlog-checkpoint.md) are signed notes, which themselves MUST have at least one signature. Thus, the thing we call a checkpoint in the code is actually just the text portion of the checkpoint.

I struggled for a while trying to make a `Checkpoint` type that parses a `CheckpointText` followed by signatures in the signed-note format. But I realized in my second attempt that no such data type is necessary. If you want to produce a checkpoint, you use one of the signing functions, which just returns a `Vec<u8>`. And if you want to parse a checkpoint, you call `open_checkpoint` on a bytestring. And if you _really_ want to open it without verifying it, you can always call `Note::from_reader` and then call `Checkpoint::from_bytes` on `note.text`.

Lmk if you agree @lukevalenta 