### PR TITLE
mtc_worker: Make the witness a proper MTC cosigner

### DIFF
--- a/crates/mtc_worker/config.bootstrap-mtca.json
+++ b/crates/mtc_worker/config.bootstrap-mtca.json
@@ -4,6 +4,7 @@
         "shard1": {
             "description": "Cloudflare bootstrap MTCA shard 1",
             "log_id": "13335.1",
+            "witness_id": "44363.47.3",
             "submission_url": "https://bootstrap-mtca.cloudflareresearch.com/logs/shard1/",
             "monitoring_url": "https://bootstrap-mtca-shard1.cloudflareresearch.com"
         }

--- a/crates/mtc_worker/config.dev.json
+++ b/crates/mtc_worker/config.dev.json
@@ -4,12 +4,14 @@
         "dev1": {
             "description": "MTCA Dev1",
             "log_id": "13335.1",
+            "witness_id": "44363.47.1",
             "submission_url": "http://localhost:8787/logs/dev1/",
             "location_hint": "enam"
         },
         "dev2": {
             "description": "MTCA Dev2",
             "log_id": "13335.2",
+            "witness_id": "44363.47.2",
             "submission_url": "http://localhost:8787/logs/dev2/",
             "location_hint": "enam",
             "max_certificate_lifetime_secs": 100,

--- a/crates/mtc_worker/config.schema.json
+++ b/crates/mtc_worker/config.schema.json
@@ -30,6 +30,10 @@
                             "type": "string",
                             "description": "The log name (a trust anchor ID) in dotted decimal notation (e.g., 32473.1)."
                         },
+                        "witness_id": {
+                            "type": "string",
+                            "description": "A cosigner ID (a trust anchor ID) in dotted decimal notation (e.g., 32473.1)."
+                        },
                         "max_certificate_lifetime_secs": {
                             "type": "integer",
                             "default": 604800,

--- a/crates/mtc_worker/config/src/lib.rs
+++ b/crates/mtc_worker/config/src/lib.rs
@@ -15,6 +15,7 @@ pub struct AppConfig {
 pub struct LogParams {
     pub description: Option<String>,
     pub log_id: String,
+    pub witness_id: String,
     #[serde(default = "default_usize::<604_800>")]
     pub max_certificate_lifetime_secs: usize,
     #[serde(default = "default_usize::<3600>")]


### PR DESCRIPTION
The Worker currently produces two cosignatures for each checkpoint. The first is from the CA itself. The second mocks a second co-signer that relying parties may include as per their own policy, such as a witness or mirror. Normally these parties wouldn't be co-located with the CA, but mocking them is useful for testing purposes.

The cosigner is a plain TLOG cosigner. That is, it doesn't have an MTC-style cosigner ID and doesn't sign subtrees with the format defined in Section 5.4.1 of the MTC spec.

This commit replaces the second cosigner with a proper MTC cosigner. Its ID is determined by the config file. Each log has been assigned a unique OID from 1.3.6.1.4.1.44363.47, the arc we've designated for MTC.

Note: This is a breaking change for the existing logs, since the second cosigner has changed. In particular, attempts to add new entries will result in `TlogError::MissingVerifierSignature`.