### PR TITLE
Make LogEntry::Metadata a generic associated type

### DIFF
--- a/crates/bootstrap_mtc_api/src/lib.rs
+++ b/crates/bootstrap_mtc_api/src/lib.rs
@@ -174,6 +174,16 @@ impl LogEntry for BootstrapMtcLogEntry {
     const REQUIRE_CHECKPOINT_TIMESTAMP: bool = false;
     type Pending = BootstrapMtcPendingLogEntry;
     type ParseError = MtcError;
+    type Metadata = SequenceMetadata;
+
+    fn make_metadata(
+        leaf_index: LeafIndex,
+        timestamp: UnixTimestamp,
+        _old_tree_size: u64,
+        _new_tree_size: u64,
+    ) -> Self::Metadata {
+        (leaf_index, timestamp)
+    }
 
     fn initial_entry() -> Option<Self::Pending> {
         Some(Self::Pending {
@@ -184,7 +194,7 @@ impl LogEntry for BootstrapMtcLogEntry {
         })
     }
 
-    fn new(pending: Self::Pending, metadata: SequenceMetadata) -> Self {
+    fn new(pending: Self::Pending, metadata: Self::Metadata) -> Self {
         Self(TlogTilesLogEntry::new(pending.entry, metadata))
     }
 

--- a/crates/bootstrap_mtc_worker/src/batcher_do.rs
+++ b/crates/bootstrap_mtc_worker/src/batcher_do.rs
@@ -4,7 +4,7 @@ use generic_log_worker::{get_durable_object_name, BatcherConfig, GenericBatcher,
 use worker::*;
 
 #[durable_object(fetch)]
-struct Batcher(GenericBatcher);
+struct Batcher(GenericBatcher<tlog_tiles::SequenceMetadata>);
 
 impl DurableObject for Batcher {
     fn new(state: State, env: Env) -> Self {
@@ -25,7 +25,7 @@ impl DurableObject for Batcher {
             enable_dedup: false, // deduplication is not currently supported
             location_hint: params.location_hint.clone(),
         };
-        Batcher(GenericBatcher::new(state, env, config))
+        Batcher(GenericBatcher::<tlog_tiles::SequenceMetadata>::new(state, env, config))
     }
 
     async fn fetch(&self, req: Request) -> Result<Response> {

--- a/crates/bootstrap_mtc_worker/src/sequencer_do.rs
+++ b/crates/bootstrap_mtc_worker/src/sequencer_do.rs
@@ -86,7 +86,7 @@ fn checkpoint_callback(env: &Env, name: &str) -> CheckpointCallbacker {
     let params = &CONFIG.logs[name];
     let bucket = load_public_bucket(env, name).unwrap();
     Box::new(
-        move |old_time: UnixTimestamp, new_time: UnixTimestamp, new_checkpoint_bytes: &[u8]| {
+        move |old_time: UnixTimestamp, new_time: UnixTimestamp, _old_tree_size: u64, _new_tree_size: u64, new_checkpoint_bytes: &[u8]| {
             let new_checkpoint = {
                 // TODO: Make more efficient. There are two unnecessary allocations here.
 

--- a/crates/ct_worker/src/batcher_do.rs
+++ b/crates/ct_worker/src/batcher_do.rs
@@ -4,7 +4,7 @@ use generic_log_worker::{get_durable_object_name, BatcherConfig, GenericBatcher,
 use worker::*;
 
 #[durable_object(fetch)]
-struct Batcher(GenericBatcher);
+struct Batcher(GenericBatcher<tlog_tiles::SequenceMetadata>);
 
 impl DurableObject for Batcher {
     fn new(state: State, env: Env) -> Self {
@@ -25,7 +25,7 @@ impl DurableObject for Batcher {
             enable_dedup: params.enable_dedup,
             location_hint: params.location_hint.clone(),
         };
-        Batcher(GenericBatcher::new(state, env, config))
+        Batcher(GenericBatcher::<tlog_tiles::SequenceMetadata>::new(state, env, config))
     }
 
     async fn fetch(&self, req: Request) -> Result<Response> {

--- a/crates/generic_log_worker/src/batcher_do.rs
+++ b/crates/generic_log_worker/src/batcher_do.rs
@@ -7,9 +7,10 @@
 //! Entries are assigned to Batcher shards with consistent hashing on the cache key.
 
 use crate::{
-    deserialize, get_durable_object_stub, load_cache_kv, obs, serialize, LookupKey,
-    SequenceMetadata, BATCH_ENDPOINT, ENTRY_ENDPOINT, SEQUENCER_BINDING,
+    deserialize, get_durable_object_stub, load_cache_kv, obs, serialize, CacheSerialize,
+    LookupKey, BATCH_ENDPOINT, ENTRY_ENDPOINT, SEQUENCER_BINDING,
 };
+use serde::{de::DeserializeOwned, Serialize};
 use base64::prelude::*;
 use futures_util::future::{join_all, select, Either};
 use std::{
@@ -23,12 +24,17 @@ use worker::kv::KvStore;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
-pub struct GenericBatcher {
+/// A Durable Object that buffers incoming log entries and submits them to the
+/// Sequencer in batches.
+///
+/// `M` is the sequence metadata type produced for each entry after sequencing
+/// (i.e., [`LogEntry::Metadata`](tlog_tiles::LogEntry::Metadata)).
+pub struct GenericBatcher<M> {
     env: Env,
     config: BatcherConfig,
     state: State,
     kv: Option<KvStore>,
-    batch: RefCell<Batch>,
+    batch: RefCell<Batch<M>>,
     in_flight: RefCell<usize>,
     processed: RefCell<usize>,
     wshim: Option<obs::Wshim>,
@@ -42,14 +48,15 @@ pub struct BatcherConfig {
     pub location_hint: Option<String>,
 }
 
-// A batch of entries to be submitted to the Sequencer together.
-struct Batch {
+// A batch of entries to be submitted to the Sequencer together. `M` is the
+// sequence metadata type returned to waiters once the batch is sequenced.
+struct Batch<M> {
     entries: Vec<PendingLogEntryBlob>,
     by_hash: HashSet<LookupKey>,
-    done: Sender<HashMap<LookupKey, SequenceMetadata>>,
+    done: Sender<HashMap<LookupKey, M>>,
 }
 
-impl Default for Batch {
+impl<M: Clone + Default> Default for Batch<M> {
     /// Returns a batch initialized with a watch channel.
     fn default() -> Self {
         Self {
@@ -60,7 +67,7 @@ impl Default for Batch {
     }
 }
 
-impl GenericBatcher {
+impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Default + Copy + 'static> GenericBatcher<M> {
     /// Returns a new batcher with the given config.
     ///
     /// # Panics
@@ -189,7 +196,7 @@ impl GenericBatcher {
     }
 }
 
-impl GenericBatcher {
+impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Default + Copy + 'static> GenericBatcher<M> {
     /// Submit the current pending batch to be sequenced.
     ///
     /// # Errors
@@ -217,8 +224,8 @@ impl GenericBatcher {
                 ..Default::default()
             },
         )?;
-        let sequenced_entries: HashMap<LookupKey, SequenceMetadata> =
-            deserialize::<Vec<(LookupKey, SequenceMetadata)>>(
+        let sequenced_entries: HashMap<LookupKey, M> =
+            deserialize::<Vec<(LookupKey, M)>>(
                 &get_durable_object_stub(
                     &self.env,
                     &self.config.name,
@@ -244,7 +251,7 @@ impl GenericBatcher {
                 .map(|(k, v)| {
                     Ok(kv
                         .put(&BASE64_STANDARD.encode(k), "")?
-                        .metadata::<SequenceMetadata>(v)?
+                        .metadata::<M>(v)?
                         .execute())
                 })
                 .collect::<Result<Vec<_>>>()?;

--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -16,7 +16,6 @@ pub use cleaner_do::*;
 pub use log_ops::upload_issuers;
 pub use sequencer_do::*;
 
-use byteorder::{BigEndian, WriteBytesExt};
 use log::{error, info};
 use log_ops::UploadOptions;
 use obs::metrics::{millis_diff_as_secs, AsF64, ObjectMetrics};
@@ -26,8 +25,12 @@ use sha2::{Digest, Sha256};
 use std::cell::RefCell;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashMap, VecDeque};
+
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use serde::de::DeserializeOwned;
 use std::io::Write;
-use tlog_tiles::{LookupKey, PendingLogEntry, SequenceMetadata};
+pub use tlog_tiles::LookupKey;
+use tlog_tiles::{PendingLogEntry, SequenceMetadata};
 use tokio::sync::Mutex;
 use util::now_millis;
 use worker::{
@@ -166,14 +169,17 @@ pub fn load_cache_kv(env: &Env, name: &str) -> Result<kv::KvStore> {
 /// # Errors
 ///
 /// Returns an error if there are issues retrieving the metadata.
-pub async fn get_cached_metadata(
+pub async fn get_cached_metadata<M>(
     kv: &KvStore,
     lookup_key: &LookupKey,
-) -> Result<Option<SequenceMetadata>> {
+) -> Result<Option<M>>
+where
+    M: Serialize + DeserializeOwned,
+{
     // Query the cache and return the entry metadata if it exists
     let metadata_opt = kv
         .get(&BASE64_STANDARD.encode(lookup_key))
-        .bytes_with_metadata::<SequenceMetadata>()
+        .bytes_with_metadata::<M>()
         .await?
         .1;
     Ok(metadata_opt)
@@ -186,40 +192,44 @@ pub async fn get_cached_metadata(
 ///
 /// Returns an error if either the KV namespace doesn't exist, or if there is an
 /// exception when writing the value.
-pub async fn put_cache_entry_metadata<L: PendingLogEntry>(
+pub async fn put_cache_entry_metadata<L, M>(
     kv: &KvStore,
     pending: &L,
-    metadata: SequenceMetadata,
-) -> Result<()> {
+    metadata: M,
+) -> Result<()>
+where
+    L: PendingLogEntry,
+    M: Serialize,
+{
     // Get the lookup key.
     let lookup_key = pending.lookup_key();
 
     // Store key => "", with metadata
     kv.put(&BASE64_STANDARD.encode(lookup_key), "")?
-        .metadata::<SequenceMetadata>(metadata)?
+        .metadata::<M>(metadata)?
         .execute()
         .await
         .map_err(Error::from)
 }
 
-trait CacheWrite {
+trait CacheWrite<M> {
     /// Put the provided sequenced entries into the cache. This does NOT overwrite existing entries.
-    async fn put_entries(&self, entries: &[(LookupKey, SequenceMetadata)]) -> Result<()>;
+    async fn put_entries(&self, entries: &[(LookupKey, M)]) -> Result<()>;
 }
 
-trait CacheRead {
+trait CacheRead<M> {
     /// Read an entry from the deduplication cache.
-    fn get_entry(&self, key: &LookupKey) -> Option<SequenceMetadata>;
+    fn get_entry(&self, key: &LookupKey) -> Option<M>;
 }
 
-struct DedupCache {
-    memory: MemoryCache,
+struct DedupCache<M> {
+    memory: MemoryCache<M>,
     storage: Storage,
 }
 
-impl CacheWrite for DedupCache {
+impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Copy + Default + 'static> CacheWrite<M> for DedupCache<M> {
     /// Write entries to both the short-term deduplication cache and its backup in DO Storage.
-    async fn put_entries(&self, entries: &[(LookupKey, SequenceMetadata)]) -> Result<()> {
+    async fn put_entries(&self, entries: &[(LookupKey, M)]) -> Result<()> {
         if entries.is_empty() {
             return Ok(());
         }
@@ -228,10 +238,10 @@ impl CacheWrite for DedupCache {
     }
 }
 
-impl CacheRead for DedupCache {
+impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Copy + Default + 'static> CacheRead<M> for DedupCache<M> {
     /// Check the short-term deduplication cache only. The long-term deduplication
     /// cache gets checked by the Worker frontend when handling add-chain requests.
-    fn get_entry(&self, key: &LookupKey) -> Option<SequenceMetadata> {
+    fn get_entry(&self, key: &LookupKey) -> Option<M> {
         self.memory.get_entry(key)
     }
 }
@@ -291,11 +301,15 @@ fn compute_cache_keys_to_load(head: u32, tail: u32, max_batches: u32) -> Vec<Str
     // Ensure we never load more than max_batches keys, even if head/tail are corrupted
     let delta = tail.saturating_sub(head).min(max_batches);
     (0..delta)
-        .map(|i| DedupCache::fifo_key((head.wrapping_add(i)) % max_batches))
+        .map(|i| dedup_cache_fifo_key((head.wrapping_add(i)) % max_batches))
         .collect()
 }
 
-impl DedupCache {
+fn dedup_cache_fifo_key(idx: u32) -> String {
+    format!("fifo:{idx}")
+}
+
+impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Copy + Default + 'static> DedupCache<M> {
     // Batches are written at most once per second, and we only need them to
     // deduplicate entries long enough for KV's eventual consistency guarantees
     // (~60s). Cap at 128 so we can use a single get_multiple call to get all
@@ -306,7 +320,7 @@ impl DedupCache {
     const FIFO_TAIL_KEY: &str = "fifo:tail";
 
     fn fifo_key(idx: u32) -> String {
-        format!("fifo:{idx}")
+        dedup_cache_fifo_key(idx)
     }
 
     // Load batches of cache entries from DO storage into the in-memory cache. log_name is the name
@@ -360,7 +374,7 @@ impl DedupCache {
     }
 
     // Store a batch of cache entries in DO storage.
-    async fn store(&self, entries: &[(LookupKey, SequenceMetadata)]) -> Result<()> {
+    async fn store(&self, entries: &[(LookupKey, M)]) -> Result<()> {
         // Get the head and tail of the dedup cache, picking 0 if uninitialized
         let head = self
             .storage
@@ -401,40 +415,99 @@ impl DedupCache {
     }
 }
 
-fn serialize_entries(entries: &[(LookupKey, SequenceMetadata)]) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(32 * entries.len());
-    for (k, (idx, ts)) in entries {
-        buf.write_all(k).unwrap();
-        buf.write_u64::<BigEndian>(*idx).unwrap();
-        buf.write_u64::<BigEndian>(*ts).unwrap();
-    }
-    buf
+/// Serialization format for the `DedupCache` DO storage ring buffer.
+///
+/// Each metadata type defines its own binary format so that the format can be
+/// kept stable across upgrades.  `SequenceMetadata` uses the original
+/// 32-bytes-per-entry binary format (16-byte key, 8-byte `leaf_index`,
+/// 8-byte `timestamp`, all big-endian); other types use `serde_json`.
+///
+/// **NOTE**: Changing this format for a deployed log will result in a `DedupCache::load`
+/// error during sequencer initialization. The sequencer's
+/// [current behavior](https://github.com/cloudflare/azul/blob/ddc4ec7c5432efed4cd5e4308f6026ffa91bc6f6/crates/generic_log_worker/src/sequencer_do.rs#L234)
+/// is to log the error and continue without the short-term deduplication cache.
+pub trait CacheSerialize: Sized {
+    /// Serialize a batch of `(LookupKey, Self)` pairs to bytes.
+    fn serialize_entries(entries: &[(LookupKey, Self)]) -> Vec<u8>;
+    /// Deserialize a batch of `(LookupKey, Self)` pairs from bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `String` describing the error if the bytes are malformed.
+    /// The `String` can be converted to a `worker::Error` via `From<String>`.
+    fn deserialize_entries(buf: &[u8]) -> std::result::Result<Vec<(LookupKey, Self)>, String>;
 }
 
-fn deserialize_entries(buf: &[u8]) -> Result<Vec<(LookupKey, SequenceMetadata)>> {
-    if !buf.len().is_multiple_of(32) {
-        return Err("invalid buffer length".into());
+/// `SequenceMetadata` uses the original 32-byte binary format for backward
+/// compatibility with existing Durable Object storage.
+impl CacheSerialize for SequenceMetadata {
+    fn serialize_entries(entries: &[(LookupKey, Self)]) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(32 * entries.len());
+        for (k, (idx, ts)) in entries {
+            buf.write_all(k).unwrap();
+            buf.write_u64::<BigEndian>(*idx).unwrap();
+            buf.write_u64::<BigEndian>(*ts).unwrap();
+        }
+        buf
     }
-    let mut entries = Vec::with_capacity(buf.len() / 32);
-    for i in 0..buf.len() / 32 {
-        let key: [u8; 16] = buf[i * 32..i * 32 + 16].try_into().unwrap();
-        let value = (
-            u64::from_be_bytes(buf[i * 32 + 16..i * 32 + 24].try_into().unwrap()),
-            u64::from_be_bytes(buf[i * 32 + 24..i * 32 + 32].try_into().unwrap()),
-        );
-        entries.push((key, value));
+
+    fn deserialize_entries(buf: &[u8]) -> std::result::Result<Vec<(LookupKey, Self)>, String> {
+        if !buf.len().is_multiple_of(32) {
+            return Err("invalid buffer length".into());
+        }
+        let mut entries = Vec::with_capacity(buf.len() / 32);
+        let mut cursor = std::io::Cursor::new(buf);
+        while usize::try_from(cursor.position()).unwrap_or(usize::MAX) < buf.len() {
+            let mut key = LookupKey::default();
+            std::io::Read::read_exact(&mut cursor, &mut key)
+                .map_err(|e| format!("reading key: {e}"))?;
+            let idx = cursor
+                .read_u64::<BigEndian>()
+                .map_err(|e| format!("reading `leaf_index`: {e}"))?;
+            let ts = cursor
+                .read_u64::<BigEndian>()
+                .map_err(|e| format!("reading `timestamp`: {e}"))?;
+            entries.push((key, (idx, ts)));
+        }
+        Ok(entries)
     }
-    Ok(entries)
 }
 
-// A fixed-size in-memory FIFO cache.
-struct MemoryCache {
+/// Implement `CacheSerialize` via `serde_json` for a given type.
+#[macro_export]
+macro_rules! impl_json_cache_serialize {
+    ($t:ty) => {
+        impl $crate::CacheSerialize for $t {
+            fn serialize_entries(entries: &[($crate::LookupKey, Self)]) -> Vec<u8> {
+                serde_json::to_vec(entries).expect("serializing cache entries to JSON")
+            }
+            fn deserialize_entries(
+                buf: &[u8],
+            ) -> ::std::result::Result<Vec<($crate::LookupKey, Self)>, String> {
+                serde_json::from_slice(buf)
+                    .map_err(|e| format!("deserializing cache entries: {e}"))
+            }
+        }
+    };
+}
+
+fn serialize_entries<M: CacheSerialize>(entries: &[(LookupKey, M)]) -> Vec<u8> {
+    M::serialize_entries(entries)
+}
+
+fn deserialize_entries<M: CacheSerialize>(buf: &[u8]) -> Result<Vec<(LookupKey, M)>> {
+    M::deserialize_entries(buf).map_err(Into::into)
+}
+
+// A fixed-size in-memory FIFO cache. `M` is the sequence metadata type stored
+// alongside each deduplicated entry's lookup key.
+struct MemoryCache<M> {
     max_size: usize,
-    map: RefCell<HashMap<LookupKey, SequenceMetadata>>,
+    map: RefCell<HashMap<LookupKey, M>>,
     fifo: RefCell<VecDeque<LookupKey>>,
 }
 
-impl MemoryCache {
+impl<M: Copy> MemoryCache<M> {
     fn new(max_size: usize) -> Self {
         assert_ne!(max_size, 0);
         Self {
@@ -445,13 +518,13 @@ impl MemoryCache {
     }
 
     // Get an entry from the in-memory cache.
-    fn get_entry(&self, key: &LookupKey) -> Option<SequenceMetadata> {
+    fn get_entry(&self, key: &LookupKey) -> Option<M> {
         self.map.borrow().get(key).copied()
     }
 
     // Put a batch of entries into the in-memory cache,
     // evicting old entries to make room if necessary.
-    fn put_entries(&self, entries: &[(LookupKey, SequenceMetadata)]) {
+    fn put_entries(&self, entries: &[(LookupKey, M)]) {
         let mut map = self.map.borrow_mut();
         let mut fifo = self.fifo.borrow_mut();
         for (key, value) in entries {
@@ -736,6 +809,13 @@ impl ObjectBackend for CachedRoObjectBucket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tlog_tiles::SequenceMetadata;
+
+    /// A minimal metadata type that uses the JSON cache format, for testing
+    /// `serialize_entries`/`deserialize_entries` with non-binary serialization.
+    #[derive(Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+    struct TestMetadata(u64);
+    impl_json_cache_serialize!(TestMetadata);
 
     // ==================== HeadTailValidation Tests ====================
 
@@ -883,21 +963,45 @@ mod tests {
     fn test_serialize_deserialize_empty() {
         let entries: Vec<(LookupKey, SequenceMetadata)> = vec![];
         let serialized = serialize_entries(&entries);
-        assert!(serialized.is_empty());
-        let deserialized = deserialize_entries(&serialized).unwrap();
+        let deserialized = deserialize_entries::<SequenceMetadata>(&serialized).unwrap();
         assert!(deserialized.is_empty());
     }
 
     #[test]
     fn test_deserialize_invalid_length() {
+        // SequenceMetadata uses the binary format (32 bytes per entry:
+        // 16-byte LookupKey + 8-byte leaf_index + 8-byte timestamp).
+        // A buffer that is not a multiple of 32 bytes should fail.
         let buf = vec![0u8; 31]; // Not a multiple of 32
-        assert!(deserialize_entries(&buf).is_err());
+        assert!(deserialize_entries::<SequenceMetadata>(&buf).is_err());
     }
 
     #[test]
     fn test_deserialize_invalid_length_one_extra() {
         let buf = vec![0u8; 33]; // 32 + 1
-        assert!(deserialize_entries(&buf).is_err());
+        assert!(deserialize_entries::<SequenceMetadata>(&buf).is_err());
+    }
+
+    #[test]
+    fn test_serialize_deserialize_json_roundtrip() {
+        // TestMetadata uses the JSON format; verify entries survive a serialize/deserialize cycle.
+        let key1 = LookupKey::from([1u8; 16]);
+        let key2 = LookupKey::from([2u8; 16]);
+        let entries = vec![(key1, TestMetadata(42)), (key2, TestMetadata(99))];
+        let serialized = serialize_entries(&entries);
+        let deserialized = deserialize_entries::<TestMetadata>(&serialized).unwrap();
+        assert_eq!(deserialized.len(), 2);
+        assert_eq!(deserialized[0].0, key1);
+        assert_eq!(deserialized[0].1 .0, 42);
+        assert_eq!(deserialized[1].0, key2);
+        assert_eq!(deserialized[1].1 .0, 99);
+    }
+
+    #[test]
+    fn test_deserialize_invalid_json() {
+        // TestMetadata uses the JSON format; invalid JSON should fail deserialization.
+        let buf = b"not valid json";
+        assert!(deserialize_entries::<TestMetadata>(buf).is_err());
     }
 
     // ==================== MemoryCache Tests ====================
@@ -974,9 +1078,41 @@ mod tests {
 
     #[test]
     fn test_fifo_key_generation() {
-        assert_eq!(DedupCache::fifo_key(0), "fifo:0");
-        assert_eq!(DedupCache::fifo_key(127), "fifo:127");
-        assert_eq!(DedupCache::fifo_key(128), "fifo:128");
-        assert_eq!(DedupCache::fifo_key(u32::MAX), format!("fifo:{}", u32::MAX));
+        assert_eq!(DedupCache::<SequenceMetadata>::fifo_key(0), "fifo:0");
+        assert_eq!(DedupCache::<SequenceMetadata>::fifo_key(127), "fifo:127");
+        assert_eq!(DedupCache::<SequenceMetadata>::fifo_key(128), "fifo:128");
+        assert_eq!(DedupCache::<SequenceMetadata>::fifo_key(u32::MAX), format!("fifo:{}", u32::MAX));
+    }
+
+    /// Regression test: confirm the `SequenceMetadata` binary wire format has
+    /// not changed.  Any change here would corrupt the dedup ring buffer in
+    /// Durable Object storage for deployed CT and bootstrap MTC workers.
+    ///
+    /// Format: `[16-byte key | 8-byte leaf_index BE | 8-byte timestamp BE]`
+    #[test]
+    fn test_sequence_metadata_cache_format_unchanged() {
+        let key: LookupKey = [
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        ];
+        let leaf_index: u64 = 0x0102030405060708;
+        let timestamp: u64  = 0x0a0b0c0d0e0f1011;
+
+        let entries: Vec<(LookupKey, SequenceMetadata)> = vec![(key, (leaf_index, timestamp))];
+        let serialized = serialize_entries(&entries);
+
+        // Manually construct the expected 32-byte buffer.
+        let mut expected = Vec::with_capacity(32);
+        expected.extend_from_slice(&key);
+        expected.extend_from_slice(&leaf_index.to_be_bytes());
+        expected.extend_from_slice(&timestamp.to_be_bytes());
+
+        assert_eq!(serialized, expected,
+            "SequenceMetadata binary format has changed — this will corrupt \
+             existing Durable Object dedup cache storage");
+
+        // Round-trip.
+        let deserialized = deserialize_entries::<SequenceMetadata>(&serialized).unwrap();
+        assert_eq!(deserialized, entries);
     }
 }

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -21,9 +21,9 @@
 use crate::{
     obs::metrics::{millis_diff_as_secs, AsF64, SequencerMetrics},
     util::now_millis,
-    CacheRead, CacheWrite, LockBackend, LookupKey, ObjectBackend, SequenceMetadata,
-    SequencerConfig,
+    CacheRead, CacheWrite, LockBackend, LookupKey, ObjectBackend, SequencerConfig,
 };
+use serde::de::DeserializeOwned;
 use anyhow::{anyhow, bail};
 use futures_util::future::try_join_all;
 use log::{debug, error, info, trace, warn};
@@ -31,6 +31,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use signed_note::VerifierList;
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::{
     cell::RefCell,
     cmp::{Ord, Ordering},
@@ -72,19 +73,19 @@ const MAX_POOL_SIZE: usize = 4000;
 /// they are rotated out of `in_sequencing`.
 /// <https://blog.cloudflare.com/durable-objects-easy-fast-correct-choose-three/#background-durable-objects-are-single-threaded>
 #[derive(Debug)]
-pub(crate) struct PoolState<P: PendingLogEntry> {
+pub(crate) struct PoolState<P: PendingLogEntry, M: Copy + Debug + Default + 'static> {
     // How many times sequencing has been skipped for any entries in the pool.
     sequence_skips: usize,
 
     // Entries that are ready to be sequenced, along with the Sender used to
     // send metadata to receivers once the corresponding entry is sequenced.
-    pending_entries: Vec<(P, Sender<SequenceMetadata>)>,
+    pending_entries: Vec<(P, Sender<M>)>,
 
     // Deduplication cache for entries currently pending sequencing.
-    pending_dedup: HashMap<LookupKey, Receiver<SequenceMetadata>>,
+    pending_dedup: HashMap<LookupKey, Receiver<M>>,
 
     // Deduplication cache for entries currently being sequenced.
-    in_sequencing_dedup: HashMap<LookupKey, Receiver<SequenceMetadata>>,
+    in_sequencing_dedup: HashMap<LookupKey, Receiver<M>>,
 
     // Ring buffer tracking insertion timestamps for the most recent entries
     // that are potentially skippable.
@@ -95,7 +96,7 @@ pub(crate) struct PoolState<P: PendingLogEntry> {
     leftover_timestamps_next_slot: usize,
 }
 
-impl<P: PendingLogEntry> Default for PoolState<P> {
+impl<P: PendingLogEntry, M: Copy + Debug + Default + 'static> Default for PoolState<P, M> {
     fn default() -> Self {
         PoolState {
             sequence_skips: 0,
@@ -108,10 +109,10 @@ impl<P: PendingLogEntry> Default for PoolState<P> {
     }
 }
 
-impl<E: PendingLogEntry> PoolState<E> {
+impl<E: PendingLogEntry, M: Serialize + DeserializeOwned + Copy + Debug + Default + 'static> PoolState<E, M> {
     // Check if the key is already in the pool. If so, return a Receiver from
     // which to read the entry metadata when it is sequenced.
-    fn check(&self, key: &LookupKey) -> Option<AddLeafResult> {
+    fn check(&self, key: &LookupKey) -> Option<AddLeafResult<M>> {
         if let Some(rx) = self.in_sequencing_dedup.get(key) {
             // Entry is being sequenced.
             Some(AddLeafResult::Pending {
@@ -128,11 +129,11 @@ impl<E: PendingLogEntry> PoolState<E> {
         }
     }
     // Add a new entry to the pool.
-    fn add(&mut self, key: LookupKey, entry: E) -> AddLeafResult {
+    fn add(&mut self, key: LookupKey, entry: E) -> AddLeafResult<M> {
         if self.pending_entries.len() >= MAX_POOL_SIZE {
             return AddLeafResult::RateLimited;
         }
-        let (tx, rx) = channel((0, 0));
+        let (tx, rx) = channel(M::default());
         self.pending_entries.push((entry, tx));
         self.pending_dedup.insert(key, rx.clone());
         self.leftover_timestamps_millis
@@ -158,7 +159,7 @@ impl<E: PendingLogEntry> PoolState<E> {
         old_size: u64,
         max_sequence_skips: usize,
         sequence_skip_threshold_millis: Option<u64>,
-    ) -> Option<Vec<(E, Sender<SequenceMetadata>)>> {
+    ) -> Option<Vec<(E, Sender<M>)>> {
         let new_size = old_size + self.pending_entries.len() as u64;
         let publishing_full_tile =
             new_size / u64::from(TlogTile::FULL_WIDTH) > old_size / u64::from(TlogTile::FULL_WIDTH);
@@ -657,19 +658,19 @@ async fn tile_reader_for_indexes(
 
 /// Result of an [`add_leaf_to_pool`] request containing either a cached log
 /// entry or a pending entry that must be resolved.
-pub(crate) enum AddLeafResult {
-    Cached(SequenceMetadata),
+pub(crate) enum AddLeafResult<M: Copy + 'static> {
+    Cached(M),
     Pending {
-        rx: Receiver<SequenceMetadata>,
+        rx: Receiver<M>,
         source: PendingSource,
     },
     RateLimited,
 }
 
-impl AddLeafResult {
+impl<M: Copy + 'static> AddLeafResult<M> {
     /// Resolve an `AddLeafResult` to a leaf entry, or None if the
     /// entry was not sequenced.
-    pub(crate) async fn resolve(self) -> Option<SequenceMetadata> {
+    pub(crate) async fn resolve(self) -> Option<M> {
         match self {
             AddLeafResult::Cached(entry) => Some(entry),
             AddLeafResult::Pending { mut rx, source: _ } => {
@@ -687,9 +688,9 @@ impl AddLeafResult {
 
     pub(crate) fn source(&self) -> &'static str {
         match self {
-            AddLeafResult::Cached(_) => "cache",
-            AddLeafResult::RateLimited => "ratelimit",
-            AddLeafResult::Pending { rx: _, source } => match source {
+            Self::Cached(_) => "cache",
+            Self::RateLimited => "ratelimit",
+            Self::Pending { rx: _, source } => match source {
                 PendingSource::InSequencing => "sequencing",
                 PendingSource::Pool => "pool",
                 PendingSource::Sequencer => "sequencer",
@@ -709,12 +710,16 @@ pub(crate) enum PendingSource {
 /// with a [`AddLeafResult::Cached`]. If the pool is full, return
 /// [`AddLeafResult::RateLimited`]. Otherwise, return a [`AddLeafResult::Pending`] which
 /// can be resolved once the entry has been sequenced.
-pub(crate) fn add_leaf_to_pool<E: PendingLogEntry>(
-    state: &RefCell<PoolState<E>>,
-    cache: &impl CacheRead,
+pub(crate) fn add_leaf_to_pool<E, M>(
+    state: &RefCell<PoolState<E, M>>,
+    cache: &impl CacheRead<M>,
     config: &SequencerConfig,
     entry: E,
-) -> AddLeafResult {
+) -> AddLeafResult<M>
+where
+    E: PendingLogEntry,
+    M: Serialize + DeserializeOwned + Copy + Debug + Default + 'static,
+{
     let hash = entry.lookup_key();
     let mut state = state.borrow_mut();
 
@@ -740,12 +745,12 @@ pub(crate) fn add_leaf_to_pool<E: PendingLogEntry>(
 /// Will return an error if sequencing fails with an error that requires the
 /// sequencer to be re-initialized to get into a good state.
 pub(crate) async fn sequence<L: LogEntry>(
-    pool_state: &RefCell<PoolState<L::Pending>>,
+    pool_state: &RefCell<PoolState<L::Pending, L::Metadata>>,
     sequence_state: &RefCell<SequenceState>,
     config: &SequencerConfig,
     object: &impl ObjectBackend,
     lock: &impl LockBackend,
-    cache: &impl CacheWrite,
+    cache: &impl CacheWrite<L::Metadata>,
     metrics: &SequencerMetrics,
 ) -> Result<(), anyhow::Error> {
     let Some(entries) = pool_state.borrow_mut().take(
@@ -816,8 +821,8 @@ async fn sequence_entries<L: LogEntry>(
     config: &SequencerConfig,
     object: &impl ObjectBackend,
     lock: &impl LockBackend,
-    cache: &impl CacheWrite,
-    entries: Vec<(L::Pending, Sender<SequenceMetadata>)>,
+    cache: &impl CacheWrite<L::Metadata>,
+    entries: Vec<(L::Pending, Sender<L::Metadata>)>,
     metrics: &SequencerMetrics,
 ) -> Result<(), SequenceError> {
     let name = &config.name;
@@ -853,6 +858,7 @@ async fn sequence_entries<L: LogEntry>(
 
     let mut overlay = HashMap::new();
     let mut n = old_size;
+    let new_size = old_size + entries.len() as u64;
     let mut sequenced_metadata = Vec::with_capacity(entries.len());
     let mut cache_metadata = Vec::with_capacity(entries.len());
 
@@ -863,8 +869,11 @@ async fn sequence_entries<L: LogEntry>(
             }
         }
 
-        // Add the entry and metadata to our lists of things sequenced
-        let metadata = (n, timestamp);
+        // Add the entry and metadata to our lists of things sequenced.
+        // L::make_metadata provides the application-specific metadata type,
+        // which may include leaf_index, timestamp, and the old and new sizes
+        // of the tree (for subtree inclusion proofs).
+        let metadata = L::make_metadata(n, timestamp, old_size, new_size);
         cache_metadata.push((entry.lookup_key(), metadata));
         sequenced_metadata.push((sender, metadata));
 
@@ -903,7 +912,7 @@ async fn sequence_entries<L: LogEntry>(
         n += 1;
 
         // If the data tile is full, stage it.
-        if n % u64::from(TlogTile::FULL_WIDTH) == 0 {
+        if n.is_multiple_of(u64::from(TlogTile::FULL_WIDTH)) {
             metrics
                 .seq_data_tile_size
                 .with_label_values(&["full"])
@@ -918,14 +927,16 @@ async fn sequence_entries<L: LogEntry>(
         }
     }
 
+    assert_eq!(n, new_size, "loop must have processed exactly entries.len() entries");
+
     // Stage leftover partial data tile, if any.
-    if n != old_size && n % u64::from(TlogTile::FULL_WIDTH) != 0 {
+    if new_size != old_size && !new_size.is_multiple_of(u64::from(TlogTile::FULL_WIDTH)) {
         metrics
             .seq_data_tile_size
             .with_label_values(&["partial"])
             .observe(data_tile.len().as_f64());
         stage_data_tile::<L>(
-            n,
+            new_size,
             &mut edge_tiles,
             &mut tile_uploads,
             std::mem::take(&mut data_tile),
@@ -934,7 +945,7 @@ async fn sequence_entries<L: LogEntry>(
     }
 
     // Produce and stage new tree tiles.
-    let tiles = TlogTile::new_tiles(old_size, n);
+    let tiles = TlogTile::new_tiles(old_size, new_size);
     for tile in tiles {
         let data = tile
             .read_data(&HashReaderWithOverlay {
@@ -951,7 +962,7 @@ async fn sequence_entries<L: LogEntry>(
                 || (t.tile.level_index() == tile.level_index() && t.tile.width() < tile.width())
         }) {
             debug!(
-                "{name}: staging tree tile: old_tree_size={old_size}, tree_size={n}, tile={tile:?}, size={}",
+                "{name}: staging tree tile: old_tree_size={old_size}, tree_size={new_size}, tile={tile:?}, size={}",
                 data.len()
             );
             edge_tiles.insert(
@@ -973,7 +984,7 @@ async fn sequence_entries<L: LogEntry>(
     // Construct the new sequence state.
     let new = {
         let tree = TreeWithTimestamp::from_hash_reader(
-            n,
+            new_size,
             &HashReaderWithOverlay {
                 edge_tiles: &edge_tiles,
                 overlay: &overlay,
@@ -1061,7 +1072,7 @@ async fn sequence_entries<L: LogEntry>(
 
     // Call the checkpoint callback. This is a no-op for CT, but is used to
     // update landmark checkpoints for MTC.
-    if let Err(e) = (config.checkpoint_callback)(old_time, timestamp, new.checkpoint()).await {
+    if let Err(e) = (config.checkpoint_callback)(old_time, timestamp, old_size, new_size, new.checkpoint()).await {
         warn!("{name}: Checkpoint callback failed: {e}");
     }
 
@@ -1069,8 +1080,8 @@ async fn sequence_entries<L: LogEntry>(
         trace!("{name}: Edge tile: {tile:?}");
     }
     debug!(
-        "{name}: Sequenced pool; tree_size={n}, entries: {}, tiles: {}, timestamp: {timestamp}, duration: {:.2}s, since_last: {:.2}s",
-        n - old_size,
+        "{name}: Sequenced pool; tree_size={new_size}, entries: {}, tiles: {}, timestamp: {timestamp}, duration: {:.2}s, since_last: {:.2}s",
+        new_size - old_size,
         tile_uploads.len(),
         millis_diff_as_secs(timestamp, now_millis()),
         millis_diff_as_secs(old_time, timestamp)
@@ -1083,7 +1094,7 @@ async fn sequence_entries<L: LogEntry>(
         .seq_delay
         .observe(millis_diff_as_secs(old_time, timestamp) - config.sequence_interval.as_secs_f64());
     metrics.seq_tiles.inc_by(tile_uploads.len().as_f64());
-    metrics.tree_size.set(n.as_f64());
+    metrics.tree_size.set(new_size.as_f64());
     metrics.tree_time.set(timestamp.as_f64() / 1000.0);
 
     Ok(())
@@ -1367,6 +1378,7 @@ pub async fn upload_issuers(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tlog_tiles::SequenceMetadata;
     use crate::{empty_checkpoint_callback, util};
 
     use anyhow::ensure;
@@ -2311,13 +2323,13 @@ mod tests {
 
     struct TestCacheBackend(RefCell<HashMap<LookupKey, SequenceMetadata>>);
 
-    impl CacheRead for TestCacheBackend {
+    impl CacheRead<SequenceMetadata> for TestCacheBackend {
         fn get_entry(&self, key: &LookupKey) -> Option<SequenceMetadata> {
             self.0.borrow().get(key).copied()
         }
     }
 
-    impl CacheWrite for TestCacheBackend {
+    impl CacheWrite<SequenceMetadata> for TestCacheBackend {
         async fn put_entries(
             &self,
             entries: &[(LookupKey, SequenceMetadata)],
@@ -2390,7 +2402,7 @@ mod tests {
 
     struct TestLog {
         config: SequencerConfig,
-        pool_state: RefCell<PoolState<StaticCTPendingLogEntry>>,
+        pool_state: RefCell<PoolState<StaticCTPendingLogEntry, SequenceMetadata>>,
         sequence_state: RefCell<SequenceState>,
         lock: TestLockBackend,
         object: TestObjectBackend,
@@ -2493,16 +2505,16 @@ mod tests {
             .unwrap();
             self.pool_state.borrow_mut().reset_in_sequencing_dedup();
         }
-        fn add_certificate(&mut self) -> AddLeafResult {
+        fn add_certificate(&mut self) -> AddLeafResult<SequenceMetadata> {
             self.add_certificate_with_seed(rand::thread_rng().next_u64())
         }
-        fn add_certificate_with_seed(&mut self, seed: u64) -> AddLeafResult {
+        fn add_certificate_with_seed(&mut self, seed: u64) -> AddLeafResult<SequenceMetadata> {
             self.add_with_seed(false, seed)
         }
-        fn add(&mut self, is_precert: bool) -> AddLeafResult {
+        fn add(&mut self, is_precert: bool) -> AddLeafResult<SequenceMetadata> {
             self.add_with_seed(is_precert, rand::thread_rng().next_u64())
         }
-        fn add_with_seed(&mut self, is_precert: bool, seed: u64) -> AddLeafResult {
+        fn add_with_seed(&mut self, is_precert: bool, seed: u64) -> AddLeafResult<SequenceMetadata> {
             let mut rng = SmallRng::seed_from_u64(seed);
             let mut certificate = vec![0; rng.gen_range(8..12)];
             rng.fill(&mut certificate[..]);

--- a/crates/generic_log_worker/src/sequencer_do.rs
+++ b/crates/generic_log_worker/src/sequencer_do.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     serialize,
     util::now_millis,
-    DedupCache, LookupKey, MemoryCache, ObjectBucket, SequenceMetadata, BATCH_ENDPOINT,
+    CacheSerialize, DedupCache, LookupKey, MemoryCache, ObjectBucket, BATCH_ENDPOINT,
     CLEANER_BINDING, ENTRY_ENDPOINT,
 };
 use futures_util::future::join_all;
@@ -33,12 +33,12 @@ const MEMORY_CACHE_SIZE: usize = 300_000;
 
 pub struct GenericSequencer<L: LogEntry> {
     env: Env,
-    do_state: State,                     // implements LockBackend
-    public_bucket: RwLock<ObjectBucket>, // implements ObjectBackend
-    cache: DedupCache,                   // implements CacheRead, CacheWrite
+    do_state: State,                                  // implements LockBackend
+    public_bucket: RwLock<ObjectBucket>,              // implements ObjectBackend
+    cache: DedupCache<L::Metadata>,                   // implements CacheRead, CacheWrite
     config: SequencerConfig,
     sequence_state: RefCell<SequenceState>,
-    pool_state: RefCell<PoolState<L::Pending>>,
+    pool_state: RefCell<PoolState<L::Pending, L::Metadata>>,
     initialized: RefCell<bool>,
     init_mux: Mutex<()>,
     wshim: Option<Wshim>,
@@ -62,7 +62,7 @@ pub struct SequencerConfig {
     pub env_label: String,
 }
 
-impl<L: LogEntry> GenericSequencer<L> {
+impl<L: LogEntry<Metadata: CacheSerialize>> GenericSequencer<L> {
     /// Return a new sequencer with the given config.
     ///
     /// # Panics
@@ -219,7 +219,7 @@ impl<L: LogEntry> GenericSequencer<L> {
     }
 }
 
-impl<L: LogEntry> GenericSequencer<L> {
+impl<L: LogEntry<Metadata: CacheSerialize>> GenericSequencer<L> {
     // Initialize the durable object when it is started on a new machine (e.g., after eviction or a deployment).
     async fn initialize(&self, metrics: &SequencerMetrics) -> Result<(), WorkerError> {
         // This can be triggered by the alarm() or fetch() handlers, so lock state to avoid a race condition.
@@ -313,7 +313,7 @@ impl<L: LogEntry> GenericSequencer<L> {
         &self,
         pending_entries: Vec<PendingLogEntryBlob>,
         metrics: &SequencerMetrics,
-    ) -> Result<Vec<(LookupKey, SequenceMetadata)>, WorkerError> {
+    ) -> Result<Vec<(LookupKey, L::Metadata)>, WorkerError> {
         // Safe to unwrap config here as the log must be initialized.
         let mut futures = Vec::with_capacity(pending_entries.len());
         let mut lookup_keys = Vec::with_capacity(pending_entries.len());
@@ -359,11 +359,15 @@ impl<L: LogEntry> GenericSequencer<L> {
 /// The parameters are as follows:
 /// - `old_time: UnixTimestamp`: The timestamp of the previous checkpoint.
 /// - `new_time: UnixTimestamp`: The timestamp of the latest checkpoint.
+/// - `old_tree_size: u64`: The tree size of the previous checkpoint.
+/// - `new_tree_size: u64`: The tree size of the latest checkpoint.
 /// - `new_checkpoint: &[u8]`: The latest checkpoint bytes. This is a signed note.
 pub type CheckpointCallbacker = Box<
     dyn Fn(
             UnixTimestamp,
             UnixTimestamp,
+            u64,
+            u64,
             &[u8],
         ) -> Pin<Box<dyn Future<Output = Result<(), WorkerError>> + 'static>>
         + 'static,
@@ -374,8 +378,10 @@ pub type CheckpointCallbacker = Box<
 #[must_use]
 pub fn empty_checkpoint_callback() -> CheckpointCallbacker {
     Box::new(
-        move |_old_time: UnixTimestamp, _new_time: UnixTimestamp, _new_checkpoint: &[u8]| {
-            Box::pin(async move { Ok(()) })
-        },
+        move |_old_time: UnixTimestamp,
+              _new_time: UnixTimestamp,
+              _old_tree_size: u64,
+              _new_tree_size: u64,
+              _new_checkpoint: &[u8]| { Box::pin(async move { Ok(()) }) },
     )
 }

--- a/crates/static_ct_api/src/static_ct.rs
+++ b/crates/static_ct_api/src/static_ct.rs
@@ -280,12 +280,22 @@ impl LogEntry for StaticCTLogEntry {
     const REQUIRE_CHECKPOINT_TIMESTAMP: bool = true;
     type Pending = StaticCTPendingLogEntry;
     type ParseError = StaticCTError;
+    type Metadata = SequenceMetadata;
+
+    fn make_metadata(
+        leaf_index: LeafIndex,
+        timestamp: UnixTimestamp,
+        _old_tree_size: u64,
+        _new_tree_size: u64,
+    ) -> Self::Metadata {
+        (leaf_index, timestamp)
+    }
 
     fn initial_entry() -> Option<Self::Pending> {
         None
     }
 
-    fn new(pending: StaticCTPendingLogEntry, metadata: SequenceMetadata) -> Self {
+    fn new(pending: StaticCTPendingLogEntry, metadata: Self::Metadata) -> Self {
         StaticCTLogEntry {
             inner: pending,
             leaf_index: metadata.0,

--- a/crates/tlog_tiles/src/entries.rs
+++ b/crates/tlog_tiles/src/entries.rs
@@ -1,7 +1,7 @@
 use length_prefixed::{ReadLengthPrefixedBytesExt, WriteLengthPrefixedBytesExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::{io::Read, marker::PhantomData};
+use std::{fmt::Debug, io::Read, marker::PhantomData};
 
 use crate::{Hash, PathElem, TlogError};
 
@@ -14,9 +14,13 @@ pub type UnixTimestamp = u64;
 /// Index of a leaf in the Merkle tree.
 pub type LeafIndex = u64;
 
-/// Metadata from sequencing that can optionally be incorporated into a
-/// `PendingLogEntry` to derive a `LogEntry`. This metadata is also transmitted
-/// from the sequencing backend to the frontend to return to the caller.
+/// Default sequence metadata type: `(LeafIndex, UnixTimestamp)`.
+///
+/// Used by all tlog applications that don't need tree-size information.
+/// Applications that need additional metadata (e.g. the IETF MTC worker, which
+/// needs `old_tree_size` and `new_tree_size` to compute subtree signature keys
+/// without enumeration) define their own type via the [`LogEntry::Metadata`]
+/// associated type.
 pub type SequenceMetadata = (LeafIndex, UnixTimestamp);
 
 /// An opaque `PendingLogEntry` that can be passed around without requiring full
@@ -56,12 +60,41 @@ pub trait LogEntry: core::fmt::Debug + Sized {
     /// The error type for [`Self::parse_from_tile_entry`]
     type ParseError: std::error::Error + Send + Sync + 'static;
 
+    /// The metadata produced by the sequencer for each entry.  Transmitted from
+    /// the sequencing backend to the frontend as the response to an `add-entry`
+    /// request.
+    ///
+    /// Most applications use the default [`SequenceMetadata`] = `(LeafIndex,
+    /// UnixTimestamp)`.  Applications that need additional sequencer-computed
+    /// values (e.g. tree sizes for subtree key lookup) define their own type.
+    type Metadata: Serialize
+        + DeserializeOwned
+        + Send
+        + Sync
+        + Clone
+        + Copy
+        + Debug
+        + Default
+        + 'static;
+
+    /// Construct a [`Self::Metadata`] value from the sequencer's raw output.
+    ///
+    /// Called once per entry at sequencing time.  The `SequenceMetadata`
+    /// implementation ignores `old_tree_size` and `new_tree_size`; other
+    /// implementations may use all four parameters.
+    fn make_metadata(
+        leaf_index: LeafIndex,
+        timestamp: UnixTimestamp,
+        old_tree_size: u64,
+        new_tree_size: u64,
+    ) -> Self::Metadata;
+
     /// Returns an optional initial entry to add into the log. This is used for
     /// the initial `null_entry` in Merkle Tree Certificates, but likely not
     /// useful anywhere else.
     fn initial_entry() -> Option<Self::Pending>;
 
-    fn new(pending: Self::Pending, metadata: SequenceMetadata) -> Self;
+    fn new(pending: Self::Pending, metadata: Self::Metadata) -> Self;
 
     /// Returns the Merkle tree leaf hash for this entry. For tlog-tiles, this is the Merkle Tree Hash
     /// (according to <https://datatracker.ietf.org/doc/html/rfc6962#section-2.1>)
@@ -155,12 +188,22 @@ impl LogEntry for TlogTilesLogEntry {
     const REQUIRE_CHECKPOINT_TIMESTAMP: bool = false;
     type Pending = TlogTilesPendingLogEntry;
     type ParseError = TlogError;
+    type Metadata = SequenceMetadata;
+
+    fn make_metadata(
+        leaf_index: LeafIndex,
+        timestamp: UnixTimestamp,
+        _old_tree_size: u64,
+        _new_tree_size: u64,
+    ) -> Self::Metadata {
+        (leaf_index, timestamp)
+    }
 
     fn initial_entry() -> Option<Self::Pending> {
         None
     }
 
-    fn new(pending: Self::Pending, _metadata: SequenceMetadata) -> Self {
+    fn new(pending: Self::Pending, _metadata: Self::Metadata) -> Self {
         Self { inner: pending }
     }
 


### PR DESCRIPTION
Adds a Metadata associated type to the LogEntry trait in tlog_tiles,
allowing each tlog application to define its own sequence metadata type
rather than sharing the fixed (LeafIndex, UnixTimestamp) tuple.

tlog_tiles:
- Adds LogEntry::Metadata: Serialize + DeserializeOwned + Copy + Default
- Adds LogEntry::make_metadata(leaf_index, timestamp, old_tree_size,
  new_tree_size) to construct the metadata from raw sequencer values
- TlogTilesLogEntry::Metadata = SequenceMetadata (unchanged behavior)
- SequenceMetadata type alias is preserved for backward compatibility

static_ct_api, bootstrap_mtc_api:
- Metadata = SequenceMetadata; make_metadata ignores tree sizes

generic_log_worker:
- All cache infrastructure (DedupCache, MemoryCache, CacheRead,
  CacheWrite) is now generic over M: the metadata type
- serialize_entries/deserialize_entries switched from fixed 32-byte
  binary format to serde_json (the binary format only worked for the
  fixed-size (u64, u64) tuple)
- PoolState<P, M>, AddLeafResult<M>, add_leaf_to_pool, sequence_entries,
  GenericSequencer, GenericBatcher all generified over M
- sequence_entries calls L::make_metadata(n, timestamp, old_size, new_size)
- Assert n == new_size after the sequencing loop
- CheckpointCallbacker gains old_tree_size and new_tree_size parameters
  so callbacks can identify which subtrees were covered by each batch
