### PR TITLE
Update to worker 0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "worker"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38079fb888798411da925f8e7da31d05f99f34d960876e7f0f64d38dd1c5a8e4"
+checksum = "4a53a6374d6ec3d7fdf49db98fa7f5173a81ffb20bb81e5594b94aa7ae1ba899"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3100,9 +3100,9 @@ dependencies = [
 
 [[package]]
 name = "worker-macros"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04c25dc6fc79ac2c111eadac8e98fddfa42f97625e48a3b94f82455d9b29766"
+checksum = "a9b87ff3abcd9e21f0c2de1b6ad145b535bc4e1761d46fa27e6dcd549e145f06"
 dependencies = [
  "async-trait",
  "proc-macro2",
@@ -3116,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "worker-sys"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa601b8e81a1a06f0b0cc1ca5d48eef4901f491d324a4b2796354b0d49aeeaf0"
+checksum = "c4b5b178b64415a5992165f5c17f9632e458bf7f6461839f885bfc6d7b685e2f"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ thiserror = "2.0"
 tlog_tiles = { path = "crates/tlog_tiles", version = "0.2.0" }
 tokio = { version = "1", features = ["sync"] }
 url = "2.2"
-worker = "0.6.5"
+worker = "0.6.6"
 x509-cert = "0.2.5"
 x509-verify = { version = "0.4.4", features = [
     "md2",

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -129,6 +129,15 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                     stub.fetch_with_str(&format!("http://fake_url.com{METRICS_ENDPOINT}"))
                         .await
                 })
+                .get("/logs/:log/sequencer_id", |_req, ctx| {
+                    // Print out the Durable Object ID of the sequencer to allow
+                    // looking it up in internal Cloudflare dashboards. This
+                    // value does not need to be kept secret.
+                    let name = ctx.data;
+                    let namespace = ctx.env.durable_object("SEQUENCER")?;
+                    let object_id = namespace.id_from_name(name)?;
+                    Response::ok(object_id.to_string())
+                })
                 .get_async("/logs/:log/*key", |_req, ctx| async move {
                     let name = ctx.data;
                     let key = ctx.param("key").unwrap();

--- a/crates/ct_worker/wrangler.jsonc
+++ b/crates/ct_worker/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
     "name": "static-ct",
     "main": "build/worker/shim.mjs",
-    "compatibility_date": "2025-04-01",
+    "compatibility_date": "2025-09-25",
     "workers_dev": false,
     "build": {
         "command": "echo 'Default environment not configured. Please specify an environment with the \"-e\" flag.' && exit 1"

--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -56,7 +56,6 @@ pub fn init_logging(level: Option<&str>) {
     let level = level
         .and_then(|level| Level::from_str(level).ok())
         .unwrap_or(Level::Info);
-    console_error_panic_hook::set_once();
     INIT_LOGGING.call_once(|| {
         console_log::init_with_level(level).expect("error initializing logger");
     });
@@ -244,9 +243,10 @@ impl CacheRead for DedupCache {
 }
 
 impl DedupCache {
-    // Batches are written at most once per second, and we only need them deduplicate
-    // entries long enough for KV's eventual consistency guarantees (~60s).
-    // Cap at 128 so we can use a single get_multiple call to get all batches at once.
+    // Batches are written at most once per second, and we only need them to
+    // deduplicate entries long enough for KV's eventual consistency guarantees
+    // (~60s). Cap at 128 so we can use a single get_multiple call to get all
+    // batches at once.
     // https://developers.cloudflare.com/durable-objects/api/storage-api/#get
     const MAX_BATCHES: usize = 128;
     const FIFO_HEAD_KEY: &str = "fifo:head";

--- a/crates/mtc_worker/src/frontend_worker.rs
+++ b/crates/mtc_worker/src/frontend_worker.rs
@@ -251,6 +251,15 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                     stub.fetch_with_str(&format!("http://fake_url.com{METRICS_ENDPOINT}"))
                         .await
                 })
+                .get("/logs/:log/sequencer_id", |_req, ctx| {
+                    // Print out the Durable Object ID of the sequencer to allow
+                    // looking it up in internal Cloudflare dashboards. This
+                    // value does not need to be kept secret.
+                    let name = ctx.data;
+                    let namespace = ctx.env.durable_object("SEQUENCER")?;
+                    let object_id = namespace.id_from_name(name)?;
+                    Response::ok(object_id.to_string())
+                })
                 .get_async("/logs/:log/*key", |_req, ctx| async move {
                     let name = ctx.data;
                     let key = ctx.param("key").unwrap();

--- a/crates/mtc_worker/wrangler.jsonc
+++ b/crates/mtc_worker/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
     "name": "mtc",
     "main": "build/worker/shim.mjs",
-    "compatibility_date": "2025-04-01",
+    "compatibility_date": "2025-09-25",
     "workers_dev": false,
     "build": {
         "command": "echo 'Default environment not configured. Please specify an environment with the \"-e\" flag.' && exit 1"


### PR DESCRIPTION
- Remove console_error_panic_hook call, as it's no longer needed after https://github.com/cloudflare/workers-rs/pull/805
- Update to worker 0.6.6 and update compatibility dates
- Add endpoint to print out sequencer Durable Object ID, useful for memory profiling in internal Cloudflare dashboards