### PR TITLE
ct_worker: Enable observability for cftest and dev environments, adju…

### DIFF
--- a/crates/ct_worker/wrangler.jsonc
+++ b/crates/ct_worker/wrangler.jsonc
@@ -202,6 +202,9 @@
                     "enabled": true,
                     "head_sampling_rate": 0.1
                 }
+            },
+            "logpush": {
+                "enabled": true
             }
         },
         "raio": {

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -1068,6 +1068,13 @@ async fn sequence_entries<L: LogEntry>(
     for tile in new.edge_tiles {
         trace!("{name}: Edge tile: {tile:?}");
     }
+    debug!(
+        "{name}: Sequenced pool; tree_size={n}, entries: {}, tiles: {}, timestamp: {timestamp}, duration: {:.2}s, since_last: {:.2}s",
+        n - old_size,
+        tile_uploads.len(),
+        millis_diff_as_secs(timestamp, now_millis()),
+        millis_diff_as_secs(old_time, timestamp)
+    );
 
     metrics
         .seq_duration


### PR DESCRIPTION
ct_worker: Enable observability for cftest and dev environments, adjust raio sampling rates

Enable full logging and tracing for cftest and dev environments. Reduce raio log sampling rate from 1 to 0.05 and enable logpush. Remove verbose sequencing log statement from generic_log_worker.