### PR TITLE
Add metrics to measure cost of extra check after put

### DIFF
--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -548,6 +548,12 @@ impl ObjectBackend for ObjectBucket {
                     .inspect(|&m| m.errors.with_label_values(&["put-failed"]).inc());
             })?;
 
+        self.metrics.as_ref().inspect(|&m| {
+            m.duration
+                .with_label_values(&["put"])
+                .observe(millis_diff_as_secs(start, now_millis()));
+        });
+
         // SAFETY: immediately fetch the uploaded object to make sure that it was persisted.
         // TODO: sentry reporting
         if let Some(fetched) = self.fetch(key.as_ref()).await? {
@@ -572,7 +578,7 @@ impl ObjectBackend for ObjectBucket {
 
         self.metrics.as_ref().inspect(|&m| {
             m.duration
-                .with_label_values(&["put"])
+                .with_label_values(&["put-and-check"])
                 .observe(millis_diff_as_secs(start, now_millis()));
         });
         Ok(())


### PR DESCRIPTION
As part of the investigation of #84, 4ac28d9 added an extra GET request after each R2 PUT operation to double-check that entries are indeed persisted (something guaranteed by R2, but we wanted to rule out that possibility). If the cost is essentially zero, there's no harm in keeping it, but otherwise remove it to reduce sequencing latency. This commit adds metrics to help make that determination.