### PR TITLE
Rework compute_key_id API

### DIFF
--- a/crates/bootstrap_mtc_api/src/cosigner.rs
+++ b/crates/bootstrap_mtc_api/src/cosigner.rs
@@ -8,7 +8,6 @@ use ed25519_dalek::{
     VerifyingKey as Ed25519VerifyingKey,
 };
 use length_prefixed::WriteLengthPrefixedBytesExt;
-use sha2::{Digest, Sha256};
 use signed_note::{KeyName, NoteError, NoteSignature, NoteVerifier};
 use tlog_tiles::{CheckpointSigner, CheckpointText, Hash, LeafIndex, UnixTimestamp};
 
@@ -130,15 +129,11 @@ impl MtcNoteVerifier {
         verifying_key: Ed25519VerifyingKey,
     ) -> Self {
         let name = KeyName::new(format!("oid/{ID_RDNA_TRUSTANCHOR_ID}.{log_id}")).unwrap();
-
-        let id = {
-            let mut hasher = Sha256::new();
-            hasher.update(name.as_str().as_bytes());
-            hasher.update([0x0a, 0xff]);
-            hasher.update(b"mtc-checkpoint/v1");
-            let result = hasher.finalize();
-            u32::from_be_bytes(result[0..4].try_into().unwrap())
-        };
+        // MTC cosignatures don't carry a signature-type byte or bare public key; the key ID is
+        // derived from the fixed "\xffmtc-checkpoint/v1" label (passed in the signature-type slot,
+        // with an empty public key) so that the hash input matches
+        // SHA-256(name || 0x0A || "\xffmtc-checkpoint/v1").
+        let id = signed_note::compute_key_id(&name, b"\xffmtc-checkpoint/v1", &[]);
 
         Self {
             cosigner_id,

--- a/crates/signed_note/src/ed25519.rs
+++ b/crates/signed_note/src/ed25519.rs
@@ -44,14 +44,7 @@ impl NoteVerifier for Ed25519NoteVerifier {
 impl Ed25519NoteVerifier {
     #[must_use]
     pub fn new(name: KeyName, verifying_key: Ed25519VerifyingKey) -> Self {
-        let id = {
-            let pubkey = [
-                &[SignatureType::Ed25519 as u8],
-                verifying_key.to_bytes().as_slice(),
-            ]
-            .concat();
-            compute_key_id(&name, &pubkey)
-        };
+        let id = compute_key_id(&name, &[SignatureType::Ed25519 as u8], verifying_key.to_bytes().as_slice());
         Self {
             name,
             id,
@@ -79,7 +72,7 @@ impl Ed25519NoteVerifier {
             return Err(NoteError::Format);
         }
 
-        if id != compute_key_id(&name, &key) {
+        if id != compute_key_id(&name, &key[0..1], &key[1..]) {
             return Err(NoteError::Id);
         }
 
@@ -126,14 +119,7 @@ impl NoteSigner for Ed25519NoteSigner {
 impl Ed25519NoteSigner {
     #[must_use]
     pub fn new(name: KeyName, signing_key: Ed25519SigningKey) -> Self {
-        let id = {
-            let pubkey = [
-                &[SignatureType::Ed25519 as u8],
-                signing_key.verifying_key().to_bytes().as_slice(),
-            ]
-            .concat();
-            compute_key_id(&name, &pubkey)
-        };
+        let id = compute_key_id(&name, &[SignatureType::Ed25519 as u8], signing_key.verifying_key().to_bytes().as_slice());
         Self {
             name,
             id,
@@ -172,16 +158,8 @@ impl Ed25519NoteSigner {
                 let signing_key =
                     ed25519_dalek::SigningKey::try_from(key).map_err(|_| NoteError::Format)?;
 
-                let pubkey = [
-                    &[SignatureType::Ed25519 as u8],
-                    ed25519_dalek::VerifyingKey::from(&signing_key)
-                        .to_bytes()
-                        .as_slice(),
-                ]
-                .concat();
-
                 // Must verify id after deriving public key.
-                if id != compute_key_id(&name, &pubkey) {
+                if id != compute_key_id(&name, &[SignatureType::Ed25519 as u8], signing_key.verifying_key().to_bytes().as_slice()) {
                     return Err(NoteError::Id);
                 }
 
@@ -203,21 +181,17 @@ pub fn generate_encoded_ed25519_key<R: CryptoRng + ?Sized>(
     name: &KeyName,
 ) -> (String, String) {
     let signing_key = ed25519_dalek::SigningKey::generate(csprng);
+    let signature_type = &[SignatureType::Ed25519 as u8];
 
-    let pubkey = [
-        &[SignatureType::Ed25519 as u8],
-        signing_key.verifying_key().to_bytes().as_slice(),
-    ]
-    .concat();
     let privkey = [
-        &[SignatureType::Ed25519 as u8],
+        signature_type,
         signing_key.to_bytes().as_slice(),
     ]
     .concat();
     let skey = format!(
         "PRIVATE+KEY+{}+{:08x}+{}",
         name,
-        compute_key_id(name, &pubkey),
+        compute_key_id(name, signature_type, signing_key.verifying_key().to_bytes().as_slice()),
         BASE64_STANDARD.encode(privkey)
     );
     let vkey = new_encoded_ed25519_verifier_key(name, &signing_key.verifying_key());
@@ -231,11 +205,12 @@ pub fn new_encoded_ed25519_verifier_key(
     name: &KeyName,
     key: &ed25519_dalek::VerifyingKey,
 ) -> String {
-    let pubkey = [&[SignatureType::Ed25519 as u8], key.to_bytes().as_slice()].concat();
+    let signature_type = &[SignatureType::Ed25519 as u8];
+    let pubkey = key.to_bytes();
     format!(
         "{}+{:08x}+{}",
         name,
-        compute_key_id(name, &pubkey),
-        BASE64_STANDARD.encode(&pubkey)
+        compute_key_id(name, signature_type, pubkey.as_slice()),
+        BASE64_STANDARD.encode([signature_type, pubkey.as_slice()].concat())
     )
 }

--- a/crates/signed_note/src/lib.rs
+++ b/crates/signed_note/src/lib.rs
@@ -315,14 +315,15 @@ pub trait NoteSigner {
     fn sign(&self, msg: &[u8]) -> Result<Vec<u8>, signature::Error>;
 }
 
-/// Computes the key ID for the given server name and encoded public key
+/// Computes the key ID for the given server name, signature type, and public key
 /// as RECOMMENDED at <https://c2sp.org/signed-note#signatures>.
 #[must_use]
-pub fn compute_key_id(name: &KeyName, key: &[u8]) -> u32 {
+pub fn compute_key_id(name: &KeyName, signature_type: &[u8], pubkey: &[u8]) -> u32 {
     let mut hasher = Sha256::new();
     hasher.update(name.0.as_bytes());
     hasher.update(b"\n");
-    hasher.update(key);
+    hasher.update(signature_type);
+    hasher.update(pubkey);
     let result = hasher.finalize();
     let mut u32_bytes = [0u8; 4];
     u32_bytes.copy_from_slice(&result[0..4]);
@@ -729,15 +730,9 @@ mod tests {
     #[test]
     fn test_from_ed25519() {
         let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rng());
-
-        let pubkey = [
-            &[SignatureType::Ed25519 as u8],
-            signing_key.verifying_key().to_bytes().as_slice(),
-        ]
-        .concat();
-        let id = compute_key_id(&NAME, &pubkey);
-
-        let vkey = new_encoded_ed25519_verifier_key(&NAME, &signing_key.verifying_key());
+        let verifying_key = signing_key.verifying_key();
+        let id = compute_key_id(&NAME, &[SignatureType::Ed25519 as u8], verifying_key.to_bytes().as_slice());
+        let vkey = new_encoded_ed25519_verifier_key(&NAME, &verifying_key);
         let verifier = Ed25519NoteVerifier::new_from_encoded_key(&vkey).unwrap();
 
         let signer = Ed25519NoteSigner {

--- a/crates/signed_note_wasm/src/lib.rs
+++ b/crates/signed_note_wasm/src/lib.rs
@@ -196,10 +196,10 @@ impl VerifierList {
 ///
 /// Returns a JS error string if `name` is not a valid signed-note key name.
 #[wasm_bindgen(js_name = "computeKeyId")]
-pub fn compute_key_id(name: &str, key: &[u8]) -> Result<u32, JsValue> {
+pub fn compute_key_id(name: &str, signature_type: &[u8], pubkey: &[u8]) -> Result<u32, JsValue> {
     let key_name = signed_note::KeyName::new(name.to_string())
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
-    Ok(signed_note::compute_key_id(&key_name, key))
+    Ok(signed_note::compute_key_id(&key_name, signature_type, pubkey))
 }
 
 /// Returns a vkey string: `<name>+<hex_key_id>+<base64(0x01 || pubkey)>`

--- a/crates/static_ct_api/src/static_ct.rs
+++ b/crates/static_ct_api/src/static_ct.rs
@@ -519,15 +519,7 @@ impl RFC6962NoteVerifier {
             .map_err(|_| NoteError::Format)?
             .to_vec();
         let key_id = Sha256::digest(&pkix);
-
-        let id = signed_note::compute_key_id(
-            &name,
-            &[SignatureType::RFC6962TreeHead as u8]
-                .iter()
-                .chain(key_id.iter())
-                .copied()
-                .collect::<Vec<_>>(),
-        );
+        let id = signed_note::compute_key_id(&name, &[SignatureType::RFC6962TreeHead as u8], &key_id[..]);
 
         Ok(Self {
             name,

--- a/crates/tlog_tiles/src/cosignature_v1.rs
+++ b/crates/tlog_tiles/src/cosignature_v1.rs
@@ -5,7 +5,7 @@ use ed25519_dalek::{
     Signer as Ed25519Signer, SigningKey as Ed25519SigningKey, Verifier as Ed25519Verifier,
     VerifyingKey as Ed25519VerifyingKey,
 };
-use signed_note::{compute_key_id, KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
+use signed_note::{KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
 
 use crate::{CheckpointSigner, CheckpointText, UnixTimestamp};
 
@@ -83,14 +83,7 @@ pub struct CosignatureV1NoteVerifier {
 impl CosignatureV1NoteVerifier {
     #[must_use]
     pub fn new(name: KeyName, verifying_key: Ed25519VerifyingKey) -> Self {
-        let id = {
-            let pubkey = [
-                &[SignatureType::CosignatureV1 as u8],
-                verifying_key.to_bytes().as_slice(),
-            ]
-            .concat();
-            compute_key_id(&name, &pubkey)
-        };
+        let id = signed_note::compute_key_id(&name, &[SignatureType::CosignatureV1 as u8], verifying_key.to_bytes().as_slice());
         Self {
             name,
             id,


### PR DESCRIPTION
Rework the compute_key_id API to accept the signature type and public
key as separate parameters, instead of a single pre-concatenated buffer.
This aligns the function signature with the C2SP signed-note spec, which
defines the key ID as:

    key ID = SHA-256(key name || 0x0A || signature type || public key)[:4]

Passing the two components as distinct arguments makes call sites easier
to audit against the spec and removes a redundant allocation on the hash
path.

Adapt callers in signed_note (Ed25519NoteVerifier, Ed25519NoteSigner,
generate_encoded_ed25519_key, new_encoded_ed25519_verifier_key) and in
the WASM bindings (signed_note_wasm::computeKeyId).

Also use the new API in bootstrap_mtc_api::MtcNoteVerifier for subtree
cosigners, where the key ID is derived from the fixed label
"\xffmtc-checkpoint/v1" with no bare public key, per
https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html#name-subtree-signed-note-format.
Add an explanatory comment at the MTC call site documenting why the
fixed label is passed in the signature-type slot with an empty public
key, so the hash input matches SHA-256(name || 0x0A || label).

Note: this is a breaking change to the exported WASM computeKeyId
function; external JS/TS callers must pass (name, signature_type,
pubkey) instead of (name, concatenated_buffer).