### PR TITLE
ct_worker: Fix logpush configuration format

### DIFF
--- a/crates/ct_worker/wrangler.jsonc
+++ b/crates/ct_worker/wrangler.jsonc
@@ -203,9 +203,7 @@
                     "head_sampling_rate": 0.1
                 }
             },
-            "logpush": {
-                "enabled": true
-            }
+            "logpush": true
         },
         "raio": {
             "account_id": "0b7358d77426ae6413d56c1cc0499b4f",
@@ -308,9 +306,7 @@
                     "head_sampling_rate": 0.05
                 }
             }, 
-            "logpush": {
-                "enabled": true
-            }
+            "logpush": true
         }
     }
 }


### PR DESCRIPTION
Change logpush configuration from object format `{"enabled": true}` to boolean `true` for both cftest and raio environments.