### PR TITLE
mtc: Encode issuer as UTF-8 string rather than RELATIVE-OID

### DIFF
--- a/crates/mtc_worker/build.rs
+++ b/crates/mtc_worker/build.rs
@@ -4,12 +4,11 @@
 // Build script to include per-environment configuration and trusted roots.
 
 use config::AppConfig;
+use der::asn1::Utf8StringRef;
 use der::{asn1::SetOfVec, Any, Tag};
-use mtc_api::RelativeOid;
 use mtc_api::ID_RDNA_TRUSTANCHOR_ID;
 use std::env;
 use std::fs;
-use std::str::FromStr;
 use url::Url;
 use x509_cert::{
     attr::AttributeTypeAndValue,
@@ -41,11 +40,14 @@ fn main() {
     });
     for (name, params) in conf.logs {
         // Make sure we can create the RDN sequence for the issuer log ID.
-        let relative_oid = RelativeOid::from_str(&params.log_id).unwrap();
         let _ = RdnSequence::from(vec![RelativeDistinguishedName(
             SetOfVec::from_iter([AttributeTypeAndValue {
                 oid: ID_RDNA_TRUSTANCHOR_ID,
-                value: Any::new(Tag::RelativeOid, relative_oid.as_bytes()).unwrap(),
+                value: Any::new(
+                    Tag::Utf8String,
+                    Utf8StringRef::new(&params.log_id).unwrap().as_bytes(),
+                )
+                .unwrap(),
             }])
             .unwrap(),
         )]);

--- a/crates/mtc_worker/src/frontend_worker.rs
+++ b/crates/mtc_worker/src/frontend_worker.rs
@@ -8,7 +8,7 @@ use crate::{
     CONFIG, ROOTS,
 };
 use der::{
-    asn1::{SetOfVec, UtcTime},
+    asn1::{SetOfVec, UtcTime, Utf8StringRef},
     Any, Tag,
 };
 use generic_log_worker::{
@@ -21,13 +21,13 @@ use generic_log_worker::{
 };
 use mtc_api::{
     serialize_signatureless_cert, AddEntryRequest, AddEntryResponse, BootstrapMtcLogEntry,
-    LandmarkSequence, RelativeOid, ID_RDNA_TRUSTANCHOR_ID, LANDMARK_KEY,
+    LandmarkSequence, ID_RDNA_TRUSTANCHOR_ID, LANDMARK_KEY,
 };
 use p256::pkcs8::EncodePublicKey;
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 use signed_note::{NoteVerifier, VerifierList};
-use std::{str::FromStr, time::Duration};
+use std::time::Duration;
 use tlog_tiles::{open_checkpoint, LeafIndex, PendingLogEntry, PendingLogEntryBlob};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
@@ -305,8 +305,10 @@ async fn add_entry(mut req: Request, env: &Env, name: &str) -> Result<Response> 
         SetOfVec::from_iter([AttributeTypeAndValue {
             oid: ID_RDNA_TRUSTANCHOR_ID,
             value: Any::new(
-                Tag::RelativeOid,
-                RelativeOid::from_str(&params.log_id).unwrap().as_bytes(),
+                Tag::Utf8String,
+                Utf8StringRef::new(&params.log_id)
+                    .map_err(|e| e.to_string())?
+                    .as_bytes(),
             )
             .map_err(|e| e.to_string())?,
         }])


### PR DESCRIPTION
RELATIVE-OID is relatively and is not implemented by all ASN.1 libraries. For example, Go's `crypto/x509.ParseCertificate()` fails to parse MTCs minted by Azul. To sidestep this problem, encode the relative OID as a UTF-8 string, something that all existing libraries support.

See <https://github.com/davidben/merkle-tree-certs/issues/142> for details.