### PR TITLE
mtc_worker: Return MTC validity window on add entry

### DIFF
--- a/crates/mtc_api/src/lib.rs
+++ b/crates/mtc_api/src/lib.rs
@@ -119,8 +119,15 @@ pub struct AddEntryRequest {
 #[serde_as]
 #[derive(Serialize)]
 pub struct AddEntryResponse {
+    /// The index of the entry in the log.
     pub leaf_index: LeafIndex,
+
+    /// The time at which the entry was added to the log.
     pub timestamp: UnixTimestamp,
+
+    /// The validity period of the certificate.
+    pub not_before: UnixTimestamp,
+    pub not_after: UnixTimestamp,
 }
 
 /// Get-roots response. This is in the same format as the RFC 6962 get-roots
@@ -684,7 +691,7 @@ pub fn validate_chain(
     raw_chain: &[Vec<u8>],
     roots: &CertPool,
     issuer: RdnSequence,
-    mut validity: Validity,
+    validity: &mut Validity,
 ) -> Result<(BootstrapMtcPendingLogEntry, Option<usize>), MtcError> {
     // We will run the ordinary chain validation on our input, but we have some post-processing we
     // need to do too. Namely we need to adjust the validity period of the provided bootstrap cert,
@@ -741,7 +748,7 @@ pub fn validate_chain(
                 data: MerkleTreeCertEntry::TbsCertEntry(tbs_cert_to_log_entry(
                     leaf.tbs_certificate,
                     issuer,
-                    validity,
+                    *validity,
                 )?)
                 .encode()?,
             },

--- a/crates/mtc_worker/config.bootstrap-mtca.json
+++ b/crates/mtc_worker/config.bootstrap-mtca.json
@@ -5,8 +5,7 @@
             "description": "Cloudflare bootstrap MTCA shard 1",
             "log_id": "13335.1",
             "submission_url": "https://bootstrap-mtca.cloudflareresearch.com/logs/shard1/",
-            "monitoring_url": "https://bootstrap-mtca-shard1.cloudflareresearch.com",
-            "enable_dedup": false
+            "monitoring_url": "https://bootstrap-mtca-shard1.cloudflareresearch.com"
         }
     }
 }

--- a/crates/mtc_worker/config.dev.json
+++ b/crates/mtc_worker/config.dev.json
@@ -5,15 +5,13 @@
             "description": "MTCA Dev1",
             "log_id": "13335.1",
             "submission_url": "http://localhost:8787/logs/dev1/",
-            "location_hint": "enam",
-            "enable_dedup": false
+            "location_hint": "enam"
         },
         "dev2": {
             "description": "MTCA Dev2",
             "log_id": "13335.2",
             "submission_url": "http://localhost:8787/logs/dev2/",
             "location_hint": "enam",
-            "enable_dedup": false,
             "max_certificate_lifetime_secs": 100,
             "landmark_interval_secs": 10
         }

--- a/crates/mtc_worker/config.schema.json
+++ b/crates/mtc_worker/config.schema.json
@@ -90,11 +90,6 @@
                             "default": 256,
                             "description": "The maximum number of entries per batch."
                         },
-                        "enable_dedup": {
-                            "type": "boolean",
-                            "default": true,
-                            "description": "Enables checking the deduplication cache for add-(pre-)chain requests. Can be disabled for tests and benchmarks. If disabled, `kv_namespaces` can be omitted from `wrangler.jsonc`."
-                        },
                         "clean_interval_secs": {
                             "type": "integer",
                             "minimum": 1,

--- a/crates/mtc_worker/config/src/lib.rs
+++ b/crates/mtc_worker/config/src/lib.rs
@@ -34,15 +34,10 @@ pub struct LogParams {
     pub batch_timeout_millis: u64,
     #[serde(default = "default_usize::<100>")]
     pub max_batch_entries: usize,
-    #[serde(default = "default_bool::<true>")]
-    pub enable_dedup: bool,
     #[serde(default = "default_u64::<60>")]
     pub clean_interval_secs: u64,
 }
 
-fn default_bool<const V: bool>() -> bool {
-    V
-}
 fn default_u8<const V: u8>() -> u8 {
     V
 }

--- a/crates/mtc_worker/src/batcher_do.rs
+++ b/crates/mtc_worker/src/batcher_do.rs
@@ -22,7 +22,7 @@ impl DurableObject for Batcher {
             name: name.to_string(),
             max_batch_entries: params.max_batch_entries,
             batch_timeout_millis: params.batch_timeout_millis,
-            enable_dedup: params.enable_dedup,
+            enable_dedup: false, // deduplication is not currently supported
             location_hint: params.location_hint.clone(),
         };
         Batcher(GenericBatcher::new(env, config))

--- a/crates/mtc_worker/src/sequencer_do.rs
+++ b/crates/mtc_worker/src/sequencer_do.rs
@@ -35,7 +35,7 @@ impl DurableObject for Sequencer {
             checkpoint_extension: Box::new(|_| vec![]), // no checkpoint extension for MTC
             sequence_interval: Duration::from_millis(params.sequence_interval_millis),
             max_sequence_skips: params.max_sequence_skips,
-            enable_dedup: params.enable_dedup,
+            enable_dedup: false, // deduplication is not currently supported
             sequence_skip_threshold_millis: params.sequence_skip_threshold_millis,
             location_hint: params.location_hint.clone(),
             checkpoint_callback: checkpoint_callback(&env, name),


### PR DESCRIPTION
Add the MTC validity window to `AddEntryResponse`. In case the entry was cached, it would be necessary to parse the validity window from the entry itself. However, for now we don't actually want to cache MTC entries, so remove caching for now.