### PR TITLE
Keep only a single copy of roots per worker script, fixes #110

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
  "signed_note",
  "static_ct_api",
  "tlog_tiles",
+ "tokio",
  "url",
  "worker",
  "x509-cert",

--- a/crates/ct_worker/Cargo.toml
+++ b/crates/ct_worker/Cargo.toml
@@ -51,6 +51,7 @@ serde_with.workspace = true
 static_ct_api.workspace = true
 signed_note.workspace = true
 tlog_tiles.workspace = true
+tokio.workspace = true
 worker.workspace = true
 x509-cert.workspace = true
 x509_util.workspace = true

--- a/crates/ct_worker/src/ccadb_roots_cron.rs
+++ b/crates/ct_worker/src/ccadb_roots_cron.rs
@@ -71,7 +71,7 @@ pub(crate) async fn update_ccadb_roots<T: AsRef<str>>(keys: &[T], kv: &KvStore) 
             buf = old;
         }
         for cert in &ccadb_roots {
-            if pool.included(cert).map_err(|e| e.to_string())? {
+            if pool.includes(cert).map_err(|e| e.to_string())? {
                 continue;
             }
             new_roots += 1;

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -203,7 +203,7 @@ async fn add_chain_or_pre_chain(
     };
 
     // Temporal interval dates prior to the Unix epoch are treated as the Unix epoch.
-    let roots = &load_roots(env, name).await?;
+    let roots = load_roots(env, name).await?;
     let pending_entry = match static_ct_api::partially_validate_chain(
         &req.chain,
         roots,

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -252,7 +252,7 @@ async fn add_chain_or_pre_chain(
             .map(Vec::as_slice)
             .collect::<Vec<&[u8]>>();
 
-        // Make sure the inferred root is persisted as well, if the add-chain
+        // Make sure the found root is persisted as well, if the add-chain
         // request did not include the root.
         let root_bytes;
         if let Some(idx) = found_root_idx {

--- a/crates/static_ct_api/src/rfc6962.rs
+++ b/crates/static_ct_api/src/rfc6962.rs
@@ -159,12 +159,12 @@ pub fn partially_validate_chain(
             has_precert_signing_cert = true;
         }
 
-        // Also check that intermediates have the CA Basic Constraint,
-        // but don't enforce for Precertificate Signing Certificates.
+        // Check that intermediates have the CA Basic Constraint.
+        // Precertificate signing certificates must also have CA:true.
         if cert
             .tbs_certificate
             .get::<BasicConstraints>()?
-            .is_some_and(|(_, bc)| !bc.ca)
+            .is_none_or(|(_, bc)| !bc.ca)
         {
             return Err(StaticCTError::IntermediateMissingCABasicConstraint);
         }

--- a/crates/x509_util/src/lib.rs
+++ b/crates/x509_util/src/lib.rs
@@ -52,7 +52,7 @@ impl CertPool {
         Ok(pool)
     }
 
-    /// Search the certificate pool for potential parents for the provided certificates.
+    /// Search the certificate pool for potential parents for the provided certificate.
     ///
     /// # Errors
     ///
@@ -109,12 +109,12 @@ impl CertPool {
         Ok(())
     }
 
-    /// Check if a certificate is included in the pool.
+    /// Check if the pool includes a certificate.
     ///
     /// # Errors
     ///
     /// Returns an error if there are issues DER-encoding the certificate.
-    pub fn included(&self, cert: &Certificate) -> Result<bool, DerError> {
+    pub fn includes(&self, cert: &Certificate) -> Result<bool, DerError> {
         Ok(self
             .by_fingerprint
             .contains_key::<[u8; 32]>(&Sha256::digest(cert.to_der()?).into()))


### PR DESCRIPTION
In 36bb0fc, we switched from loading roots once per Worker script (with
LazyLock) to loading roots dynamically for each fetch request, since we
need an async operation to fetch roots from KV, and LazyLock doesn't
support async initialization. This means each add-chain request has to
keep a separate copy of the roots in the Worker memory. Combined with
ad6ced9 which caused the dynamically loaded roots to be kept in memory
across the asynchronous call to the sequencer, this resulted in the
memory issues observed in #110.

Use the runtime-agnostic tokio::sync::LazyCell to restore the previous
behavior of loading roots only once for each Worker script.

This is deployed for the cftest logs, and we are no longer seeing high rates of 500/429 errors.

This PR contains several other commits that can be reviewed independently, including two bug fixes in chain validation (none critical).