### PR TITLE
mtc_worker: Fix shard1, create shard2

### DIFF
--- a/crates/mtc_worker/config.bootstrap-mtca.json
+++ b/crates/mtc_worker/config.bootstrap-mtca.json
@@ -3,10 +3,17 @@
     "logs": {
         "shard1": {
             "description": "Cloudflare bootstrap MTCA shard 1",
-            "log_id": "44363.48.5",
-            "cosigner_id": "44363.48.6",
+            "log_id": "13335.1",
+            "cosigner_id": "13335.1",
             "submission_url": "https://bootstrap-mtca.cloudflareresearch.com/logs/shard1/",
             "monitoring_url": "https://bootstrap-mtca-shard1.cloudflareresearch.com"
+        },
+        "shard2": {
+            "description": "Cloudflare bootstrap MTCA shard 2",
+            "log_id": "44363.48.5",
+            "cosigner_id": "44363.48.6",
+            "submission_url": "https://bootstrap-mtca.cloudflareresearch.com/logs/shard2/",
+            "monitoring_url": "https://bootstrap-mtca-shard2.cloudflareresearch.com"
         }
     }
 }

--- a/crates/mtc_worker/wrangler.jsonc
+++ b/crates/mtc_worker/wrangler.jsonc
@@ -91,6 +91,10 @@
                 {
                     "bucket_name": "bootstrap-mtca-shard1",
                     "binding": "public_shard1"
+                },
+                {
+                    "bucket_name": "bootstrap-mtca-shard2",
+                    "binding": "public_shard2"
                 }
             ],
             "durable_objects": {


### PR DESCRIPTION
A previous commit (a6868ea8f4a502737410ec02dce7f006b6c4e30b) changed the log ID and cosigner ID for dev1, dev2, and shard1. This was a breaking change, since older checkpoints can no longer be opened.

In order to allow safe deployment to shard1, revert its log ID to the old one and add a cosigner ID with the same relative OID.

Meanwhile, create a new log, shard2, with the cosigner and log ID we picked.