### PR TITLE
Upgrade RustCrypto ecosystem to enable ml-dsa 0.1.0-rc.8

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: cargo build --verbose
+        run: cargo build --tests --workspace --verbose
 
   test:
     name: Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ npx wrangler -e=${ENV} tail
 - Worker build is handled by `worker-build`, not `cargo build` directly — wrangler.jsonc invokes it automatically
 - Config types live in separate sub-crates: `crates/ct_worker/config/`, `crates/bootstrap_mtc_worker/config/`
 - `DEPLOY_ENV=<env>` env var must be set when invoking `worker-build` manually; wrangler.jsonc sets it per environment
-- `der` crate is patched to a private fork in `Cargo.toml` `[patch.crates-io]` — do not remove or alter this
+
 
 ## Workflow
 
@@ -77,4 +77,4 @@ npx wrangler -e=${ENV} tail
 ✅ **Always:** Run `cargo clippy -- -D warnings` before pushing; CI fails on any warning
 ✅ **Always:** Add new shared dependencies to `[workspace.dependencies]` in root `Cargo.toml`
 ⚠️ **Requires Approval:** Publishing crates to crates.io (`tlog_tiles`, `static_ct_api`, `signed_note`, `signed_note`) — worker crates have `publish = false`
-🚫 **Never:** Remove or modify the `[patch.crates-io]` override for `der`; it points to a required fork
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -158,11 +158,11 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -198,7 +198,7 @@ dependencies = [
  "ed25519-dalek",
  "futures-executor",
  "generic_log_worker",
- "getrandom 0.2.16",
+ "getrandom 0.4.2",
  "itertools 0.14.0",
  "jsonschema",
  "log",
@@ -285,6 +285,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +362,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -393,10 +410,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef0c543070d296ea414df2dd7625d1b24866ce206709d8a4a424f28377f5861"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -470,24 +502,41 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
 dependencies = [
- "generic-array",
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
  "rand_core",
+ "serdect",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
- "generic-array",
- "typenum",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "rand_core",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
+dependencies = [
+ "crypto-bigint",
+ "libm",
+ "rand_core",
 ]
 
 [[package]]
@@ -523,7 +572,7 @@ dependencies = [
  "ed25519-dalek",
  "futures-executor",
  "generic_log_worker",
- "getrandom 0.2.16",
+ "getrandom 0.4.2",
  "itertools 0.14.0",
  "jsonschema",
  "log",
@@ -551,13 +600,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -614,8 +673,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
-source = "git+https://github.com/lukevalenta/formats?branch=relative-oid-tag-v0.7.10#895775339c03f7dc42529c131d578751406870a4"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid",
  "der_derive",
@@ -626,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -647,14 +707,14 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer",
  "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -676,9 +736,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "91bbdd377139884fafcad8dc43a760a3e1e681aa26db910257fa6535b70e1829"
 dependencies = [
  "der",
  "digest",
@@ -686,13 +746,14 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+ "zeroize",
 ]
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
 dependencies = [
  "pkcs8",
  "signature",
@@ -700,15 +761,16 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand_core",
  "serde",
  "sha2",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -721,20 +783,21 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.0-rc.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "7d7a0bfd012613a7bcfe02cbfccf2b846e9ef9e1bccb641c48d461253cfb034d"
 dependencies = [
  "base16ct",
  "crypto-bigint",
+ "crypto-common",
  "digest",
- "ff",
- "generic-array",
- "group",
- "hkdf",
+ "hybrid-array",
+ "once_cell",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
+ "rustcrypto-ff",
+ "rustcrypto-group",
  "sec1",
  "subtle",
  "zeroize",
@@ -792,20 +855,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -950,17 +1003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
-dependencies = [
- "typenum",
- "version_check",
- "zeroize",
-]
-
-[[package]]
 name = "generic_log_worker"
 version = "0.2.0"
 dependencies = [
@@ -969,6 +1011,7 @@ dependencies = [
  "bitcode",
  "byteorder",
  "console_log",
+ "crypto-common",
  "ed25519-dalek",
  "futures-executor",
  "futures-util",
@@ -999,10 +1042,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1013,8 +1054,24 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core",
+ "wasip2",
+ "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1022,17 +1079,6 @@ name = "glam"
 version = "0.30.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd47b05dddf0005d850e5644cae7f2b14ac3df487979dbfff3b56f20b1a6ae46"
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core",
- "subtle",
-]
 
 [[package]]
 name = "h2"
@@ -1088,6 +1134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,19 +1152,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
 ]
@@ -1156,6 +1199,17 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "subtle",
+ "typenum",
+ "zeroize",
+]
 
 [[package]]
 name = "hyper"
@@ -1343,6 +1397,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1462,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "const-oid",
+ "crypto-common",
  "der",
  "ed25519-dalek",
  "hex",
@@ -1526,9 +1587,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "length_prefixed"
@@ -1555,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1657,23 +1721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-cmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,7 +1779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -1799,39 +1845,42 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "44f0a10fe314869359cb2901342b045f4e5a962ef9febc006f03d2a8c848fe4c"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
  "sha2",
 ]
 
 [[package]]
 name = "p384"
-version = "0.13.1"
+version = "0.14.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+checksum = "b079e66810c55ab3d6ba424e056dc4aefcdb8046c8c3f3816142edbdd7af7721"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "fiat-crypto",
+ "primefield",
  "primeorder",
  "sha2",
 ]
 
 [[package]]
 name = "p521"
-version = "0.13.3"
+version = "0.14.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+checksum = "9eecc34c4c6e6596d5271fecf90ac4f16593fa198e77282214d0c22736aa9266"
 dependencies = [
  "base16ct",
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
- "rand_core",
  "sha2",
 ]
 
@@ -1860,9 +1909,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -1907,20 +1956,19 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.7.5"
+version = "0.8.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
 dependencies = [
  "der",
- "pkcs8",
  "spki",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
 dependencies = [
  "der",
  "spki",
@@ -1976,19 +2024,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
- "zerocopy",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6543f5eec854fbf74ba5ef651fbdc9408919b47c3e1526623687135c16d12e9"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common",
+ "rand_core",
+ "rustcrypto-ff",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "primeorder"
-version = "0.13.6"
+version = "0.14.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "569d9ad6ef822bb0322c7e7d84e5e286244050bd5246cac4c013535ae91c2c90"
 dependencies = [
  "elliptic-curve",
 ]
@@ -2053,34 +2116,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rayon"
@@ -2218,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.5.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "23a3127ee32baec36af75b4107082d9bd823501ec14a4e016be4b6b37faa74ae"
 dependencies = [
  "hmac",
  "subtle",
@@ -2242,22 +2298,20 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.10.0-rc.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "87ed3e93fc7e473e464b9726f4759659e72bc8665e4b8ea227547024f416d905"
 dependencies = [
  "const-oid",
+ "crypto-bigint",
+ "crypto-primes",
  "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core",
  "sha2",
  "signature",
  "spki",
- "subtle",
  "zeroize",
 ]
 
@@ -2268,6 +2322,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustcrypto-ff"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd2a8adb347447693cd2ba0d218c4b66c62da9b0a5672b17b981e4291ec65ff6"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "rustcrypto-group"
+version = "0.14.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f9b61aa45933c062c9f6b5c3c50ab710687eca83dd3802653b140b43f85ed"
+dependencies = [
+ "rand_core",
+ "rustcrypto-ff",
+ "subtle",
 ]
 
 [[package]]
@@ -2395,18 +2470,19 @@ dependencies = [
  "spki",
  "thiserror 2.0.17",
  "x509-cert",
+ "x509_util",
 ]
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
+ "ctutils",
  "der",
- "generic-array",
- "pkcs8",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -2548,24 +2624,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
+name = "serdect"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "digest",
 ]
 
@@ -2587,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
 dependencies = [
  "digest",
  "rand_core",
@@ -2642,16 +2728,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",
@@ -2757,7 +2837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2884,7 +2964,7 @@ name = "tlog_tiles_wasm"
 version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
- "getrandom 0.2.16",
+ "getrandom 0.4.2",
  "tlog_tiles",
  "wasm-bindgen",
 ]
@@ -3054,6 +3134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3147,7 +3233,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -3210,6 +3305,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.12.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,6 +3337,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.12.0",
+ "semver",
 ]
 
 [[package]]
@@ -3498,6 +3627,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.12.0",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.12.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.12.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "worker"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,9 +3780,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "x509-cert"
-version = "0.2.5"
+version = "0.3.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+checksum = "1e21aad3a769f25f3d2d0cbf30ea8b50a1d602354bd6ab687fad112821608ba6"
 dependencies = [
  "const-oid",
  "der",
@@ -3582,6 +3799,7 @@ dependencies = [
  "chrono",
  "const-oid",
  "der",
+ "digest",
  "p256",
  "p384",
  "p521",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,13 +72,21 @@ chrono = { version = "0.4", features = ["serde"] }
 console_error_panic_hook = "0.1.1"
 console_log = { version = "1.0" }
 criterion = { version = "0.5", features = ["html_reports"] }
+crypto-common = "0.2"
+digest = "0.11"
 csv = "1.3.1"
 generic_log_worker = { path = "crates/generic_log_worker", version = "0.2.0" }
-der = "0.7.10"
-ed25519-dalek = { version = "2.1.1", features = ["pem"] }
+der = { version = "0.8", features = ["oid"] }
+# NOTE: Several RustCrypto crates below are pinned to pre-release (RC/pre) versions.
+# These were required to unblock ml-dsa 0.1.0-rc.8 (WASM stack overflow fix).
+# The RustCrypto ecosystem releases these crates in a coordinated batch; once
+# stable releases are published, they should be upgraded together:
+#   ed25519-dalek, p256, p384, p521, rsa, signature, x509-cert, pkcs8
+# Track: https://github.com/RustCrypto/signatures/issues/1024
+ed25519-dalek = { version = "3.0.0-pre.6", features = ["pem"] }
 futures-executor = "0.3.31"
 futures-util = "0.3.31"
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
 hex = "0.4"
 itertools = "0.14.0"
 jsonschema = "0.30"
@@ -86,21 +94,21 @@ length_prefixed = { path = "crates/length_prefixed" }
 libfuzzer-sys = "0.4"
 log = { version = "0.4" }
 bootstrap_mtc_api = { version = "0.2.0", path = "crates/bootstrap_mtc_api" }
-p256 = { version = "0.13", features = ["ecdsa"] }
-p384 = { version = "0.13", features = ["ecdsa"] }
-p521 = { version = "0.13", features = ["ecdsa"] }
+p256 = { version = "0.14.0-rc.8", features = ["ecdsa"] }
+p384 = { version = "0.14.0-rc.8", features = ["ecdsa"] }
+p521 = { version = "0.14.0-rc.8", features = ["ecdsa"] }
 parking_lot = "0.12"
 prometheus = "0.14"
-rand = "0.8.5"
-rand_core = "0.6.4"
+rand = "0.10"
+rand_core = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11"
 serde_json = "1.0"
 serde_with = { version = "3.9.0", features = ["base64"] }
-sha1 = { version = "0.10", features = ["oid"] }
-sha2 = "0.10"
-signature = "2.2.0"
+sha1 = { version = "0.11", features = ["oid"] }
+sha2 = "0.11"
+signature = "3.0.0-rc.10"
 signed_note = { path = "crates/signed_note", version = "0.2.0" }
 static_ct_api = { path = "crates/static_ct_api", version = "0.2.0" }
 thiserror = "2.0"
@@ -110,16 +118,14 @@ reqwest = { version = "0.12", features = ["json"] }
 url = "2.2"
 wasm-bindgen = "0.2"
 worker = "0.7.4"
-x509-cert = "0.2.5"
+x509-cert = "0.3.0-rc.4"
 
 x509_util = { path = "crates/x509_util" }
 sct_validator = { path = "crates/sct_validator" }
 
 # sct_validator dependencies
-rsa = { version = "0.9", default-features = false, features = ["sha2"] }
+rsa = { version = "0.10.0-rc.17", default-features = false, features = ["sha2", "encoding"] }
 hashbrown = "0.15"
-spki = "0.7"
-const-oid = "0.9.6"
-
-[patch.crates-io]
-der = { git = "https://github.com/lukevalenta/formats", branch = "relative-oid-tag-v0.7.10" }
+spki = "0.8"
+const-oid = "0.10"
+pkcs8 = { version = "0.11.0-rc.11", features = ["pem"] }

--- a/crates/bootstrap_mtc_api/src/cosigner.rs
+++ b/crates/bootstrap_mtc_api/src/cosigner.rs
@@ -242,19 +242,17 @@ mod tests {
     use tlog_tiles::{open_checkpoint, record_hash, TreeWithTimestamp};
 
     use super::*;
-    use rand::rngs::OsRng;
     use signed_note::VerifierList;
     use std::str::FromStr;
 
     #[test]
     fn test_cosignature_v1_sign_verify() {
-        let mut rng = OsRng;
-
         let origin = "example.com/origin";
         let timestamp = 100;
         let tree_size = 4;
 
         // Make a tree head and sign it
+        let mut rng = rand::rng();
         let tree = TreeWithTimestamp::new(tree_size, record_hash(b"hello world"), timestamp);
         let signer = {
             let sk = Ed25519SigningKey::generate(&mut rng);

--- a/crates/bootstrap_mtc_api/src/lib.rs
+++ b/crates/bootstrap_mtc_api/src/lib.rs
@@ -235,12 +235,12 @@ pub fn serialize_signatureless_cert(
     if spki_hash != entry.subject_public_key_info_hash {
         return Err(MtcError::Dynamic("spki hash mismatch".to_string()));
     }
-    let signature_algorithm = AlgorithmIdentifier {
+    let signature_algorithm: AlgorithmIdentifier<Any> = AlgorithmIdentifier {
         oid: ID_ALG_MTCPROOF,
         parameters: None,
     };
 
-    let tbs_certificate = TbsCertificate {
+    let tbs_certificate = x509_util::OwnedTbsCertificate {
         version: entry.version,
         serial_number: SerialNumber::new(&leaf_index.to_be_bytes())?,
         signature: signature_algorithm.clone(),
@@ -252,7 +252,7 @@ pub fn serialize_signatureless_cert(
         subject_unique_id: entry.subject_unique_id,
         extensions: entry.extensions,
     };
-    let certificate = Certificate {
+    let certificate = x509_util::OwnedCertificate {
         tbs_certificate,
         signature_algorithm,
         signature: BitString::from_bytes(
@@ -481,17 +481,17 @@ fn filter_extensions(extensions: &mut Vec<Extension>) -> Result<(), MtcError> {
 /// Errors if the bootstrap certificate contains unsupported fields or
 /// extensions.
 pub fn tbs_cert_to_log_entry(
-    bootstrap: TbsCertificate,
-    issuer: RdnSequence,
+    bootstrap: &TbsCertificate,
+    issuer: &RdnSequence,
     validity: Validity,
 ) -> Result<TbsCertificateLogEntry, MtcError> {
-    if bootstrap.version != Version::V3 {
+    if bootstrap.version() != Version::V3 {
         return Err(MtcError::Dynamic("bootstrap version must be v3".into()));
     }
     if validity
         .not_before
         .to_unix_duration()
-        .lt(&bootstrap.validity.not_before.to_unix_duration())
+        .lt(&bootstrap.validity().not_before.to_unix_duration())
     {
         return Err(MtcError::Dynamic(
             "entry not_before must not be less than bootstrap not_before".into(),
@@ -500,30 +500,34 @@ pub fn tbs_cert_to_log_entry(
     if validity
         .not_after
         .to_unix_duration()
-        .gt(&bootstrap.validity.not_after.to_unix_duration())
+        .gt(&bootstrap.validity().not_after.to_unix_duration())
     {
         return Err(MtcError::Dynamic(
             "entry not_after must not be greater than bootstrap not_after".into(),
         ));
     }
 
-    let extensions = if let Some(mut bootstrap_extensions) = bootstrap.extensions {
-        filter_extensions(&mut bootstrap_extensions)?;
-        Some(bootstrap_extensions)
+    let extensions = if let Some(bootstrap_extensions) = bootstrap.extensions() {
+        let mut exts = bootstrap_extensions.clone();
+        filter_extensions(&mut exts)?;
+        Some(exts)
     } else {
         None
     };
 
+    // Convert RdnSequence → Name via DER round-trip (Name is a newtype over RdnSequence).
+    let issuer = Name::from_der(&issuer.to_der()?)?;
+
     Ok(TbsCertificateLogEntry {
-        version: bootstrap.version,
+        version: bootstrap.version(),
         issuer,
         validity,
-        subject: bootstrap.subject,
+        subject: bootstrap.subject().clone(),
         subject_public_key_info_hash: OctetString::new(
-            &Sha256::digest(bootstrap.subject_public_key_info.to_der()?)[..],
+            &Sha256::digest(bootstrap.subject_public_key_info().to_der()?)[..],
         )?,
-        issuer_unique_id: bootstrap.issuer_unique_id,
-        subject_unique_id: bootstrap.subject_unique_id,
+        issuer_unique_id: bootstrap.issuer_unique_id().clone(),
+        subject_unique_id: bootstrap.subject_unique_id().clone(),
         extensions,
     })
 }
@@ -542,24 +546,24 @@ pub fn validate_correspondence(
 ) -> Result<(), MtcError> {
     // We will run ordinary chain validation on the given chain. After, we will do additional
     // validation, expressed in the below closure.
-    let validator_hook = |leaf: Certificate,
+    let validator_hook = |bootstrap: Certificate,
                           chain_certs: Vec<&Certificate>,
                           _chain_fingerprints: Vec<[u8; 32]>,
                           _found_root_idx: Option<usize>|
      -> Result<(), MtcError> {
-        let bootstrap = leaf.tbs_certificate.clone();
-
-        if !(log_entry.version == bootstrap.version && log_entry.version == Version::V3) {
+        if !(log_entry.version == bootstrap.tbs_certificate().version()
+            && log_entry.version == Version::V3)
+        {
             return Err(MtcError::Dynamic(
                 "entry and bootstrap versions must be v3".into(),
             ));
         }
         // Make sure the validity is contained within the validity of every cert in
         // the chain.
-        for cert in core::iter::once(&leaf).chain(chain_certs) {
+        for cert in core::iter::once(&bootstrap).chain(chain_certs) {
             if log_entry.validity.not_before.to_unix_duration().lt(&cert
-                .tbs_certificate
-                .validity
+                .tbs_certificate()
+                .validity()
                 .not_before
                 .to_unix_duration())
             {
@@ -568,8 +572,8 @@ pub fn validate_correspondence(
                 ));
             }
             if log_entry.validity.not_after.to_unix_duration().gt(&cert
-                .tbs_certificate
-                .validity
+                .tbs_certificate()
+                .validity()
                 .not_after
                 .to_unix_duration())
             {
@@ -579,41 +583,50 @@ pub fn validate_correspondence(
                 ));
             }
         }
-        if log_entry.subject != bootstrap.subject {
+        if log_entry.subject != *bootstrap.tbs_certificate().subject() {
             return Err(MtcError::Dynamic(
                 "entry subject must match bootstrap subject".into(),
             ));
         }
         if log_entry.subject_public_key_info_hash
-            != OctetString::new(&Sha256::digest(bootstrap.subject_public_key_info.to_der()?)[..])?
+            != OctetString::new(
+                &Sha256::digest(
+                    bootstrap
+                        .tbs_certificate()
+                        .subject_public_key_info()
+                        .to_der()?,
+                )[..],
+            )?
         {
             return Err(MtcError::Dynamic(
                 "entry spki hash must match hash of bootstrap spki".into(),
             ));
         }
-        if log_entry.issuer_unique_id != bootstrap.issuer_unique_id {
+        if log_entry.issuer_unique_id != *bootstrap.tbs_certificate().issuer_unique_id() {
             return Err(MtcError::Dynamic(
                 "entry issuer unique ID must match bootstrap issuer unique ID".into(),
             ));
         }
-        if log_entry.subject_unique_id != bootstrap.subject_unique_id {
+        if log_entry.subject_unique_id != *bootstrap.tbs_certificate().subject_unique_id() {
             return Err(MtcError::Dynamic(
                 "entry subject unique ID must match bootstrap subject unique ID".into(),
             ));
         }
 
-        let (log_entry_extensions, mut bootstrap_extensions) =
-            match (&log_entry.extensions, bootstrap.extensions) {
-                // If no extensions in either entry or bootstrap, we're done.
-                (None, None) => return Ok(()),
-                // If mismatched, that's an error.
-                (Some(_), None) | (None, Some(_)) => {
-                    return Err(MtcError::Dynamic("mismatched extensions".into()))
-                }
-                // Otherwise both the log entry and bootstrap cert have
-                // extensions. Check them below.
-                (Some(log_ext), Some(boot_ext)) => (log_ext, boot_ext),
-            };
+        let (log_entry_extensions, mut bootstrap_extensions) = match (
+            &log_entry.extensions,
+            bootstrap.tbs_certificate().extensions().cloned(),
+        ) {
+            // If no extensions in either entry or bootstrap, we're done.
+            (None, None) => return Ok(()),
+            // If mismatched, that's an error.
+            (Some(_), None) | (None, Some(_)) => {
+                return Err(MtcError::Dynamic("mismatched extensions".into()))
+            }
+            // Otherwise both the log entry and bootstrap cert have
+            // extensions. Check them below.
+            (Some(log_ext), Some(boot_ext)) => (log_ext, boot_ext),
+        };
 
         // Check and filter bootstrap extensions.
         filter_extensions(&mut bootstrap_extensions)?;
@@ -708,7 +721,7 @@ pub fn validate_correspondence(
 pub fn validate_chain(
     raw_chain: &[Vec<u8>],
     roots: &CertPool,
-    issuer: RdnSequence,
+    issuer: &RdnSequence,
     validity: &mut Validity,
 ) -> Result<(BootstrapMtcPendingLogEntry, Option<usize>), MtcError> {
     // We will run the ordinary chain validation on our input, but we have some post-processing we
@@ -722,20 +735,20 @@ pub fn validate_chain(
         // all certificates in the chain.
         for cert in std::iter::once(&leaf).chain(chain_certs) {
             if validity.not_before.to_unix_duration().lt(&cert
-                .tbs_certificate
-                .validity
+                .tbs_certificate()
+                .validity()
                 .not_before
                 .to_unix_duration())
             {
-                validity.not_before = cert.tbs_certificate.validity.not_before;
+                validity.not_before = cert.tbs_certificate().validity().not_before;
             }
             if validity.not_after.to_unix_duration().gt(&cert
-                .tbs_certificate
-                .validity
+                .tbs_certificate()
+                .validity()
                 .not_after
                 .to_unix_duration())
             {
-                validity.not_after = cert.tbs_certificate.validity.not_after;
+                validity.not_after = cert.tbs_certificate().validity().not_after;
             }
             // Check that we still have a non-empty validity period.
             if validity
@@ -764,7 +777,7 @@ pub fn validate_chain(
             bootstrap: bootstrap_tile_entry,
             entry: TlogTilesPendingLogEntry {
                 data: MerkleTreeCertEntry::TbsCertEntry(tbs_cert_to_log_entry(
-                    leaf.tbs_certificate,
+                    leaf.tbs_certificate(),
                     issuer,
                     *validity,
                 )?)
@@ -818,19 +831,14 @@ mod tests {
         ))
         .unwrap();
 
-        let validity = Validity {
-            not_before: Time::UtcTime(
-                UtcTime::from_unix_duration(Duration::from_secs(1_518_521_919)).unwrap(),
-            ),
-            not_after: Time::UtcTime(
-                UtcTime::from_unix_duration(Duration::from_secs(1_743_161_919)).unwrap(),
-            ),
-        };
+        let validity = Validity::new(
+            Time::UtcTime(UtcTime::from_unix_duration(Duration::from_secs(1_518_521_919)).unwrap()),
+            Time::UtcTime(UtcTime::from_unix_duration(Duration::from_secs(1_743_161_919)).unwrap()),
+        );
 
         let mut log_entry = {
-            let bootstrap = &bootstrap_chain[0].tbs_certificate;
             let issuer = RdnSequence::default();
-            tbs_cert_to_log_entry(bootstrap.clone(), issuer, validity).unwrap()
+            tbs_cert_to_log_entry(bootstrap_chain[0].tbs_certificate(), &issuer, validity).unwrap()
         };
 
         // Valid.
@@ -876,23 +884,118 @@ mod tests {
     }
 
     #[test]
+    fn test_serialize_signatureless_cert() {
+        use der::Decode as _;
+        use tlog_tiles::{Proof, Subtree, TlogTilesLogEntry, TlogTilesPendingLogEntry};
+
+        let certs =
+            Certificate::load_pem_chain(include_bytes!("../../static_ct_api/tests/leaf-cert.pem"))
+                .unwrap();
+        let cert = &certs[0];
+        let tbs = cert.tbs_certificate();
+        let issuer = RdnSequence::default();
+        let validity = Validity::new(
+            Time::UtcTime(UtcTime::from_unix_duration(Duration::from_secs(1_518_521_919)).unwrap()),
+            Time::UtcTime(UtcTime::from_unix_duration(Duration::from_secs(1_743_161_919)).unwrap()),
+        );
+        let log_entry = tbs_cert_to_log_entry(tbs, &issuer, validity).unwrap();
+        let spki_der = tbs.subject_public_key_info().to_der().unwrap();
+
+        // Construct a BootstrapMtcLogEntry wrapping the log entry.
+        let mtc_entry = MerkleTreeCertEntry::TbsCertEntry(log_entry);
+        let bootstrap_log_entry = BootstrapMtcLogEntry(TlogTilesLogEntry {
+            inner: TlogTilesPendingLogEntry {
+                data: mtc_entry.encode().unwrap(),
+            },
+        });
+
+        let leaf_index: LeafIndex = 42;
+        let subtree = Subtree::new(0, 64).unwrap();
+        let proof: Proof = vec![];
+
+        let cert_der = serialize_signatureless_cert(
+            &bootstrap_log_entry,
+            leaf_index,
+            &spki_der,
+            &subtree,
+            proof,
+        )
+        .unwrap();
+
+        // Parse the output as a Certificate and verify key fields.
+        let out = Certificate::from_der(&cert_der).unwrap();
+        let out_tbs = out.tbs_certificate();
+
+        // Serial number must equal leaf_index encoded as big-endian bytes.
+        // Leading zeros may differ due to DER integer sign-bit encoding.
+        let trim_leading_zeros =
+            |b: &[u8]| -> Vec<u8> { b.iter().copied().skip_while(|&x| x == 0).collect() };
+        assert_eq!(
+            trim_leading_zeros(out_tbs.serial_number().as_bytes()),
+            trim_leading_zeros(&leaf_index.to_be_bytes()),
+            "serial_number must encode leaf_index"
+        );
+
+        // Signature algorithm must be id-alg-mtcproof.
+        assert_eq!(
+            out_tbs.signature().oid,
+            ID_ALG_MTCPROOF,
+            "signature algorithm must be id-alg-mtcproof"
+        );
+
+        // Subject must match the original cert's subject.
+        assert_eq!(out_tbs.subject(), tbs.subject(), "subject must round-trip");
+
+        // SPKI in the output must match the input spki_der.
+        assert_eq!(
+            out_tbs.subject_public_key_info().to_der().unwrap(),
+            spki_der,
+            "subject_public_key_info must round-trip"
+        );
+
+        // Verify the issuer is encoded (empty RdnSequence → Name with no RDNs).
+        // This exercises the Name→issuer round-trip via DER.
+        let issuer_der = out_tbs.issuer().to_der().unwrap();
+        let expected_issuer_der = Name::from_der(&RdnSequence::default().to_der().unwrap())
+            .unwrap()
+            .to_der()
+            .unwrap();
+        assert_eq!(
+            issuer_der, expected_issuer_der,
+            "issuer must encode correctly"
+        );
+
+        // Validity must match what we passed in.
+        assert_eq!(
+            out_tbs.validity().not_before.to_unix_duration().as_secs(),
+            1_518_521_919,
+            "not_before must round-trip"
+        );
+        assert_eq!(
+            out_tbs.validity().not_after.to_unix_duration().as_secs(),
+            1_743_161_919,
+            "not_after must round-trip"
+        );
+
+        // Unique IDs: the source cert has none, so the output should have none.
+        assert!(out_tbs.issuer_unique_id().is_none());
+        assert!(out_tbs.subject_unique_id().is_none());
+    }
+
+    #[test]
     fn test_encode() {
         let certs =
             Certificate::load_pem_chain(include_bytes!("../../static_ct_api/tests/leaf-cert.pem"))
                 .unwrap();
-        let bootstrap = &certs[0].tbs_certificate;
         let issuer = RdnSequence::default();
 
-        let validity = Validity {
-            not_before: Time::UtcTime(
-                UtcTime::from_unix_duration(Duration::from_secs(1_518_521_919)).unwrap(),
-            ),
-            not_after: Time::UtcTime(
-                UtcTime::from_unix_duration(Duration::from_secs(1_743_161_919)).unwrap(),
-            ),
-        };
+        let validity = Validity::new(
+            Time::UtcTime(UtcTime::from_unix_duration(Duration::from_secs(1_518_521_919)).unwrap()),
+            Time::UtcTime(UtcTime::from_unix_duration(Duration::from_secs(1_743_161_919)).unwrap()),
+        );
 
-        let log_entry = tbs_cert_to_log_entry(bootstrap.clone(), issuer, validity).unwrap();
+        let log_entry =
+            tbs_cert_to_log_entry(certs[0].tbs_certificate(), &issuer, validity).unwrap();
         let decoded = TbsCertificateLogEntry::from_der(&log_entry.to_der().unwrap()).unwrap();
 
         assert_eq!(log_entry, decoded);

--- a/crates/bootstrap_mtc_worker/Cargo.toml
+++ b/crates/bootstrap_mtc_worker/Cargo.toml
@@ -37,7 +37,7 @@ x509-cert.workspace = true
 der.workspace = true
 
 [dev-dependencies]
-rand = { workspace = true, features = ["small_rng"] }
+rand.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
 futures-executor.workspace = true

--- a/crates/bootstrap_mtc_worker/build.rs
+++ b/crates/bootstrap_mtc_worker/build.rs
@@ -3,10 +3,10 @@
 
 // Build script to include per-environment configuration and trusted roots.
 
+use bootstrap_mtc_api::ID_RDNA_TRUSTANCHOR_ID;
 use config::AppConfig;
 use der::asn1::Utf8StringRef;
-use der::{asn1::SetOfVec, Any, Tag};
-use bootstrap_mtc_api::ID_RDNA_TRUSTANCHOR_ID;
+use der::{Any, Tag};
 use std::env;
 use std::fs;
 use url::Url;
@@ -39,17 +39,17 @@ fn main() {
     });
     for (name, params) in conf.logs {
         // Make sure we can create the RDN sequence for the issuer log ID.
-        let _ = RdnSequence::from(vec![RelativeDistinguishedName(
-            SetOfVec::from_iter([AttributeTypeAndValue {
+        let _ = RdnSequence::from(vec![RelativeDistinguishedName::try_from(vec![
+            AttributeTypeAndValue {
                 oid: ID_RDNA_TRUSTANCHOR_ID,
                 value: Any::new(
                     Tag::Utf8String,
                     Utf8StringRef::new(&params.log_id).unwrap().as_bytes(),
                 )
                 .unwrap(),
-            }])
-            .unwrap(),
-        )]);
+            },
+        ])
+        .unwrap()]);
 
         // Valid location hints: https://developers.cloudflare.com/durable-objects/reference/data-location/#supported-locations-1
         if let Some(location) = &params.location_hint {

--- a/crates/bootstrap_mtc_worker/src/batcher_do.rs
+++ b/crates/bootstrap_mtc_worker/src/batcher_do.rs
@@ -25,7 +25,7 @@ impl DurableObject for Batcher {
             enable_dedup: false, // deduplication is not currently supported
             location_hint: params.location_hint.clone(),
         };
-        Batcher(GenericBatcher::<tlog_tiles::SequenceMetadata>::new(state, env, config))
+        Batcher(GenericBatcher::new(state, env, config))
     }
 
     async fn fetch(&self, req: Request) -> Result<Response> {

--- a/crates/bootstrap_mtc_worker/src/ccadb_roots_cron.rs
+++ b/crates/bootstrap_mtc_worker/src/ccadb_roots_cron.rs
@@ -78,7 +78,7 @@ pub(crate) async fn update_ccadb_roots(kv: &KvStore) -> Result<()> {
         write!(
             &mut buf,
             "\n# {}\n# added on {} from CCADB\n{}\n",
-            cert.tbs_certificate.subject,
+            cert.tbs_certificate().subject(),
             DateTime::from_timestamp_millis(
                 now_millis()
                     .try_into()

--- a/crates/bootstrap_mtc_worker/src/frontend_worker.rs
+++ b/crates/bootstrap_mtc_worker/src/frontend_worker.rs
@@ -5,7 +5,7 @@
 
 use crate::{load_checkpoint_cosigner, load_origin, load_roots, SequenceMetadata, CONFIG};
 use der::{
-    asn1::{SetOfVec, UtcTime, Utf8StringRef},
+    asn1::{UtcTime, Utf8StringRef},
     Any, Encode, Tag,
 };
 use generic_log_worker::{
@@ -287,9 +287,8 @@ fn build_issuer_rdn(log_id: &str) -> std::result::Result<RdnSequence, String> {
         value: any_value,
     };
 
-    let rdn = RelativeDistinguishedName(
-        SetOfVec::from_iter([attr]).expect("single attribute should always succeed"),
-    );
+    let rdn = RelativeDistinguishedName::try_from(vec![attr])
+        .expect("single attribute should always succeed");
 
     Ok(RdnSequence::from(vec![rdn]))
 }
@@ -303,10 +302,7 @@ fn build_validity(
     let not_after = UtcTime::from_unix_duration(now + Duration::from_secs(max_lifetime_secs))
         .map_err(|e| e.to_string())?;
 
-    Ok(Validity {
-        not_before: Time::UtcTime(not_before),
-        not_after: Time::UtcTime(not_after),
-    })
+    Ok(Validity::new(Time::UtcTime(not_before), Time::UtcTime(not_after)))
 }
 
 /// Returns the issuer cert for SCT validation. For multi-cert chains, that's
@@ -329,7 +325,7 @@ fn resolve_issuer_for_sct(
     // Single-cert chain: look up issuer from roots pool
     let leaf =
         Certificate::from_der(&chain[0]).map_err(|e| format!("failed to parse leaf: {e}"))?;
-    let issuer_dn = &leaf.tbs_certificate.issuer;
+    let issuer_dn = leaf.tbs_certificate().issuer();
 
     roots
         .find_by_subject(issuer_dn)
@@ -348,7 +344,7 @@ async fn add_entry(mut req: Request, env: &Env, name: &str) -> Result<Response> 
 
     let roots = load_roots(env, name).await?;
     let (pending_entry, found_root_idx) =
-        match bootstrap_mtc_api::validate_chain(&req.chain, roots, issuer, &mut validity) {
+        match bootstrap_mtc_api::validate_chain(&req.chain, roots, &issuer, &mut validity) {
             Ok(v) => v,
             Err(e) => {
                 log::warn!("{name}: Bad request: {e}");
@@ -530,9 +526,9 @@ mod tests {
     #[test]
     fn test_build_issuer_rdn() {
         let rdn = build_issuer_rdn("test-log-id").unwrap();
-        assert_eq!(rdn.0.len(), 1);
+        assert_eq!(rdn.as_ref().len(), 1);
 
-        let attr = rdn.0[0].0.iter().next().unwrap();
+        let attr = rdn.as_ref()[0].as_ref().iter().next().unwrap();
         assert_eq!(attr.oid, ID_RDNA_TRUSTANCHOR_ID);
 
         let encoded = attr.value.to_der().unwrap();

--- a/crates/ct_worker/Cargo.toml
+++ b/crates/ct_worker/Cargo.toml
@@ -32,7 +32,7 @@ url.workspace = true
 x509-cert.workspace = true
 
 [dev-dependencies]
-rand = { workspace = true, features = ["small_rng"] }
+rand.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
 futures-executor.workspace = true

--- a/crates/ct_worker/src/batcher_do.rs
+++ b/crates/ct_worker/src/batcher_do.rs
@@ -25,7 +25,7 @@ impl DurableObject for Batcher {
             enable_dedup: params.enable_dedup,
             location_hint: params.location_hint.clone(),
         };
-        Batcher(GenericBatcher::<tlog_tiles::SequenceMetadata>::new(state, env, config))
+        Batcher(GenericBatcher::new(state, env, config))
     }
 
     async fn fetch(&self, req: Request) -> Result<Response> {

--- a/crates/ct_worker/src/ccadb_roots_cron.rs
+++ b/crates/ct_worker/src/ccadb_roots_cron.rs
@@ -87,7 +87,7 @@ pub(crate) async fn update_ccadb_roots<T: AsRef<str>>(keys: &[T], kv: &KvStore) 
             write!(
                 &mut buf,
                 "\n# {}\n# added on {} from CCADB\n{}\n",
-                cert.tbs_certificate.subject,
+                cert.tbs_certificate().subject(),
                 DateTime::from_timestamp_millis(
                     now_millis()
                         .try_into()

--- a/crates/generic_log_worker/Cargo.toml
+++ b/crates/generic_log_worker/Cargo.toml
@@ -13,7 +13,8 @@ categories = ["cryptography"]
 keywords = ["transparency", "crypto"]
 
 [dev-dependencies]
-rand = { workspace = true, features = ["small_rng"] }
+crypto-common.workspace = true
+rand.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
 futures-executor.workspace = true

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -292,7 +292,7 @@ pub(crate) async fn create_log(
             config.origin.as_str(),
             &extensions.iter().map(String::as_str).collect::<Vec<_>>(),
             &dyn_signers,
-            &mut rand::thread_rng(),
+            &mut rand::rng(),
         )
         .map_err(|e| anyhow!("failed to sign checkpoint: {e}"))?;
     lock.put(CHECKPOINT_KEY, &sth)
@@ -1003,7 +1003,7 @@ async fn sequence_entries<L: LogEntry>(
                 config.origin.as_str(),
                 &extensions.iter().map(String::as_str).collect::<Vec<_>>(),
                 &dyn_signers,
-                &mut rand::thread_rng(),
+                &mut rand::rng(),
             )
             .map_err(|e| SequenceError::NonFatal(format!("couldn't sign checkpoint: {e}")))?;
         SequenceState {
@@ -1385,11 +1385,12 @@ mod tests {
     use ed25519_dalek::SigningKey as Ed25519SigningKey;
     use futures_executor::block_on;
     use itertools::Itertools;
+    use crypto_common::Generate as _;
     use p256::ecdsa::SigningKey as EcdsaSigningKey;
     use prometheus::Registry;
     use rand::{
-        rngs::{OsRng, SmallRng},
-        thread_rng, Rng, RngCore, SeedableRng,
+        rngs::SmallRng,
+        Rng, RngExt, SeedableRng,
     };
     use signed_note::{KeyName, Note};
     use static_ct_api::{
@@ -1506,10 +1507,10 @@ mod tests {
         }
 
         // Check that we can make a consistency proof for random spans in the tree
-        let mut rng = thread_rng();
+        let mut rng = rand::rng();
         for _ in 0..100 {
-            let prev_tree_size = rng.gen_range(1..n);
-            let new_tree_size = rng.gen_range(prev_tree_size + 1..=n);
+            let prev_tree_size = rng.random_range(1..n);
+            let new_tree_size = rng.random_range(prev_tree_size + 1..=n);
             let consistency_proof = block_on(prove_consistency(
                 tree_hashes[usize::try_from(new_tree_size).unwrap()],
                 new_tree_size,
@@ -1697,11 +1698,12 @@ mod tests {
 
     fn test_duplicates(is_precert: bool) {
         let mut log = TestLog::new();
-        log.add_with_seed(is_precert, rand::thread_rng().next_u64()); // 1
-        log.add_with_seed(is_precert, rand::thread_rng().next_u64()); // 2
+        let mut rng = rand::rng();
+        log.add_with_seed(is_precert, rng.next_u64()); // 1
+        log.add_with_seed(is_precert, rng.next_u64()); // 2
         log.sequence().unwrap();
-        log.add_with_seed(is_precert, rand::thread_rng().next_u64()); // 3
-        log.add_with_seed(is_precert, rand::thread_rng().next_u64()); // 4
+        log.add_with_seed(is_precert, rng.next_u64()); // 3
+        log.add_with_seed(is_precert, rng.next_u64()); // 4
 
         // Two pairs of duplicates from the pending pool.
         let res01 = log.add_with_seed(is_precert, 0); // 5
@@ -1813,7 +1815,7 @@ mod tests {
         // Try to load the checkpoint with two randomly generated checkpoint signers. These should fail
         let checkpoint_signer = StaticCTCheckpointSigner::new(
             log.config.origin.clone(),
-            EcdsaSigningKey::random(&mut OsRng),
+            EcdsaSigningKey::generate_from_rng(&mut rand::rng()),
         )
         .unwrap();
         log.config.checkpoint_signers = vec![Box::new(checkpoint_signer)];
@@ -1826,7 +1828,7 @@ mod tests {
 
         let checkpoint_signer = Ed25519CheckpointSigner::new(
             log.config.origin.clone(),
-            Ed25519SigningKey::generate(&mut OsRng),
+            Ed25519SigningKey::generate(&mut rand::rng()),
         )
         .unwrap();
         log.config.checkpoint_signers = vec![Box::new(checkpoint_signer)];
@@ -2412,7 +2414,7 @@ mod tests {
 
     impl TestLog {
         fn new() -> Self {
-            let mut rng = OsRng;
+            let mut rng = rand::rng();
 
             let cache = TestCacheBackend(RefCell::new(HashMap::new()));
             let object = TestObjectBackend::new();
@@ -2423,7 +2425,7 @@ mod tests {
             let checkpoint_signers: Vec<Box<dyn CheckpointSigner>> = {
                 let signer = StaticCTCheckpointSigner::new(
                     origin.clone(),
-                    EcdsaSigningKey::random(&mut rng),
+                    EcdsaSigningKey::generate_from_rng(&mut rng),
                 )
                 .unwrap();
                 let witness = Ed25519CheckpointSigner::new(
@@ -2506,22 +2508,22 @@ mod tests {
             self.pool_state.borrow_mut().reset_in_sequencing_dedup();
         }
         fn add_certificate(&mut self) -> AddLeafResult<SequenceMetadata> {
-            self.add_certificate_with_seed(rand::thread_rng().next_u64())
+            self.add_certificate_with_seed(rand::rng().next_u64())
         }
         fn add_certificate_with_seed(&mut self, seed: u64) -> AddLeafResult<SequenceMetadata> {
             self.add_with_seed(false, seed)
         }
         fn add(&mut self, is_precert: bool) -> AddLeafResult<SequenceMetadata> {
-            self.add_with_seed(is_precert, rand::thread_rng().next_u64())
+            self.add_with_seed(is_precert, rand::rng().next_u64())
         }
         fn add_with_seed(&mut self, is_precert: bool, seed: u64) -> AddLeafResult<SequenceMetadata> {
             let mut rng = SmallRng::seed_from_u64(seed);
-            let mut certificate = vec![0; rng.gen_range(8..12)];
+            let mut certificate = vec![0; rng.random_range(8..12)];
             rng.fill(&mut certificate[..]);
             let precert_opt: Option<PrecertData> = if is_precert {
                 let mut issuer_key_hash = [0; 32];
                 rng.fill(&mut issuer_key_hash);
-                let mut pre_certificate = vec![0; rng.gen_range(1..5)];
+                let mut pre_certificate = vec![0; rng.random_range(1..5)];
                 rng.fill(&mut pre_certificate[..]);
                 Some(PrecertData {
                     issuer_key_hash,
@@ -2530,7 +2532,7 @@ mod tests {
             } else {
                 None
             };
-            let issuers = CHAINS[rng.gen_range(0..CHAINS.len())];
+            let issuers = CHAINS[rng.random_range(0..CHAINS.len())];
             let leaf = StaticCTPendingLogEntry {
                 certificate,
                 precert_opt,

--- a/crates/integration_tests/Cargo.toml
+++ b/crates/integration_tests/Cargo.toml
@@ -38,6 +38,7 @@ anyhow = { workspace = true }
 length_prefixed.workspace = true
 byteorder = { workspace = true }
 chrono.workspace = true
+crypto-common.workspace = true
 hex.workspace = true
 log.workspace = true
 rand.workspace = true

--- a/crates/integration_tests/src/assertions.rs
+++ b/crates/integration_tests/src/assertions.rs
@@ -101,8 +101,8 @@ pub fn assert_sct_signature(
     // Extract the issuer `SubjectPublicKeyInfo` DER.
     let issuer_cert = Certificate::from_der(issuer_der).context("decoding issuer certificate")?;
     let issuer_spki_der = issuer_cert
-        .tbs_certificate
-        .subject_public_key_info
+        .tbs_certificate()
+        .subject_public_key_info()
         .to_der()
         .context("encoding issuer SPKI")?;
 
@@ -149,9 +149,8 @@ pub fn assert_sct_signature(
     let ct_poison_oid = der::asn1::ObjectIdentifier::new_unwrap("1.3.6.1.4.1.11129.2.4.3");
     let leaf_cert = Certificate::from_der(leaf_der).context("parsing leaf cert")?;
     let is_precert = leaf_cert
-        .tbs_certificate
-        .extensions
-        .as_ref()
+        .tbs_certificate()
+        .extensions()
         .is_some_and(|exts| exts.iter().any(|e| e.extn_id == ct_poison_oid));
 
     // For precerts, the worker signs over the TBS with the CT poison extension
@@ -160,7 +159,7 @@ pub fn assert_sct_signature(
     let effective_cert_der: &[u8];
     let effective_issuer_spki: &[u8];
     if is_precert {
-        cert_to_sign = static_ct_api::build_precert_tbs(&leaf_cert.tbs_certificate)
+        cert_to_sign = static_ct_api::build_precert_tbs(leaf_cert.tbs_certificate())
             .context("building precert TBS for signature verification")?;
         effective_cert_der = &cert_to_sign;
         effective_issuer_spki = &issuer_spki_der;

--- a/crates/integration_tests/src/fixtures.rs
+++ b/crates/integration_tests/src/fixtures.rs
@@ -30,23 +30,24 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use const_oid::AssociatedOid;
+use crypto_common::Generate;
 use der::{
     asn1::{Ia5String, Null},
     Decode, Encode, Length, Writer,
 };
 use p256::{ecdsa::SigningKey, pkcs8::DecodePrivateKey};
-use rand::rngs::OsRng;
 use serde::Deserialize;
 use x509_cert::{
-    builder::{Builder, CertificateBuilder, Profile},
-    certificate::Certificate,
+    builder::profile::BuilderProfile,
+    builder::{Builder, CertificateBuilder},
+    certificate::{Certificate, TbsCertificate},
     ext::{
         pkix::{name::GeneralName, ExtendedKeyUsage, SubjectAltName},
-        AsExtension, Extension,
+        Criticality, Extension,
     },
     name::Name,
     serial_number::SerialNumber,
-    spki::SubjectPublicKeyInfoOwned,
+    spki::{SubjectPublicKeyInfoOwned, SubjectPublicKeyInfoRef},
     time::Validity,
 };
 
@@ -67,8 +68,8 @@ impl AssociatedOid for CtPoisonExtension {
     const OID: der::asn1::ObjectIdentifier = CT_PRECERT_POISON_OID;
 }
 
-// `AsExtension` requires `AssociatedOid + der::Encode`.
-// We implement `Encode` directly: the extension value is ASN.1 NULL.
+// x509-cert 0.3: ToExtension is implemented for `&T` when T: Criticality + AssociatedOid + Encode.
+// We implement Encode (value = ASN.1 NULL) and Criticality (always critical).
 impl Encode for CtPoisonExtension {
     fn encoded_len(&self) -> der::Result<Length> {
         Null.encoded_len()
@@ -78,8 +79,8 @@ impl Encode for CtPoisonExtension {
     }
 }
 
-impl AsExtension for CtPoisonExtension {
-    fn critical(&self, _subject: &x509_cert::name::RdnSequence, _extensions: &[Extension]) -> bool {
+impl Criticality for CtPoisonExtension {
+    fn criticality(&self, _subject: &Name, _extensions: &[Extension]) -> bool {
         true
     }
 }
@@ -271,6 +272,29 @@ fn build_cert(
 
 /// Like `build_cert`, but also returns the DER-encoded `SubjectPublicKeyInfo` of
 /// the leaf certificate.  Used by MTC tests that need to call `get-certificate`.
+/// Minimal leaf certificate profile for integration tests.
+struct LeafProfile {
+    issuer: Name,
+    subject: Name,
+}
+
+impl BuilderProfile for LeafProfile {
+    fn get_issuer(&self, _subject: &Name) -> Name {
+        self.issuer.clone()
+    }
+    fn get_subject(&self) -> Name {
+        self.subject.clone()
+    }
+    fn build_extensions(
+        &self,
+        _spk: SubjectPublicKeyInfoRef<'_>,
+        _issuer_spk: SubjectPublicKeyInfoRef<'_>,
+        _tbs: &TbsCertificate,
+    ) -> Result<Vec<Extension>, x509_cert::builder::Error> {
+        Ok(vec![])
+    }
+}
+
 fn build_cert_with_spki(
     ca_key: &SigningKey,
     not_before: chrono::DateTime<chrono::Utc>,
@@ -281,40 +305,30 @@ fn build_cert_with_spki(
 
     let serial = SerialNumber::from(rand::random::<u32>());
 
-    let validity = Validity {
-        not_before: Time::GeneralTime(der::asn1::GeneralizedTime::from_date_time(to_der_datetime(
+    let validity = Validity::new(
+        Time::GeneralTime(der::asn1::GeneralizedTime::from_date_time(to_der_datetime(
             not_before,
         )?)),
-        not_after: Time::GeneralTime(der::asn1::GeneralizedTime::from_date_time(to_der_datetime(
+        Time::GeneralTime(der::asn1::GeneralizedTime::from_date_time(to_der_datetime(
             not_after,
         )?)),
-    };
+    );
 
     let subject = Name::from_str("CN=integration-test.example.com,O=Test,C=US")
         .context("building subject name")?;
 
     // Generate a fresh key for this leaf.
-    let leaf_key = SigningKey::random(&mut OsRng);
-    let leaf_spki = SubjectPublicKeyInfoOwned::from_key(*leaf_key.verifying_key())
+    let leaf_key = SigningKey::generate_from_rng(&mut rand::rng());
+    let leaf_spki = SubjectPublicKeyInfoOwned::from_key(leaf_key.verifying_key())
         .context("encoding leaf SPKI")?;
     let leaf_spki_der = leaf_spki.to_der().context("encoding leaf SPKI to DER")?;
-    // leaf_spki was moved into CertificateBuilder::new; we keep the DER copy above.
 
     let ca_cert = Certificate::from_der(&ca_cert_der_bytes()).context("parsing CA cert")?;
+    let issuer = ca_cert.tbs_certificate().subject().clone();
 
-    let mut builder = CertificateBuilder::new(
-        Profile::Leaf {
-            issuer: ca_cert.tbs_certificate.subject.clone(),
-            enable_key_agreement: false,
-            enable_key_encipherment: false,
-        },
-        serial,
-        validity,
-        subject,
-        leaf_spki,
-        ca_key,
-    )
-    .context("creating CertificateBuilder")?;
+    let profile = LeafProfile { issuer, subject };
+    let mut builder = CertificateBuilder::new(profile, serial, validity, leaf_spki)
+        .context("creating CertificateBuilder")?;
 
     let san = SubjectAltName(vec![GeneralName::DnsName(
         Ia5String::new("integration-test.example.com").context("building SAN")?,
@@ -334,7 +348,7 @@ fn build_cert_with_spki(
     }
 
     let cert_der = builder
-        .build_with_rng::<p256::ecdsa::DerSignature>(&mut OsRng)
+        .build_with_rng::<_, p256::ecdsa::DerSignature, _>(ca_key, &mut rand::rng())
         .context("signing certificate")?
         .to_der()
         .context("encoding certificate to DER")?;

--- a/crates/sct_validator/Cargo.toml
+++ b/crates/sct_validator/Cargo.toml
@@ -12,7 +12,7 @@ description = "WASM-compatible SCT (Signed Certificate Timestamp) validation for
 [dependencies]
 base64.workspace = true
 chrono.workspace = true
-const-oid = "0.9.6"
+const-oid.workspace = true
 der.workspace = true
 hashbrown = "0.15"
 log.workspace = true
@@ -22,9 +22,10 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 signature.workspace = true
-spki = "0.7"
+spki.workspace = true
 thiserror.workspace = true
-x509-cert = { version = "0.2.5", features = ["sct"] }
+x509-cert = { workspace = true, features = ["sct"] }
+x509_util.workspace = true
 
 [dev-dependencies]
-x509-cert = { version = "0.2.5", features = ["pem"] }
+x509-cert = { workspace = true, features = ["pem"] }

--- a/crates/sct_validator/src/lib.rs
+++ b/crates/sct_validator/src/lib.rs
@@ -24,12 +24,11 @@ pub use sct::{extract_scts_from_cert, ParsedSct};
 pub use verify::verify_sct_signature;
 
 use base64::prelude::*;
-use der::Encode;
+use der::{Decode, Encode};
 use hashbrown::HashMap;
 use p256::ecdsa::VerifyingKey as P256VerifyingKey;
 use serde::Deserialize;
 use spki::SubjectPublicKeyInfoRef;
-use x509_cert::der::Decode;
 
 /// Log list freshness period in seconds (70 days).
 /// If the log list is older than this, SCT validation auto-succeeds.
@@ -447,8 +446,8 @@ impl SctValidator {
         let issuer_cert = x509_cert::Certificate::from_der(issuer_der)
             .map_err(|e| SctError::Other(format!("issuer: {e}")))?;
         let issuer_spki_der = issuer_cert
-            .tbs_certificate
-            .subject_public_key_info
+            .tbs_certificate()
+            .subject_public_key_info()
             .to_der()
             .map_err(|e| SctError::Other(format!("issuer SPKI: {e}")))?;
 

--- a/crates/sct_validator/src/sct.rs
+++ b/crates/sct_validator/src/sct.rs
@@ -5,9 +5,11 @@
 
 use crate::error::SctError;
 use const_oid::AssociatedOid;
-use der::{Decode, Encode};
-use x509_cert::ext::pkix::sct::{SignedCertificateTimestamp, SignedCertificateTimestampList};
-use x509_cert::Certificate;
+use der::Decode;
+use x509_cert::ext::{
+    pkix::sct::{SignedCertificateTimestamp, SignedCertificateTimestampList},
+    Extension,
+};
 
 /// A parsed SCT from a certificate.
 #[derive(Clone, Debug)]
@@ -48,14 +50,14 @@ pub enum SignatureAlgorithm {
 /// extension is missing or malformed, or if there are issues generating the
 /// `TBSCertificate` from the leaf.
 pub fn extract_scts_from_cert(leaf_der: &[u8]) -> Result<(Vec<ParsedSct>, Vec<u8>, u64), SctError> {
-    let cert = Certificate::from_der(leaf_der).map_err(|e| SctError::Other(e.to_string()))?;
-    let lifetime_days = extract_lifetime_days(&cert)?;
-
+    let cert = x509_util::OwnedCertificate::from_der(leaf_der)
+        .map_err(|e| SctError::Other(e.to_string()))?;
+    let lifetime_days = extract_lifetime_days(&cert.tbs_certificate.validity)?;
     let mut tbs = cert.tbs_certificate;
     let extensions = tbs.extensions.as_mut().ok_or(SctError::NoSctExtension)?;
     let (sct_ext_index, parsed_scts) = find_and_parse_scts(extensions)?;
 
-    // Remove SCT extension to get the "CT certificate" that was signed
+    // Remove SCT extension to get the "CT certificate" that was signed.
     extensions.remove(sct_ext_index);
 
     let ct_cert_der = tbs
@@ -86,6 +88,10 @@ fn find_and_parse_scts(
         }
     };
 
+    Ok((index, parse_sct_extension(sct_ext)?))
+}
+
+fn parse_sct_extension(sct_ext: &Extension) -> Result<Vec<ParsedSct>, SctError> {
     let sct_list = SignedCertificateTimestampList::from_der(sct_ext.extn_value.as_bytes())
         .map_err(|e| SctError::Other(format!("failed to parse SCT list DER: {e}")))?;
 
@@ -99,8 +105,7 @@ fn find_and_parse_scts(
             parsed_scts.push(convert_sct(&sct)?);
         }
     }
-
-    Ok((index, parsed_scts))
+    Ok(parsed_scts)
 }
 
 fn convert_sct(sct: &SignedCertificateTimestamp) -> Result<ParsedSct, SctError> {
@@ -145,8 +150,7 @@ fn parse_signature_algorithm(
     }
 }
 
-fn extract_lifetime_days(cert: &Certificate) -> Result<u64, SctError> {
-    let validity = &cert.tbs_certificate.validity;
+fn extract_lifetime_days(validity: &x509_cert::time::Validity) -> Result<u64, SctError> {
     let not_before_secs = validity.not_before.to_unix_duration().as_secs();
     let not_after_secs = validity.not_after.to_unix_duration().as_secs();
 
@@ -165,6 +169,8 @@ fn extract_lifetime_days(cert: &Certificate) -> Result<u64, SctError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use der::Encode as _;
+    use x509_cert::Certificate;
 
     /// Golden-file regression test for `extract_scts_from_cert`.
     ///
@@ -176,8 +182,6 @@ mod tests {
     /// ```
     #[test]
     fn test_tbs_without_sct_golden() {
-        use x509_cert::Certificate;
-
         const GOLDEN: &str = "tests/golden/cloudflare-tbs-without-sct.der";
 
         let cert = Certificate::load_pem_chain(include_bytes!("../tests/cloudflare.pem"))

--- a/crates/signed_note/src/ed25519.rs
+++ b/crates/signed_note/src/ed25519.rs
@@ -6,7 +6,7 @@ use ed25519_dalek::{
     Signer as Ed25519Signer, SigningKey as Ed25519SigningKey, Verifier as Ed25519Verifier,
     VerifyingKey as Ed25519VerifyingKey,
 };
-use rand_core::CryptoRngCore;
+use rand_core::CryptoRng;
 
 /// [`Ed25519NoteVerifier`] is the verifier for the ordinary (non-timestamped) Ed25519 signature type defined in <https://c2sp.org/signed-note>.
 #[derive(Clone)]
@@ -198,7 +198,7 @@ impl Ed25519NoteSigner {
 
 /// Generates a signer and verifier key pair for a named server.
 /// The signer key skey is private and must be kept secret.
-pub fn generate_encoded_ed25519_key<R: CryptoRngCore + ?Sized>(
+pub fn generate_encoded_ed25519_key<R: CryptoRng + ?Sized>(
     csprng: &mut R,
     name: &KeyName,
 ) -> (String, String) {

--- a/crates/signed_note/src/lib.rs
+++ b/crates/signed_note/src/lib.rs
@@ -186,28 +186,17 @@
 //!
 //! struct ZeroRng;
 //!
-//! impl rand_core::RngCore for ZeroRng {
-//!     fn next_u32(&mut self) -> u32 {
-//!         0
-//!     }
-//!
-//!     fn next_u64(&mut self) -> u64 {
-//!         0
-//!     }
-//!
-//!     fn fill_bytes(&mut self, dest: &mut [u8]) {
-//!         for byte in dest.iter_mut() {
-//!             *byte = 0;
-//!         }
-//!     }
-//!
-//!     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
-//!         self.fill_bytes(dest);
+//! impl rand_core::TryRng for ZeroRng {
+//!     type Error = core::convert::Infallible;
+//!     fn try_next_u32(&mut self) -> Result<u32, Self::Error> { Ok(0) }
+//!     fn try_next_u64(&mut self) -> Result<u64, Self::Error> { Ok(0) }
+//!     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+//!         for byte in dest.iter_mut() { *byte = 0; }
 //!         Ok(())
 //!     }
 //! }
 //!
-//! impl rand_core::CryptoRng for ZeroRng {}
+//! impl rand_core::TryCryptoRng for ZeroRng {}
 //!
 //! let (skey, _) = signed_note::generate_encoded_ed25519_key(&mut ZeroRng{}, &KeyName::new("EnochRoot".into()).unwrap());
 //! let signer = Ed25519NoteSigner::new_from_encoded_key(&skey).unwrap();
@@ -708,7 +697,7 @@ impl Note {
 mod tests {
 
     use super::*;
-    use rand::rngs::OsRng;
+
     use std::sync::LazyLock;
 
     static NAME: LazyLock<KeyName> = LazyLock::new(|| KeyName::new("EnochRoot".into()).unwrap());
@@ -729,7 +718,7 @@ mod tests {
 
     #[test]
     fn test_generate_key() {
-        let (skey, vkey) = generate_encoded_ed25519_key(&mut OsRng, &NAME);
+        let (skey, vkey) = generate_encoded_ed25519_key(&mut rand::rng(), &NAME);
 
         let signer = Ed25519NoteSigner::new_from_encoded_key(&skey).unwrap();
         let verifier = Ed25519NoteVerifier::new_from_encoded_key(&vkey).unwrap();
@@ -739,7 +728,7 @@ mod tests {
 
     #[test]
     fn test_from_ed25519() {
-        let signing_key = ed25519_dalek::SigningKey::generate(&mut OsRng);
+        let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rng());
 
         let pubkey = [
             &[SignatureType::Ed25519 as u8],

--- a/crates/static_ct_api/src/rfc6962.rs
+++ b/crates/static_ct_api/src/rfc6962.rs
@@ -106,8 +106,8 @@ pub fn partially_validate_chain(
         // reason for a CT log to reject a submission: <https://googlechrome.github.io/CertificateTransparency/log_policy.html>.
         if require_server_auth_eku
             && !leaf
-                .tbs_certificate
-                .get::<ExtendedKeyUsage>()?
+                .tbs_certificate()
+                .get_extension::<ExtendedKeyUsage>()?
                 .is_some_and(|(_, eku)| eku.0.contains(&ID_KP_SERVER_AUTH))
         {
             return Err(StaticCTError::InvalidLeaf);
@@ -132,12 +132,15 @@ pub fn partially_validate_chain(
             (
                 Some(PrecertData {
                     issuer_key_hash: Sha256::digest(
-                        issuer.tbs_certificate.subject_public_key_info.to_der()?,
+                        issuer
+                            .tbs_certificate()
+                            .subject_public_key_info()
+                            .to_der()?,
                     )
                     .into(),
                     pre_certificate: leaf.to_der()?,
                 }),
-                build_precert_tbs(&leaf.tbs_certificate)?,
+                build_precert_tbs(leaf.tbs_certificate())?,
             )
         } else {
             (None, leaf.to_der()?)
@@ -181,7 +184,7 @@ impl_newtype!(CTPrecertPoison, Null);
 
 /// Returns whether or not the certificate contains the precertificate poison extension.
 fn is_precert(cert: &Certificate) -> Result<bool, StaticCTError> {
-    match cert.tbs_certificate.get::<CTPrecertPoison>()? {
+    match cert.tbs_certificate().get_extension::<CTPrecertPoison>()? {
         Some((true, _)) => Ok(true),
         Some((false, _)) => Err(StaticCTError::InvalidCTPoison),
         None => Ok(false),
@@ -190,7 +193,7 @@ fn is_precert(cert: &Certificate) -> Result<bool, StaticCTError> {
 
 /// Returns whether or not the certificate is a precertificate signing certificate.
 fn is_precert_signing_cert(cert: &Certificate) -> Result<bool, StaticCTError> {
-    match cert.tbs_certificate.get::<ExtendedKeyUsage>()? {
+    match cert.tbs_certificate().get_extension::<ExtendedKeyUsage>()? {
         Some((_, eku)) => {
             for usage in eku.0 {
                 if usage == CT_PRECERT_SIGNING_CERT {
@@ -219,7 +222,7 @@ fn is_precert_signing_cert(cert: &Certificate) -> Result<bool, StaticCTError> {
 ///
 /// Returns an error if the certificate is not a valid precertificate.
 pub fn build_precert_tbs(tbs: &TbsCertificate) -> Result<Vec<u8>, StaticCTError> {
-    let mut tbs = tbs.clone();
+    let mut tbs = x509_util::OwnedTbsCertificate::from(tbs);
 
     let exts = tbs
         .extensions
@@ -242,7 +245,7 @@ mod tests {
     use chrono::prelude::*;
     use der::{asn1::OctetString, Decode};
     use x509_cert::ext::Extension;
-    use x509_cert::Certificate;
+    use x509_cert::{Certificate, TbsCertificate};
 
     fn parse_datetime(s: &str) -> UnixTimestamp {
         u64::try_from(DateTime::parse_from_rfc3339(s).unwrap().timestamp_millis()).unwrap()
@@ -279,9 +282,8 @@ mod tests {
 
     test_is_precert!(
         remove_exts_from_precert,
-        wipe_extensions(
-            &mut Certificate::load_pem_chain(include_bytes!("../tests/precert-valid.pem")).unwrap()
-                [0]
+        &wipe_extensions(
+            &Certificate::load_pem_chain(include_bytes!("../tests/precert-valid.pem")).unwrap()[0]
         ),
         false,
         false
@@ -289,9 +291,8 @@ mod tests {
 
     test_is_precert!(
         poison_non_critical,
-        make_poison_non_critical(
-            &mut Certificate::load_pem_chain(include_bytes!("../tests/precert-valid.pem")).unwrap()
-                [0]
+        &make_poison_non_critical(
+            &Certificate::load_pem_chain(include_bytes!("../tests/precert-valid.pem")).unwrap()[0]
         ),
         false,
         true
@@ -299,9 +300,8 @@ mod tests {
 
     test_is_precert!(
         poison_non_null,
-        make_poison_non_null(
-            &mut Certificate::load_pem_chain(include_bytes!("../tests/precert-valid.pem")).unwrap()
-                [0]
+        &make_poison_non_null(
+            &Certificate::load_pem_chain(include_bytes!("../tests/precert-valid.pem")).unwrap()[0]
         ),
         false,
         true
@@ -363,19 +363,21 @@ mod tests {
     fn test_build_precert_tbs() {
         let precert_chain =
             Certificate::load_pem_chain(include_bytes!("../tests/preissuer-chain.pem")).unwrap();
-        let precert = &precert_chain[0].tbs_certificate;
+        let precert = precert_chain[0].tbs_certificate();
 
         let der = build_precert_tbs(precert).unwrap();
         let tbs = TbsCertificate::from_der(&der).unwrap();
 
         // Ensure CT poison is removed.
-        assert!(precert.get::<CTPrecertPoison>().unwrap().is_some());
-        assert!(tbs.get::<CTPrecertPoison>().unwrap().is_none());
+        assert!(precert
+            .get_extension::<CTPrecertPoison>()
+            .unwrap()
+            .is_some());
+        assert!(tbs.get_extension::<CTPrecertPoison>().unwrap().is_none());
     }
 
-    fn wipe_extensions(cert: &mut Certificate) -> &Certificate {
-        cert.tbs_certificate.extensions = None;
-        cert
+    fn wipe_extensions(cert: &Certificate) -> Certificate {
+        rebuild_cert_with_extensions(cert, None)
     }
 
     /// Golden-file regression test for `build_precert_tbs`.
@@ -393,7 +395,7 @@ mod tests {
 
         let precert_chain =
             Certificate::load_pem_chain(include_bytes!("../tests/preissuer-chain.pem")).unwrap();
-        let tbs_der = build_precert_tbs(&precert_chain[0].tbs_certificate).unwrap();
+        let tbs_der = build_precert_tbs(precert_chain[0].tbs_certificate()).unwrap();
 
         let golden_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(GOLDEN);
         if std::env::var("UPDATE_GOLDEN").is_ok() {
@@ -408,21 +410,35 @@ mod tests {
         );
     }
 
-    fn make_poison_non_critical(cert: &mut Certificate) -> &Certificate {
-        cert.tbs_certificate.extensions = Some(vec![Extension {
-            extn_id: CT_PRECERT_POISON,
-            critical: false,
-            extn_value: OctetString::new(Null.to_der().unwrap()).unwrap(),
-        }]);
-        cert
+    fn make_poison_non_critical(cert: &Certificate) -> Certificate {
+        rebuild_cert_with_extensions(
+            cert,
+            Some(&[Extension {
+                extn_id: CT_PRECERT_POISON,
+                critical: false,
+                extn_value: OctetString::new(Null.to_der().unwrap()).unwrap(),
+            }]),
+        )
     }
 
-    fn make_poison_non_null(cert: &mut Certificate) -> &Certificate {
-        cert.tbs_certificate.extensions = Some(vec![Extension {
-            extn_id: CT_PRECERT_POISON,
-            critical: true,
-            extn_value: OctetString::new([]).unwrap(),
-        }]);
-        cert
+    fn make_poison_non_null(cert: &Certificate) -> Certificate {
+        rebuild_cert_with_extensions(
+            cert,
+            Some(&[Extension {
+                extn_id: CT_PRECERT_POISON,
+                critical: true,
+                extn_value: OctetString::new([]).unwrap(),
+            }]),
+        )
+    }
+
+    /// Rebuild a `Certificate` replacing its TBS extensions with `new_exts`.
+    fn rebuild_cert_with_extensions(
+        cert: &Certificate,
+        new_exts: Option<&[Extension]>,
+    ) -> Certificate {
+        let mut owned = x509_util::OwnedCertificate::from(cert);
+        owned.tbs_certificate.extensions = new_exts.map(|exts| exts.to_vec());
+        Certificate::from_der(&owned.to_der().unwrap()).unwrap()
     }
 }

--- a/crates/tlog_tiles/src/checkpoint.rs
+++ b/crates/tlog_tiles/src/checkpoint.rs
@@ -37,7 +37,7 @@
 use crate::{tlog::Hash, HashReader, TlogError, UnixTimestamp};
 use base64::{prelude::BASE64_STANDARD, Engine};
 use ed25519_dalek::{Signer, SigningKey as Ed25519SigningKey};
-use rand::{seq::SliceRandom, Rng};
+use rand::{seq::SliceRandom, Rng, RngExt};
 use sha2::{Digest, Sha256};
 use signed_note::{
     Ed25519NoteVerifier, KeyName, Note, NoteError, NoteSignature, NoteVerifier, VerifierList,
@@ -508,13 +508,13 @@ impl TreeWithTimestamp {
 /// Clients MUST ignore unknown signatures, and including some "grease" ones
 /// ensures they do.
 fn gen_grease_signatures(origin: &str, rng: &mut impl Rng) -> Vec<NoteSignature> {
-    let mut g1 = vec![0u8; 5 + rng.gen_range(0..100)];
+    let mut g1 = vec![0u8; 5 + rng.random_range(0..100)];
     rng.fill(&mut g1[..]);
 
-    let mut g2 = vec![0u8; 5 + rng.gen_range(0..100)];
+    let mut g2 = vec![0u8; 5 + rng.random_range(0..100)];
     let mut hasher = Sha256::new();
     hasher.update(b"grease\n");
-    hasher.update([rng.gen()]);
+    hasher.update([rng.random::<u8>()]);
     let h = hasher.finalize();
     g2[..4].copy_from_slice(&h[..4]);
     rng.fill(&mut g2[4..]);
@@ -547,8 +547,6 @@ fn gen_grease_signatures(origin: &str, rng: &mut impl Rng) -> Vec<NoteSignature>
 
 #[cfg(test)]
 mod tests {
-    use rand::rngs::OsRng;
-
     use super::*;
     use crate::tlog::record_hash;
 
@@ -643,8 +641,6 @@ mod tests {
 
     #[test]
     fn test_sign_verify() {
-        let mut rng = OsRng;
-
         let origin = "example.com/origin";
         let timestamp = 100;
         let tree_size = 4;
@@ -652,10 +648,12 @@ mod tests {
         // Make a tree head and sign it
         let tree = TreeWithTimestamp::new(tree_size, record_hash(b"hello world"), timestamp);
         let signer = {
-            let sk = Ed25519SigningKey::generate(&mut rng);
+            let sk = Ed25519SigningKey::generate(&mut rand::rng());
             Ed25519CheckpointSigner::new(KeyName::new("my-signer".into()).unwrap(), sk).unwrap()
         };
-        let checkpoint = tree.sign(origin, &[], &[&signer], &mut rng).unwrap();
+        let checkpoint = tree
+            .sign(origin, &[], &[&signer], &mut rand::rng())
+            .unwrap();
 
         // Now verify the checkpoint
         let verifier = signer.verifier();

--- a/crates/tlog_tiles/src/cosignature_v1.rs
+++ b/crates/tlog_tiles/src/cosignature_v1.rs
@@ -146,13 +146,10 @@ mod tests {
     use crate::{open_checkpoint, record_hash, TreeWithTimestamp};
 
     use super::*;
-    use rand::rngs::OsRng;
     use signed_note::VerifierList;
 
     #[test]
     fn test_cosignature_v1_sign_verify() {
-        let mut rng = OsRng;
-
         let origin = "example.com/origin";
         let timestamp = 100;
         let tree_size = 4;
@@ -160,11 +157,13 @@ mod tests {
         // Make a tree head and sign it
         let tree = TreeWithTimestamp::new(tree_size, record_hash(b"hello world"), timestamp);
         let signer = {
-            let sk = Ed25519SigningKey::generate(&mut rng);
+            let sk = Ed25519SigningKey::generate(&mut rand::rng());
             let name = KeyName::new("my-signer".into()).unwrap();
             CosignatureV1CheckpointSigner::new(name, sk)
         };
-        let checkpoint = tree.sign(origin, &[], &[&signer], &mut rng).unwrap();
+        let checkpoint = tree
+            .sign(origin, &[], &[&signer], &mut rand::rng())
+            .unwrap();
 
         // Now verify the signed checkpoint
         let verifier = signer.verifier();

--- a/crates/x509_util/Cargo.toml
+++ b/crates/x509_util/Cargo.toml
@@ -12,6 +12,7 @@ description.workspace = true
 [dependencies]
 const-oid.workspace = true
 der.workspace = true
+digest.workspace = true
 p256.workspace = true
 p384.workspace = true
 p521.workspace = true

--- a/crates/x509_util/src/lib.rs
+++ b/crates/x509_util/src/lib.rs
@@ -3,9 +3,9 @@
 
 //! Utilities for X.509 operations.
 
-use der::{Decode, Encode, Error as DerError};
+use der::{Decode, Encode, Error as DerError, Sequence};
 use sha2::{Digest, Sha256};
-use signature::Verifier as _; // for vk.verify()
+use signature::Verifier;
 use std::collections::{hash_map::Entry, HashMap};
 use x509_cert::{
     ext::pkix::{AuthorityKeyIdentifier, BasicConstraints, SubjectKeyIdentifier},
@@ -22,6 +22,114 @@ pub fn certs_to_bytes(certs: &[Certificate]) -> Result<Vec<Vec<u8>>, DerError> {
         .iter()
         .map(der::Encode::to_der)
         .collect::<Result<_, _>>()
+}
+
+/// An owned, freely mutable representation of an X.509 `TBSCertificate`.
+///
+/// Mirrors the field layout of `x509_cert::TbsCertificateInner` prior to
+/// [RustCrypto/formats#1505](https://github.com/RustCrypto/formats/pull/1505),
+/// which made those fields private.  Construct from a parsed `&TbsCertificate`
+/// via `From`, mutate any fields as needed, then call `to_der()`.
+#[derive(Clone, Debug, Sequence)]
+pub struct OwnedTbsCertificate {
+    #[asn1(
+        context_specific = "0",
+        tag_mode = "EXPLICIT",
+        default = "Default::default"
+    )]
+    pub version: x509_cert::certificate::Version,
+    pub serial_number: x509_cert::serial_number::SerialNumber,
+    pub signature: spki::AlgorithmIdentifierOwned,
+    pub issuer: x509_cert::name::Name,
+    pub validity: x509_cert::time::Validity,
+    pub subject: x509_cert::name::Name,
+    pub subject_public_key_info: spki::SubjectPublicKeyInfoOwned,
+    #[asn1(context_specific = "1", tag_mode = "IMPLICIT", optional = "true")]
+    pub issuer_unique_id: Option<der::asn1::BitString>,
+    #[asn1(context_specific = "2", tag_mode = "IMPLICIT", optional = "true")]
+    pub subject_unique_id: Option<der::asn1::BitString>,
+    #[asn1(context_specific = "3", tag_mode = "EXPLICIT", optional = "true")]
+    pub extensions: Option<x509_cert::ext::Extensions>,
+}
+
+impl From<&x509_cert::TbsCertificate> for OwnedTbsCertificate {
+    fn from(tbs: &x509_cert::TbsCertificate) -> Self {
+        Self {
+            version: tbs.version(),
+            serial_number: tbs.serial_number().clone(),
+            signature: tbs.signature().clone(),
+            issuer: tbs.issuer().clone(),
+            validity: *tbs.validity(),
+            subject: tbs.subject().clone(),
+            subject_public_key_info: tbs.subject_public_key_info().clone(),
+            issuer_unique_id: tbs.issuer_unique_id().clone(),
+            subject_unique_id: tbs.subject_unique_id().clone(),
+            extensions: tbs.extensions().cloned(),
+        }
+    }
+}
+
+impl OwnedTbsCertificate {
+    /// Decode a DER-encoded `TBSCertificate` into an `OwnedTbsCertificate`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `der::Error` if the DER cannot be decoded.
+    pub fn from_der(bytes: &[u8]) -> Result<Self, DerError> {
+        Decode::from_der(bytes)
+    }
+
+    /// Encode this `TBSCertificate` as DER.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `der::Error` if any field cannot be encoded.
+    pub fn to_der(&self) -> Result<Vec<u8>, DerError> {
+        Encode::to_der(self)
+    }
+}
+
+/// An owned, freely mutable representation of an X.509 `Certificate`.
+///
+/// Mirrors the field layout of `x509_cert::CertificateInner` prior to
+/// [RustCrypto/formats#1505](https://github.com/RustCrypto/formats/pull/1505).
+/// Construct from a parsed `&Certificate` via `From`, or build from components,
+/// then call `to_der()`.
+#[derive(Clone, Debug, Sequence)]
+pub struct OwnedCertificate {
+    pub tbs_certificate: OwnedTbsCertificate,
+    pub signature_algorithm: spki::AlgorithmIdentifierOwned,
+    pub signature: der::asn1::BitString,
+}
+
+impl From<&x509_cert::Certificate> for OwnedCertificate {
+    fn from(cert: &x509_cert::Certificate) -> Self {
+        Self {
+            tbs_certificate: OwnedTbsCertificate::from(cert.tbs_certificate()),
+            signature_algorithm: cert.signature_algorithm().clone(),
+            signature: cert.signature().clone(),
+        }
+    }
+}
+
+impl OwnedCertificate {
+    /// Decode a DER-encoded `Certificate` into an `OwnedCertificate`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `der::Error` if the DER cannot be decoded.
+    pub fn from_der(bytes: &[u8]) -> Result<Self, DerError> {
+        Decode::from_der(bytes)
+    }
+
+    /// Encode this `Certificate` as DER.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `der::Error` if any field cannot be encoded.
+    pub fn to_der(&self) -> Result<Vec<u8>, DerError> {
+        Encode::to_der(self)
+    }
 }
 
 /// A `CertPool` is a set of certificates.
@@ -59,12 +167,18 @@ impl CertPool {
     ///
     /// Returns an error if there are issues DER-encoding certificate extensions.
     pub fn find_potential_parents(&self, cert: &Certificate) -> Result<&[usize], DerError> {
-        if let Some((_, aki)) = cert.tbs_certificate.get::<AuthorityKeyIdentifier>()? {
+        if let Some((_, aki)) = cert
+            .tbs_certificate()
+            .get_extension::<AuthorityKeyIdentifier>()?
+        {
             if let Some(indexes) = self.by_subject_key_id.get(&aki.to_der()?) {
                 return Ok(indexes);
             }
         }
-        if let Some(indexes) = self.by_name.get(&cert.tbs_certificate.issuer.to_string()) {
+        if let Some(indexes) = self
+            .by_name
+            .get(&cert.tbs_certificate().issuer().to_string())
+        {
             return Ok(indexes);
         }
         Ok(&[])
@@ -82,10 +196,13 @@ impl CertPool {
             let idx = self.certs.len();
             e.insert(idx);
             self.by_name
-                .entry(cert.tbs_certificate.subject.to_string())
+                .entry(cert.tbs_certificate().subject().to_string())
                 .or_default()
                 .push(idx);
-            if let Some((_, ski)) = cert.tbs_certificate.get::<SubjectKeyIdentifier>()? {
+            if let Some((_, ski)) = cert
+                .tbs_certificate()
+                .get_extension::<SubjectKeyIdentifier>()?
+            {
                 self.by_subject_key_id
                     .entry(ski.to_der()?)
                     .or_default()
@@ -264,8 +381,8 @@ where
 
     // Check whether the leaf expiry date is within the acceptable range.
     let not_after = u64::try_from(
-        leaf.tbs_certificate
-            .validity
+        leaf.tbs_certificate()
+            .validity()
             .not_after
             .to_unix_duration()
             .as_millis(),
@@ -335,7 +452,7 @@ where
         let Some(path) = find_path_to_root(current_cert, roots, validated_intermediates.len())?
         else {
             return Err(ValidationError::NoPathToTrustedRoot {
-                to_verify_issuer: current_cert.tbs_certificate.issuer.to_string(),
+                to_verify_issuer: current_cert.tbs_certificate().issuer().to_string(),
             }
             .into());
         };
@@ -417,7 +534,7 @@ fn find_path_to_root(
 /// Verify that a cert is well-formed according to RFC 5280.
 fn check_well_formedness(cert: &Certificate) -> Result<(), ValidationError> {
     // Reject mismatched signature algorithms: https://github.com/google/certificate-transparency-go/pull/702.
-    if cert.signature_algorithm != cert.tbs_certificate.signature {
+    if cert.signature_algorithm() != cert.tbs_certificate().signature() {
         return Err(ValidationError::MismatchingSigAlg);
     }
     Ok(())
@@ -431,12 +548,14 @@ fn check_well_formedness(cert: &Certificate) -> Result<(), ValidationError> {
 /// root CA certificate, using the chain of intermediate CA certificates
 /// provided by the submitter.
 /// ```
+/// Verify that `issuer` signed `child` by dispatching on the signature algorithm OID.
+///
 /// Supported algorithms: ECDSA P-256, ECDSA P-384, ECDSA P-521, RSA PKCS#1 v1.5 (SHA-1/256/384/512).
 fn is_link_valid(child: &Certificate, issuer: &Certificate) -> bool {
     // Note: chain links are discovered by comparing
-    //   child.tbs_certificate.issuer.to_string()
+    //   child.tbs_certificate().issuer().to_string()
     // to
-    //   issuer.tbs_certificate.subject.to_string().
+    //   issuer.tbs_certificate().subject().to_string().
     // When these are equal, there is a plausible link between these. This is NOT the actual
     // algorithm for determining whether a link is valid. A discussion on the correct algorithm can
     // be found here:
@@ -449,20 +568,20 @@ fn is_link_valid(child: &Certificate, issuer: &Certificate) -> bool {
         SHA_256_WITH_RSA_ENCRYPTION, SHA_384_WITH_RSA_ENCRYPTION, SHA_512_WITH_RSA_ENCRYPTION,
     };
 
-    let Ok(tbs_der) = child.tbs_certificate.to_der() else {
+    let Ok(tbs_der) = child.tbs_certificate().to_der() else {
         return false;
     };
-    let Some(sig_bytes) = child.signature.as_bytes() else {
+    let Some(sig_bytes) = child.signature().as_bytes() else {
         return false;
     };
-    let Ok(spki_der) = issuer.tbs_certificate.subject_public_key_info.to_der() else {
+    let Ok(spki_der) = issuer.tbs_certificate().subject_public_key_info().to_der() else {
         return false;
     };
     let Ok(spki) = spki::SubjectPublicKeyInfoRef::try_from(spki_der.as_slice()) else {
         return false;
     };
 
-    match child.signature_algorithm.oid {
+    match child.signature_algorithm().oid {
         // ecdsa-with-SHA256 → P-256; ecdsa-with-SHA384 → P-384; ecdsa-with-SHA512 → P-521.
         ECDSA_WITH_SHA_256 => verify_p256(spki, &tbs_der, sig_bytes),
         ECDSA_WITH_SHA_384 => verify_p384(spki, &tbs_der, sig_bytes),
@@ -475,6 +594,7 @@ fn is_link_valid(child: &Certificate, issuer: &Certificate) -> bool {
     }
 }
 
+/// Verify a P-256 ECDSA signature over `tbs_der` using the key in `spki`.
 fn verify_p256(spki: spki::SubjectPublicKeyInfoRef<'_>, tbs_der: &[u8], sig_bytes: &[u8]) -> bool {
     let Ok(vk) = p256::ecdsa::VerifyingKey::try_from(spki) else {
         return false;
@@ -484,6 +604,7 @@ fn verify_p256(spki: spki::SubjectPublicKeyInfoRef<'_>, tbs_der: &[u8], sig_byte
         .unwrap_or(false)
 }
 
+/// Verify a P-384 ECDSA signature over `tbs_der` using the key in `spki`.
 fn verify_p384(spki: spki::SubjectPublicKeyInfoRef<'_>, tbs_der: &[u8], sig_bytes: &[u8]) -> bool {
     let Ok(vk) = p384::ecdsa::VerifyingKey::try_from(spki) else {
         return false;
@@ -493,27 +614,20 @@ fn verify_p384(spki: spki::SubjectPublicKeyInfoRef<'_>, tbs_der: &[u8], sig_byte
         .unwrap_or(false)
 }
 
+/// Verify a P-521 ECDSA signature over `tbs_der` using the key in `spki`.
 fn verify_p521(spki: spki::SubjectPublicKeyInfoRef<'_>, tbs_der: &[u8], sig_bytes: &[u8]) -> bool {
-    // In p521 0.13.x, VerifyingKey is a wrapper struct rather than a type alias for
-    // ecdsa::VerifyingKey<NistP521>, so it does not inherit TryFrom<SubjectPublicKeyInfoRef>.
-    // Work around this by extracting the raw SEC1 bytes and using from_sec1_bytes directly.
-    // This workaround can be removed once we upgrade to p521 >=0.14 (currently in rc), where
-    // VerifyingKey becomes a type alias and inherits the TryFrom impl.
-    let Some(pub_key_bytes) = spki.subject_public_key.as_bytes() else {
+    let Ok(vk) = p521::ecdsa::VerifyingKey::try_from(spki) else {
         return false;
     };
-    let Ok(vk) = p521::ecdsa::VerifyingKey::from_sec1_bytes(pub_key_bytes) else {
-        return false;
-    };
-    // Convert the DER-encoded signature to a fixed-size P-521 signature.
-    p521::ecdsa::Signature::from_der(sig_bytes)
+    p521::ecdsa::DerSignature::try_from(sig_bytes)
         .map(|sig| vk.verify(tbs_der, &sig).is_ok())
         .unwrap_or(false)
 }
 
+/// Verify an RSA PKCS#1 v1.5 signature over `tbs_der` using the key in `spki`.
 fn verify_rsa<D>(spki: spki::SubjectPublicKeyInfoRef<'_>, tbs_der: &[u8], sig_bytes: &[u8]) -> bool
 where
-    D: sha2::digest::Digest + rsa::pkcs8::AssociatedOid,
+    D: digest::Digest + const_oid::AssociatedOid,
 {
     let Ok(rsa_key) = rsa::RsaPublicKey::try_from(spki) else {
         return false;
@@ -537,8 +651,8 @@ fn check_ca_basic_constraints(
 ) -> Result<(), ValidationError> {
     // Check the cert's basic constraints.
     if ca_cert
-        .tbs_certificate
-        .get::<BasicConstraints>()
+        .tbs_certificate()
+        .get_extension::<BasicConstraints>()
         .map_err(ValidationError::from)?
         .is_none_or(|(_, bc)| {
             // If the path length constraint is specified, check it. The
@@ -754,7 +868,6 @@ mod tests {
         "../../static_ct_api/tests/subleaf.misordered.chain";
         false
     );
-
     macro_rules! test_not_after {
         ($name:ident; $start:expr; $end:expr; $want_err:expr) => {
             test_validate_chain!($name; "../../static_ct_api/tests/fake-ca-cert.pem"; "../../static_ct_api/tests/leaf-signed-by-fake-intermediate-cert.pem", "../../static_ct_api/tests/fake-intermediate-cert.pem"; $start; $end; $want_err; 2; false);
@@ -796,7 +909,7 @@ mod tests {
                 .unwrap();
 
         // Get the subject DN before moving into pool
-        let subject_dn = root.tbs_certificate.subject.clone();
+        let subject_dn = root.tbs_certificate().subject().clone();
 
         // Create a pool with this root
         let pool = CertPool::new(vec![root]).unwrap();
@@ -807,7 +920,7 @@ mod tests {
 
         // Verify it's the same cert (compare subjects)
         assert_eq!(
-            found.unwrap().tbs_certificate.subject.to_string(),
+            found.unwrap().tbs_certificate().subject().to_string(),
             subject_dn.to_string()
         );
     }
@@ -825,7 +938,7 @@ mod tests {
 
         // Try to find by a different subject (use the leaf's issuer, which isn't in pool)
         let leaf = &pool.certs[0];
-        let issuer_dn = &leaf.tbs_certificate.issuer;
+        let issuer_dn = &leaf.tbs_certificate().issuer();
 
         // The issuer is not in the pool, so this should return None
         let not_found = pool.find_by_subject(issuer_dn);


### PR DESCRIPTION
Upgrades all RustCrypto crates to their latest RC versions to unblock
ml-dsa 0.1.0-rc.8, which fixes a WASM stack overflow with ML-DSA
signatures in Cloudflare Workers.

Workspace dependency changes:
- der 0.7.10 (patched fork) → 0.8.0 (Tag::RelativeOid now native)
- const-oid 0.9.6 → 0.10
- spki 0.7 → 0.8
- pkcs8 (new) 0.11.0-rc.11
- signature 2.2.0 → 3.0.0-rc.10
- sha1 0.10 → 0.11
- sha2 0.10 → 0.11
- digest (new) 0.11 (now used directly in verify_rsa bound)
- rand 0.8.5 → 0.10.0
- rand_core 0.6.4 → 0.10.0
- getrandom 0.2 → 0.4
- ed25519-dalek 2.1.1 → 3.0.0-pre.6
- p256 0.13 → 0.14.0-rc.8
- p384 0.13 → 0.14.0-rc.8
- p521 0.13 → 0.14.0-rc.8
- rsa 0.9 → 0.10.0-rc.17
- x509-cert 0.2.5 → 0.3.0-rc.4
- crypto-common (new) 0.2

In x509_util, adapt is_link_valid to the upgraded crates:
- verify_rsa bound updated from sha2::digest::Digest + rsa::pkcs8::AssociatedOid
  to digest::Digest + const_oid::AssociatedOid to match rsa 0.10-rc's API
- verify_p521 workaround removed: p521 0.14 makes VerifyingKey a type alias
  for ecdsa::VerifyingKey<NistP521>, so it now inherits TryFrom<SubjectPublicKeyInfoRef>
  and DerSignature, matching the p256/p384 helper pattern

Add OwnedTbsCertificate and OwnedCertificate to x509_util:
- Mirrors the pre-#1505 field layout of x509-cert's TbsCertificateInner
  and CertificateInner (all fields pub), making it straightforward to
  construct, modify, and re-encode certificates without the field-by-field
  DER boilerplate that x509-cert 0.3's private fields otherwise require
- Implements From<&TbsCertificate>, From<&Certificate>, from_der, to_der,
  to_x509 for ergonomic construction and conversion
- Replaces all field-by-field TBS/Certificate DER reconstruction sites:
  build_precert_tbs, extract_scts_from_cert, serialize_signatureless_cert
- extract_scts_from_cert now parses directly to OwnedCertificate via
  from_der; extract_lifetime_days accepts &Validity instead of &Certificate
- Adds OwnedTbsCertificate/OwnedCertificate round-trip tests including
  unique ID and extension encoding

Adapt to x509-cert 0.3 API changes (private fields, accessor methods,
Validity::new, RelativeDistinguishedName::try_from, etc.) throughout
bootstrap_mtc_api, bootstrap_mtc_worker, ct_worker, sct_validator,
static_ct_api, and integration_tests.

Adapt to rand 0.10 API changes (OsRng→SysRng, thread_rng()→rng(),
gen_range→random_range, RngExt, TryRng/TryCryptoRng in doc examples).