### PR TITLE
Add rfc6962 prefix to validate_chain

### DIFF
--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -204,7 +204,7 @@ async fn add_chain_or_pre_chain(
 
     // Temporal interval dates prior to the Unix epoch are treated as the Unix epoch.
     let roots = &load_roots(env, name).await?;
-    let pending_entry = match static_ct_api::validate_chain(
+    let pending_entry = match static_ct_api::rfc6962_validate_chain(
         &req.chain,
         roots,
         Some(

--- a/crates/static_ct_api/src/rfc6962.rs
+++ b/crates/static_ct_api/src/rfc6962.rs
@@ -77,13 +77,13 @@ pub struct GetRootsResponse {
     pub certificates: Vec<Vec<u8>>,
 }
 
-/// Validates a certificate chain and returns a pending log entry.
+/// Validates a certificate chain according to [RFC6962](https://datatracker.ietf.org/doc/html/rfc6962) and returns a pending log entry.
 ///
 /// # Errors
 ///
 /// Returns a `ValidationError` if the chain fails to validate.
 #[allow(clippy::too_many_lines)]
-pub fn validate_chain(
+pub fn rfc6962_validate_chain(
     raw_chain: &[Vec<u8>],
     roots: &CertPool,
     not_after_start: Option<UnixTimestamp>,
@@ -450,7 +450,7 @@ mod tests {
                     chain.append(&mut Certificate::load_pem_chain(include_bytes!($chain_file)).unwrap());
                 )*
 
-                let result = validate_chain(
+                let result = rfc6962_validate_chain(
                         &x509_util::certs_to_bytes(&chain).unwrap(),
                         &CertPool::new(roots).unwrap(),
                         $not_after_start,


### PR DESCRIPTION
We don't want anyone to use validate_chain and think that it does real chain validation, as this is a specialized version for RFC 6962.