### PR TITLE
mtc_api: Make `LandmarkSequence::add` more robust

### DIFF
--- a/crates/mtc_api/src/landmark.rs
+++ b/crates/mtc_api/src/landmark.rs
@@ -50,10 +50,9 @@ impl LandmarkSequence {
                 ));
             }
         }
-        // Keep `max_landmarks + 1` tree sizes, since we want `max_landmarks`
-        // landmark intervals.
-        if self.landmarks.len() == self.max_landmarks + 1 {
-            self.landmarks.pop_front();
+        if self.landmarks.len() > self.max_landmarks {
+            self.landmarks
+                .drain(..self.landmarks.len() - self.max_landmarks);
         }
         self.landmarks.push_back(tree_size);
         self.last_landmark += 1;


### PR DESCRIPTION
If the number of landmarks is greater than the max, then drain the oldest landmarks from the deque. This makes the code more robust in case we ever decode a `LandmarkSequence` with a different `max_landmarks` than when it was encoded.