### PR TITLE
mtc_worker: /get-certificate: Handle invalid input as 400

### DIFF
--- a/crates/mtc_worker/src/frontend_worker.rs
+++ b/crates/mtc_worker/src/frontend_worker.rs
@@ -110,10 +110,13 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                 .post_async("/logs/:log/get-certificate", |mut req, ctx| async move {
                     let name = ctx.data;
                     let params = &CONFIG.logs[name];
-                    let GetCertificateRequest {
+                    let Ok(GetCertificateRequest {
                         leaf_index,
                         spki_der,
-                    } = req.json().await?;
+                    }) = req.json().await
+                    else {
+                        return Response::error("Unexpected input", 400);
+                    };
                     let object_backend = ObjectBucket::new(load_public_bucket(&ctx.env, name)?);
                     // Fetch the current checkpoint to know which tiles to fetch
                     // (full or partials).


### PR DESCRIPTION
If the request body is not the JSON blob we expect, then we return 500. This is because we use the default error handling for workers. It's more appropriate to handle this as a 400, since it's the client's fault and not the server's.