### PR TITLE
mtc_worker: Update log and cosigner ID

### DIFF
--- a/crates/mtc_api/src/subtree_cosignature.rs
+++ b/crates/mtc_api/src/subtree_cosignature.rs
@@ -9,7 +9,7 @@ use ed25519_dalek::{
 };
 use length_prefixed::WriteLengthPrefixedBytesExt;
 use signed_note::{compute_key_id, KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
-use tlog_tiles::{CheckpointText, CheckpointSigner, Hash, LeafIndex, UnixTimestamp};
+use tlog_tiles::{CheckpointSigner, CheckpointText, Hash, LeafIndex, UnixTimestamp};
 
 #[derive(Clone)]
 pub struct TrustAnchorID(pub Vec<u8>);
@@ -55,6 +55,21 @@ impl MTCSubtreeCosigner {
         );
 
         Ok(self.k.try_sign(&serialized)?.to_vec())
+    }
+
+    /// Return the log ID as bytes.
+    pub fn log_id(&self) -> &[u8] {
+        &self.v.log_id.0
+    }
+
+    /// Return the cosigner ID as bytes.
+    pub fn cosigner_id(&self) -> &[u8] {
+        &self.v.cosigner_id.0
+    }
+
+    /// Return the verifying key as bytes.
+    pub fn verifying_key(&self) -> &[u8] {
+        self.v.verifying_key.as_bytes()
     }
 }
 

--- a/crates/mtc_worker/config.bootstrap-mtca.json
+++ b/crates/mtc_worker/config.bootstrap-mtca.json
@@ -3,7 +3,8 @@
     "logs": {
         "shard1": {
             "description": "Cloudflare bootstrap MTCA shard 1",
-            "log_id": "13335.1",
+            "log_id": "44363.48.5",
+            "cosigner_id": "44363.48.6",
             "submission_url": "https://bootstrap-mtca.cloudflareresearch.com/logs/shard1/",
             "monitoring_url": "https://bootstrap-mtca-shard1.cloudflareresearch.com"
         }

--- a/crates/mtc_worker/config.dev.json
+++ b/crates/mtc_worker/config.dev.json
@@ -3,13 +3,15 @@
     "logs": {
         "dev1": {
             "description": "MTCA Dev1",
-            "log_id": "13335.1",
+            "log_id": "44363.48.1",
+            "cosigner_id": "44363.48.2",
             "submission_url": "http://localhost:8787/logs/dev1/",
             "location_hint": "enam"
         },
         "dev2": {
             "description": "MTCA Dev2",
-            "log_id": "13335.2",
+            "log_id": "44363.48.3",
+            "cosigner_id": "44363.48.4",
             "submission_url": "http://localhost:8787/logs/dev2/",
             "location_hint": "enam",
             "max_certificate_lifetime_secs": 100,

--- a/crates/mtc_worker/config.schema.json
+++ b/crates/mtc_worker/config.schema.json
@@ -28,7 +28,11 @@
                         },
                         "log_id": {
                             "type": "string",
-                            "description": "The log name (a trust anchor ID) in dotted decimal notation (e.g., 32473.1)."
+                            "description": "The log ID (a trust anchor ID) in dotted decimal notation (e.g., 32473.1)."
+                        },
+                        "cosigner_id": {
+                            "type": "string",
+                            "description": "The cosigner's ID (a trust anchor ID) in dotted decimal notation (e.g., 32473.1)."
                         },
                         "max_certificate_lifetime_secs": {
                             "type": "integer",

--- a/crates/mtc_worker/config/src/lib.rs
+++ b/crates/mtc_worker/config/src/lib.rs
@@ -15,6 +15,7 @@ pub struct AppConfig {
 pub struct LogParams {
     pub description: Option<String>,
     pub log_id: String,
+    pub cosigner_id: String,
     #[serde(default = "default_usize::<604_800>")]
     pub max_certificate_lifetime_secs: usize,
     #[serde(default = "default_usize::<3600>")]

--- a/crates/mtc_worker/src/cleaner_do.rs
+++ b/crates/mtc_worker/src/cleaner_do.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
-use crate::{load_checkpoint_signers, load_origin, CONFIG};
+use crate::{load_cosigner, load_origin, CONFIG};
 use generic_log_worker::{get_durable_object_name, CleanerConfig, GenericCleaner, CLEANER_BINDING};
 use mtc_api::BootstrapMtcPendingLogEntry;
 use signed_note::VerifierList;
-use tlog_tiles::PendingLogEntry;
+use tlog_tiles::{CheckpointSigner, PendingLogEntry};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
@@ -26,12 +26,7 @@ impl DurableObject for Cleaner {
             origin: load_origin(name),
             data_path: BootstrapMtcPendingLogEntry::DATA_TILE_PATH,
             aux_path: BootstrapMtcPendingLogEntry::AUX_TILE_PATH,
-            verifiers: VerifierList::new(
-                load_checkpoint_signers(&env, name)
-                    .iter()
-                    .map(|s| s.verifier())
-                    .collect(),
-            ),
+            verifiers: VerifierList::new(vec![load_cosigner(&env, name).verifier()]),
             clean_interval: Duration::from_secs(params.clean_interval_secs),
         };
 

--- a/crates/mtc_worker/src/sequencer_do.rs
+++ b/crates/mtc_worker/src/sequencer_do.rs
@@ -5,7 +5,7 @@
 
 use std::{future::Future, pin::Pin, time::Duration};
 
-use crate::{load_checkpoint_signers, load_origin, CONFIG};
+use crate::{load_cosigner, load_origin, CONFIG};
 use generic_log_worker::{
     get_durable_object_name, load_public_bucket, CheckpointCallbacker, GenericSequencer,
     SequencerConfig, SEQUENCER_BINDING,
@@ -31,7 +31,7 @@ impl DurableObject for Sequencer {
         let config = SequencerConfig {
             name: name.to_string(),
             origin: load_origin(name),
-            checkpoint_signers: load_checkpoint_signers(&env, name),
+            checkpoint_signers: vec![Box::new(load_cosigner(&env, name))],
             checkpoint_extension: Box::new(|_| vec![]), // no checkpoint extension for MTC
             sequence_interval: Duration::from_millis(params.sequence_interval_millis),
             max_sequence_skips: params.max_sequence_skips,


### PR DESCRIPTION
Closes #137.

Assign all deployed logs ("dev1", "dev2", and "shard1") a distinct OID from the space on Cloudflare's PEN allocated for MTC experiments. Also, use a distinct OID for the cosigner for each log. (Each has its own secret key.)

This is a breaking change that will require a migration to first delete all durable object data. The reason is that signatures for existing artifacts no longer verify:

```
dev2: Initializing log from fetch handler
dev2: Log exists, not creating
▲ [WARNING] dev2 failed to submit timed-out batch: Error: Error: invalid signature for key localhost:8787/logs/dev2+f0b8bc08 - Cause: Error: invalid signature for key localhost:8787/logs/dev2+f0b8bc08

[wrangler:info] POST /logs/dev2/add-entry 503 Service Unavailable (1069ms)
✘ [ERROR] Uncaught invalid signature for key localhost:8787/logs/dev2+f0b8bc08

✘ [ERROR] Uncaught Error: invalid signature for key localhost:8787/logs/dev2+f0b8bc08
```

Alternatively, we could spin down these logs and spin up new ones.