### PR TITLE
mtc_worker: Remove extra cosigner

### DIFF
--- a/crates/ct_worker/README.md
+++ b/crates/ct_worker/README.md
@@ -132,7 +132,7 @@ Run the following for each of the `dev2025h1a` and `dev2025h2a` log shards to co
         openssl genpkey -algorithm ed25519 | npx wrangler -e=${ENV} secret put WITNESS_KEY_${LOG_NAME}
         openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 | npx wrangler -e=${ENV} secret put SIGNING_KEY_${LOG_NAME}
 
-    (Note: For mtc_worker we use ed25519 for both the witness key and the signing key.)
+    (Note: For mtc_worker we use ed25519 for the signing key. There is no witness.)
 
 1.  Deploy the worker. The worker will be available at `https://static-ct-${ENV}.<your-team>.workers.dev/logs/${LOG_NAME}`.
 

--- a/crates/mtc_worker/src/frontend_worker.rs
+++ b/crates/mtc_worker/src/frontend_worker.rs
@@ -4,8 +4,7 @@
 //! Entrypoint for the static CT submission APIs.
 
 use crate::{
-    load_checkpoint_signers, load_origin, load_roots, load_signing_key, load_witness_key,
-    SequenceMetadata, CONFIG,
+    load_checkpoint_signers, load_origin, load_roots, load_signing_key, SequenceMetadata, CONFIG,
 };
 use der::{
     asn1::{SetOfVec, UtcTime, Utf8StringRef},
@@ -50,8 +49,6 @@ struct MetadataResponse<'a> {
     description: &'a Option<String>,
     #[serde_as(as = "Base64")]
     key: &'a [u8],
-    #[serde_as(as = "Base64")]
-    witness_key: &'a [u8],
     submission_url: &'a str,
     monitoring_url: &'a str,
 }
@@ -229,15 +226,9 @@ async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
                     let key = verifying_key
                         .to_public_key_der()
                         .map_err(|e| e.to_string())?;
-                    let witness_key = load_witness_key(&ctx.env, name)?;
-                    let witness_key = witness_key
-                        .verifying_key()
-                        .to_public_key_der()
-                        .map_err(|e| e.to_string())?;
                     Response::from_json(&MetadataResponse {
                         description: &params.description,
                         key: key.as_bytes(),
-                        witness_key: witness_key.as_bytes(),
                         submission_url: &params.submission_url,
                         monitoring_url: if params.monitoring_url.is_empty() {
                             &params.submission_url


### PR DESCRIPTION
Partially addresses #137.

Currently mtc_worker loads two cosigners whenever it mints a checkpoint: one for the MTCA itself; and another for a mocked witness. However the mocked witness isn't a proper MTC cosigner, as it doesn't format the message to be signed properly.

To avoid confusing users, just remove the witness altogether.