### PR TITLE
Ensure that the inferred root is uploaded to /issuers

### DIFF
--- a/crates/x509_util/src/lib.rs
+++ b/crates/x509_util/src/lib.rs
@@ -119,4 +119,17 @@ impl CertPool {
             .by_fingerprint
             .contains_key::<[u8; 32]>(&Sha256::digest(cert.to_der()?).into()))
     }
+
+    /// Fetch a certificate from the pool by its fingerprint.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there are issues DER-encoding the certificate.
+    pub fn by_fingerprint(&self, fingerprint: &[u8; 32]) -> Option<&Certificate> {
+        if let Some(idx) = self.by_fingerprint.get(fingerprint) {
+            self.certs.get(*idx)
+        } else {
+            None
+        }
+    }
 }


### PR DESCRIPTION
As reported by Andrew Ayer in
https://groups.google.com/a/chromium.org/g/ct-policy/c/dVz6tMLWsRY/m/m1_lh0IzGwAJ, the previous bugfix was incomplete as inferred roots for chains were not getting uploaded to /issuers.