### PR TITLE
CI: split lint/build/test jobs; add cargo-machete; fix test-code clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,15 +10,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Clippy
-      run: cargo clippy -- -D warnings -W clippy::pedantic
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - name: Clippy (required)
+        run: cargo clippy -- -D warnings
+      - name: Clippy (pedantic, advisory)
+        run: cargo clippy --tests -- -W clippy::pedantic
+        continue-on-error: true
+      - name: Unused dependencies
+        run: cargo install cargo-machete --quiet && cargo machete
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,7 +985,6 @@ dependencies = [
  "base64",
  "bitcode",
  "byteorder",
- "console_error_panic_hook",
  "console_log",
  "ed25519-dalek",
  "futures-executor",

--- a/crates/bootstrap_mtc_api/src/landmark.rs
+++ b/crates/bootstrap_mtc_api/src/landmark.rs
@@ -559,7 +559,7 @@ mod tests {
 
         // Create a sequence with max_active_landmarks + 1 entries
         let seq = LandmarkSequence {
-            max_active_landmarks: max_active_landmarks,
+            max_active_landmarks,
             last_landmark: 200,
             landmarks: (32..=201).collect(), // 170 landmarks
         };

--- a/crates/generic_log_worker/Cargo.toml
+++ b/crates/generic_log_worker/Cargo.toml
@@ -24,7 +24,6 @@ anyhow.workspace = true
 base64.workspace = true
 bitcode.workspace = true
 byteorder.workspace = true
-console_error_panic_hook.workspace = true
 console_log.workspace = true
 ed25519-dalek.workspace = true
 futures-util.workspace = true

--- a/crates/integration_tests/Cargo.toml
+++ b/crates/integration_tests/Cargo.toml
@@ -8,6 +8,10 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
+
+[package.metadata.cargo-machete]
+# These deps are used in tests/ (not src/), which cargo-machete doesn't scan.
+ignored = ["bootstrap_mtc_api", "byteorder", "length_prefixed", "log", "signature", "x509_util", "x509-verify"]
 homepage.workspace = true
 repository.workspace = true
 description = "Integration tests for ct_worker (static CT API) and bootstrap_mtc_worker (MTC API)"

--- a/crates/sct_validator/src/sct.rs
+++ b/crates/sct_validator/src/sct.rs
@@ -145,6 +145,23 @@ fn parse_signature_algorithm(
     }
 }
 
+fn extract_lifetime_days(cert: &Certificate) -> Result<u64, SctError> {
+    let validity = &cert.tbs_certificate.validity;
+    let not_before_secs = validity.not_before.to_unix_duration().as_secs();
+    let not_after_secs = validity.not_after.to_unix_duration().as_secs();
+
+    if not_after_secs < not_before_secs {
+        return Err(SctError::Other(
+            "certificate notAfter is before notBefore".to_string(),
+        ));
+    }
+
+    let lifetime_secs = not_after_secs - not_before_secs;
+    let lifetime_days = lifetime_secs / (24 * 60 * 60);
+
+    Ok(lifetime_days)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,21 +198,4 @@ mod tests {
             "TBS DER mismatch — if intentional, re-run with UPDATE_GOLDEN=1"
         );
     }
-}
-
-fn extract_lifetime_days(cert: &Certificate) -> Result<u64, SctError> {
-    let validity = &cert.tbs_certificate.validity;
-    let not_before_secs = validity.not_before.to_unix_duration().as_secs();
-    let not_after_secs = validity.not_after.to_unix_duration().as_secs();
-
-    if not_after_secs < not_before_secs {
-        return Err(SctError::Other(
-            "certificate notAfter is before notBefore".to_string(),
-        ));
-    }
-
-    let lifetime_secs = not_after_secs - not_before_secs;
-    let lifetime_days = lifetime_secs / (24 * 60 * 60);
-
-    Ok(lifetime_days)
 }

--- a/crates/tlog_tiles_wasm/Cargo.toml
+++ b/crates/tlog_tiles_wasm/Cargo.toml
@@ -9,6 +9,11 @@ publish = false
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false
 
+[package.metadata.cargo-machete]
+# getrandom is not called directly but must be present so its wasm_js feature
+# activates the correct WASM backend for all transitive dependents.
+ignored = ["getrandom"]
+
 [lib]
 crate-type = ["cdylib"]
 


### PR DESCRIPTION
Split the single CI job into parallel lint, build, and test jobs.

Clippy changes:
- Required clippy (blocking): cargo clippy -- -D warnings
- Pedantic clippy (advisory): cargo clippy --tests -- -W clippy::pedantic with continue-on-error: true. The --tests flag is needed here to catch warnings in #[cfg(test)] blocks, which the required step skips.

Add cargo-machete step to detect unused workspace dependencies:
- getrandom in tlog_tiles_wasm is ignored (needed for wasm_js feature activation, not called directly)
- Several deps in integration_tests are ignored (used in tests/ which machete does not scan)

Remove console_error_panic_hook from generic_log_worker [dependencies] (was never used in this crate).

Fix two clippy warnings now detected via --tests:
- bootstrap_mtc_api/src/landmark.rs: redundant field name (max_active_landmarks: max_active_landmarks -> max_active_landmarks)
- sct_validator/src/sct.rs: items_after_test_module — move extract_lifetime_days above the #[cfg(test)] mod