### PR TITLE
Add dev-roots feature for MTC log

### DIFF
--- a/crates/mtc_api/src/lib.rs
+++ b/crates/mtc_api/src/lib.rs
@@ -123,6 +123,15 @@ pub struct AddEntryResponse {
     pub timestamp: UnixTimestamp,
 }
 
+/// Get-roots response. This is in the same format as the RFC 6962 get-roots
+/// response, which is the base64 encoding of the DER-encoded certificate bytes.
+#[serde_as]
+#[derive(Serialize)]
+pub struct GetRootsResponse {
+    #[serde_as(as = "Vec<Base64>")]
+    pub certificates: Vec<Vec<u8>>,
+}
+
 /// A wrapper around `TlogTilesPendingLogEntry` that supports auxiliary bootstrap data.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct BootstrapMtcPendingLogEntry {

--- a/crates/mtc_worker/Cargo.toml
+++ b/crates/mtc_worker/Cargo.toml
@@ -11,6 +11,9 @@ description = "An implementation of a Merkle Tree Certificates CA on Cloudflare 
 categories = ["cryptography"]
 keywords = ["certificate", "transparency", "crypto", "pki"]
 
+[features]
+dev-bootstrap-roots = []
+
 [package.metadata.release]
 release = false
 

--- a/crates/mtc_worker/dev-bootstrap-roots.pem
+++ b/crates/mtc_worker/dev-bootstrap-roots.pem
@@ -1,0 +1,48 @@
+# Root certificate for generating test data for Bushbaby.
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 2023 (0x7e7)
+        Signature Algorithm: ecdsa-with-SHA256
+        Issuer: C=US, ST=California, L=San Francisco, O=My Corp, CN=My Corp Root CA
+        Validity
+            Not Before: Sep 26 20:53:47 2025 GMT
+            Not After : Sep 26 20:53:47 2035 GMT
+        Subject: C=US, ST=California, L=San Francisco, O=My Corp, CN=My Corp Root CA
+        Subject Public Key Info:
+            Public Key Algorithm: id-ecPublicKey
+                Public-Key: (256 bit)
+                pub:
+                    04:da:58:ff:b6:8f:ce:41:79:b2:3e:5d:48:2d:fc:
+                    01:d6:fe:d1:fe:97:91:15:28:9d:64:a7:c3:80:99:
+                    d9:20:92:28:cd:9e:0e:14:57:85:37:0a:e8:2c:9d:
+                    1d:c7:e2:03:04:61:f7:71:b8:33:51:f8:91:69:ad:
+                    cb:38:d2:56:38
+                ASN1 OID: prime256v1
+                NIST CURVE: P-256
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Subject Key Identifier:
+                9B:6B:39:DD:FB:E2:22:55:F3:20:55:17:53:3D:81:B4:C3:5E:EB:BB
+    Signature Algorithm: ecdsa-with-SHA256
+    Signature Value:
+        30:44:02:20:08:5e:82:d8:d5:a0:d5:6f:27:85:f8:76:8c:05:
+        2d:9e:e5:30:b9:b8:ca:07:99:a1:b6:91:6e:74:43:0d:a0:3e:
+        02:20:57:6e:cc:e2:38:b2:8c:65:97:ef:e0:a8:9c:f3:44:86:
+        7f:1f:7a:47:8a:fc:56:8a:69:32:b0:da:65:c1:63:21
+-----BEGIN CERTIFICATE-----
+MIIB/TCCAaSgAwIBAgICB+cwCgYIKoZIzj0EAwIwZjELMAkGA1UEBhMCVVMxEzAR
+BgNVBAgTCkNhbGlmb3JuaWExFjAUBgNVBAcTDVNhbiBGcmFuY2lzY28xEDAOBgNV
+BAoTB015IENvcnAxGDAWBgNVBAMTD015IENvcnAgUm9vdCBDQTAeFw0yNTA5MjYy
+MDUzNDdaFw0zNTA5MjYyMDUzNDdaMGYxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpD
+YWxpZm9ybmlhMRYwFAYDVQQHEw1TYW4gRnJhbmNpc2NvMRAwDgYDVQQKEwdNeSBD
+b3JwMRgwFgYDVQQDEw9NeSBDb3JwIFJvb3QgQ0EwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAATaWP+2j85BebI+XUgt/AHW/tH+l5EVKJ1kp8OAmdkgkijNng4UV4U3
+CugsnR3H4gMEYfdxuDNR+JFprcs40lY4o0IwQDAOBgNVHQ8BAf8EBAMCAoQwDwYD
+VR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUm2s53fviIlXzIFUXUz2BtMNe67swCgYI
+KoZIzj0EAwIDRwAwRAIgCF6C2NWg1W8nhfh2jAUtnuUwubjKB5mhtpFudEMNoD4C
+IFduzOI4soxll+/gqJzzRIZ/H3pHivxWimkysNplwWMh
+-----END CERTIFICATE-----

--- a/crates/mtc_worker/wrangler.jsonc
+++ b/crates/mtc_worker/wrangler.jsonc
@@ -15,7 +15,10 @@
         "dev": {
             "build": {
                 // Change '--release' to '--dev' to compile with debug symbols.
-                // DEPLOY_ENV is used in build.rs to select per-environment config and roots.
+                // DEPLOY_ENV is used in build.rs to select per-environment
+                // config and roots. Add `--features dev-bootstrap-roots` to the
+                // worker-build command to enable dev bootstrap roots (which
+                // should NOT be enabled in a production deployment).
                 "command": "cargo install -q worker-build && DEPLOY_ENV=dev worker-build --release"
             },
             "workers_dev": true,

--- a/crates/x509_util/src/lib.rs
+++ b/crates/x509_util/src/lib.rs
@@ -104,8 +104,12 @@ impl CertPool {
     ///
     /// Returns an error if there are DER encoding issues.
     pub fn append_certs_from_pem(&mut self, input: &[u8]) -> Result<(), DerError> {
-        for cert in Certificate::load_pem_chain(input)? {
-            self.add_cert(cert)?;
+        // Until next x509-cert release, load_pem_chain doesn't support an empty
+        // input: https://github.com/RustCrypto/formats/pull/1965
+        if !input.is_empty() {
+            for cert in Certificate::load_pem_chain(input)? {
+                self.add_cert(cert)?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Also add a get-roots endpoint for MTC, to make it easier to see which roots are accepted.