### PR TITLE
Return a 503 instead of 429 on sequencing errors

### DIFF
--- a/crates/generic_log_worker/src/batcher_do.rs
+++ b/crates/generic_log_worker/src/batcher_do.rs
@@ -154,7 +154,7 @@ impl GenericBatcher {
                 } else {
                     // Failed to sequence this entry, either due to an error
                     // submitting the batch or rate limiting at the Sequencer.
-                    Response::error("rate limited", 429)
+                    Response::error("sequencing error", 503)
                 };
                 *self.in_flight.borrow_mut() -= 1;
 


### PR DESCRIPTION
The original reason I put 429 is that this could have been the result of rate limiting at the sequencer. However, there are other reasons this could happen, for example if the worker gets redeployed and in-flight requests from the batcher to sequencer fail. 503 seems more appropriate and still signals to the client to retry again later.