### PR TITLE
mtc_worker: Put landmark checkpoint in object storage

### DIFF
--- a/crates/mtc_api/src/landmark.rs
+++ b/crates/mtc_api/src/landmark.rs
@@ -9,10 +9,13 @@ pub struct LandmarkSequence {
     pub landmarks: VecDeque<u64>,
 }
 
-/// The location in object storage for the landmark sequence
+/// The location in object storage for the landmark sequence.
 pub const LANDMARK_KEY: &str = "landmark";
 
-/// The location in object storage for the landmark bundle. Its serialized form is JSON
+/// The location in object storage for the landmark checkpoint.
+pub const LANDMARK_CHECKPOINT_KEY: &str = "landmark-checkpoint";
+
+/// The location in object storage for the landmark bundle. Its serialized form is JSON.
 pub const LANDMARK_BUNDLE_KEY: &str = "landmark-bundle";
 
 impl LandmarkSequence {


### PR DESCRIPTION
The landmark checkpoint is also part of the landmark bundle, but the landmark bundle is not a standard API and is only intended to be consumed by our internal infrastructure. Relying parties consume the landmark checkpoint as a TLOG note.