### PR TITLE
Add dashboard observability for `raio` shards

### DIFF
--- a/crates/ct_worker/wrangler.jsonc
+++ b/crates/ct_worker/wrangler.jsonc
@@ -275,6 +275,10 @@
                     "head_sampling_rate": 1,
                     "invocation_logs": true,
                     "persist": false
+                },
+                "traces": {
+                    "enabled": true,
+                    "head_sampling_rate": 0.05
                 }
             }
         }


### PR DESCRIPTION
Question: One thing I'm not clear on is where the `observability` key is supposed to go in `wrangler.jsonc`. Can it be scoped to environment or does it need to be global?