### PR TITLE
ct_worker: Update worker-build to 0.7.5 and enable trace persistence for raio

### DIFF
--- a/crates/ct_worker/wrangler.jsonc
+++ b/crates/ct_worker/wrangler.jsonc
@@ -17,7 +17,7 @@
             "build": {
                 // Change '--release' to '--dev' to compile with debug symbols.
                 // DEPLOY_ENV is used in build.rs to select per-environment config and roots.
-                "command": "cargo install -q worker-build@0.1.14 && DEPLOY_ENV=dev worker-build --release"
+                "command": "cargo install -q worker-build@0.7.5 && DEPLOY_ENV=dev worker-build --release"
             },
             "route": {
                 "pattern": "static-ct-dev.cloudflareresearch.com",
@@ -129,7 +129,7 @@
             "build": {
                 // Change '--release' to '--dev' to compile with debug symbols.
                 // DEPLOY_ENV is used in build.rs to select per-environment config and roots.
-                "command": "cargo install -q worker-build@0.1.14 && DEPLOY_ENV=cftest worker-build --release"
+                "command": "cargo install -q worker-build@0.7.5 && DEPLOY_ENV=cftest worker-build --release"
             },
             "route": {
                 "pattern": "static-ct.cloudflareresearch.com",
@@ -210,7 +210,7 @@
             "build": {
                 // Change '--release' to '--dev' to compile with debug symbols.
                 // DEPLOY_ENV is used in build.rs to select per-environment config and roots.
-                "command": "cargo install -q worker-build@0.1.14 && DEPLOY_ENV=raio worker-build --release"
+                "command": "cargo install -q worker-build@0.7.5 && DEPLOY_ENV=raio worker-build --release"
             },
             "routes": [
                 "https://ct.cloudflare.com/logs/raio2025h2b/*",
@@ -299,7 +299,7 @@
                     "enabled": true,
                     "head_sampling_rate": 0.05,
                     "invocation_logs": true,
-                    "persist": false
+                    "persist": true
                 },
                 "traces": {
                     "enabled": true,


### PR DESCRIPTION
* Updated worker-build from 0.1.14 to 0.7.5 across dev, cftest, and raio. The CT worker build was failing due to a wasm-bindgen mismatch (wasm-bindgen 0.2.108 vs wasm-bindgen-cli 0.2.105); upgrading to 0.7.5 resolved it.  
* Enabled trace persistence in raio by setting persist to true. We’ll keep sample logs in the Dashboard for quick checks and use Kibana as the primary store.