### PR TITLE
Decouple sequencer metadata from LogEntry via per-worker SequencerMetadata types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,5 +87,6 @@ If any step fails, fix the issue in the commit it belongs to (use `git commit --
 
 ✅ **Always:** Add new shared dependencies to `[workspace.dependencies]` in root `Cargo.toml`. Do not add a dependency to a crate's `Cargo.toml` before you actually use it — `cargo machete` will flag speculative additions.
 
+✅ **Always:** Keep Workers-specific concerns (Durable Object storage formats, KV dedup cache, Worker runtime dependencies) out of the specification-level crates (`tlog_tiles`, `static_ct_api`, `bootstrap_mtc_api`, `signed_note`). Those crates implement public specs and are published to crates.io; they should not gain types, traits, or dependencies whose only consumers are Cloudflare Workers. Wire-format types used only by the sequencer and frontend belong in `generic_log_worker` or the concrete worker crate.
 ⚠️ **Requires Approval:** Publishing crates to crates.io (`tlog_tiles`, `static_ct_api`, `signed_note`, `signed_note`) — worker crates have `publish = false`
 

--- a/crates/bootstrap_mtc_api/src/lib.rs
+++ b/crates/bootstrap_mtc_api/src/lib.rs
@@ -194,8 +194,8 @@ impl LogEntry for BootstrapMtcLogEntry {
         })
     }
 
-    fn new(pending: Self::Pending, metadata: Self::Metadata) -> Self {
-        Self(TlogTilesLogEntry::new(pending.entry, metadata))
+    fn new(pending: Self::Pending, leaf_index: LeafIndex, timestamp: UnixTimestamp) -> Self {
+        Self(TlogTilesLogEntry::new(pending.entry, leaf_index, timestamp))
     }
 
     fn merkle_tree_leaf(&self) -> Hash {

--- a/crates/bootstrap_mtc_api/src/lib.rs
+++ b/crates/bootstrap_mtc_api/src/lib.rs
@@ -25,8 +25,8 @@ use std::{
 };
 use thiserror::Error;
 use tlog_tiles::{
-    Hash, LeafIndex, LogEntry, PathElem, PendingLogEntry, Proof, SequenceMetadata, Subtree,
-    TlogError, TlogTilesLogEntry, TlogTilesPendingLogEntry, UnixTimestamp,
+    Hash, LeafIndex, LogEntry, PathElem, PendingLogEntry, Proof, Subtree, TlogError,
+    TlogTilesLogEntry, TlogTilesPendingLogEntry, UnixTimestamp,
 };
 use x509_cert::{
     certificate::Version,
@@ -174,16 +174,6 @@ impl LogEntry for BootstrapMtcLogEntry {
     const REQUIRE_CHECKPOINT_TIMESTAMP: bool = false;
     type Pending = BootstrapMtcPendingLogEntry;
     type ParseError = MtcError;
-    type Metadata = SequenceMetadata;
-
-    fn make_metadata(
-        leaf_index: LeafIndex,
-        timestamp: UnixTimestamp,
-        _old_tree_size: u64,
-        _new_tree_size: u64,
-    ) -> Self::Metadata {
-        (leaf_index, timestamp)
-    }
 
     fn initial_entry() -> Option<Self::Pending> {
         Some(Self::Pending {

--- a/crates/bootstrap_mtc_worker/src/batcher_do.rs
+++ b/crates/bootstrap_mtc_worker/src/batcher_do.rs
@@ -1,10 +1,12 @@
-use crate::CONFIG;
-use generic_log_worker::{get_durable_object_name, BatcherConfig, GenericBatcher, BATCHER_BINDING};
+use crate::{BootstrapMtcSequenceMetadata, CONFIG};
+use generic_log_worker::{
+    get_durable_object_name, BatcherConfig, GenericBatcher, BATCHER_BINDING,
+};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
 #[durable_object(fetch)]
-struct Batcher(GenericBatcher<tlog_tiles::SequenceMetadata>);
+struct Batcher(GenericBatcher<BootstrapMtcSequenceMetadata>);
 
 impl DurableObject for Batcher {
     fn new(state: State, env: Env) -> Self {

--- a/crates/bootstrap_mtc_worker/src/frontend_worker.rs
+++ b/crates/bootstrap_mtc_worker/src/frontend_worker.rs
@@ -3,7 +3,7 @@
 
 //! Entrypoint for the static CT submission APIs.
 
-use crate::{load_checkpoint_cosigner, load_origin, load_roots, SequenceMetadata, CONFIG};
+use crate::{load_checkpoint_cosigner, load_origin, load_roots, BootstrapMtcSequenceMetadata, CONFIG};
 use der::{
     asn1::{UtcTime, Utf8StringRef},
     Any, Encode, Tag,
@@ -447,10 +447,10 @@ async fn add_entry(mut req: Request, env: &Env, name: &str) -> Result<Response> 
         // Return the response from the sequencing directly to the client.
         return Ok(response);
     }
-    let metadata = deserialize::<SequenceMetadata>(&response.bytes().await?)?;
+    let metadata = deserialize::<BootstrapMtcSequenceMetadata>(&response.bytes().await?)?;
     Response::from_json(&AddEntryResponse {
-        leaf_index: metadata.0,
-        timestamp: metadata.1,
+        leaf_index: metadata.leaf_index(),
+        timestamp: metadata.timestamp(),
         not_before: validity.not_before.to_unix_duration().as_secs(),
         not_after: validity.not_after.to_unix_duration().as_secs(),
     })

--- a/crates/bootstrap_mtc_worker/src/lib.rs
+++ b/crates/bootstrap_mtc_worker/src/lib.rs
@@ -12,7 +12,6 @@ use signed_note::KeyName;
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::{LazyLock, OnceLock};
-use tlog_tiles::SequenceMetadata;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 use x509_util::CertPool;
@@ -22,7 +21,10 @@ mod ccadb_roots_cron;
 mod cleaner_do;
 mod ct_logs_cron;
 mod frontend_worker;
+mod sequence_metadata;
 mod sequencer_do;
+
+pub(crate) use sequence_metadata::BootstrapMtcSequenceMetadata;
 
 // Application configuration.
 static CONFIG: LazyLock<AppConfig> = LazyLock::new(|| {

--- a/crates/bootstrap_mtc_worker/src/sequence_metadata.rs
+++ b/crates/bootstrap_mtc_worker/src/sequence_metadata.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+//! [`BootstrapMtcSequenceMetadata`] — the per-entry metadata produced by the
+//! bootstrap MTC sequencer.
+
+use generic_log_worker::{
+    deserialize_sequence_metadata_entries, serialize_sequence_metadata_entries, SequencerMetadata,
+};
+use serde::{Deserialize, Serialize};
+use tlog_tiles::{LeafIndex, LookupKey, UnixTimestamp};
+
+/// Sequencer metadata for a bootstrap MTC log entry.
+///
+/// Carries the leaf index and sequencing timestamp.
+///
+/// Wire-format constraints (do not change without migration):
+///
+/// 1. **Durable Object dedup ring buffer**: 32-byte binary layout
+///    `[16-byte lookup key | 8-byte leaf_index BE | 8-byte timestamp BE]`.
+///    This format matches the one previously used when the type was
+///    `(LeafIndex, UnixTimestamp)`; preserving it avoids a one-time deserialize
+///    warning on deploy as the sequencer loads any entries already in DO
+///    storage.
+/// 2. **DO→Worker RPC**: `bitcode` sequence of the two u64 fields (preserved by
+///    the tuple-struct layout).
+///
+/// Bootstrap MTC does not currently use the long-term KV dedup cache.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BootstrapMtcSequenceMetadata(pub LeafIndex, pub UnixTimestamp);
+
+impl BootstrapMtcSequenceMetadata {
+    /// Return the leaf index.
+    #[must_use]
+    pub fn leaf_index(&self) -> LeafIndex {
+        self.0
+    }
+
+    /// Return the sequencing timestamp (milliseconds since the Unix epoch).
+    #[must_use]
+    pub fn timestamp(&self) -> UnixTimestamp {
+        self.1
+    }
+}
+
+impl SequencerMetadata for BootstrapMtcSequenceMetadata {
+    fn new(
+        leaf_index: LeafIndex,
+        timestamp: UnixTimestamp,
+        _old_tree_size: u64,
+        _new_tree_size: u64,
+    ) -> Self {
+        Self(leaf_index, timestamp)
+    }
+
+    fn serialize_cache_entries(entries: &[(LookupKey, Self)]) -> Vec<u8> {
+        let pairs: Vec<(LookupKey, (u64, u64))> =
+            entries.iter().map(|(k, m)| (*k, (m.0, m.1))).collect();
+        serialize_sequence_metadata_entries(&pairs)
+    }
+
+    fn deserialize_cache_entries(buf: &[u8]) -> Result<Vec<(LookupKey, Self)>, String> {
+        let pairs = deserialize_sequence_metadata_entries(buf)?;
+        Ok(pairs
+            .into_iter()
+            .map(|(k, (idx, ts))| (k, Self(idx, ts)))
+            .collect())
+    }
+}

--- a/crates/bootstrap_mtc_worker/src/sequencer_do.rs
+++ b/crates/bootstrap_mtc_worker/src/sequencer_do.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::VecDeque, time::Duration};
 
-use crate::{load_checkpoint_cosigner, load_origin, CONFIG};
+use crate::{load_checkpoint_cosigner, load_origin, BootstrapMtcSequenceMetadata, CONFIG};
 use generic_log_worker::{
     get_durable_object_name, load_public_bucket,
     log_ops::{prove_subtree_consistency, ProofError},
@@ -24,7 +24,7 @@ use tlog_tiles::{CheckpointText, Hash, UnixTimestamp};
 use worker::*;
 
 #[durable_object(alarm)]
-struct Sequencer(GenericSequencer<BootstrapMtcLogEntry>);
+struct Sequencer(GenericSequencer<BootstrapMtcLogEntry, BootstrapMtcSequenceMetadata>);
 
 impl DurableObject for Sequencer {
     fn new(state: State, env: Env) -> Self {

--- a/crates/ct_worker/src/batcher_do.rs
+++ b/crates/ct_worker/src/batcher_do.rs
@@ -1,10 +1,12 @@
-use crate::CONFIG;
-use generic_log_worker::{get_durable_object_name, BatcherConfig, GenericBatcher, BATCHER_BINDING};
+use crate::{StaticCTSequenceMetadata, CONFIG};
+use generic_log_worker::{
+    get_durable_object_name, BatcherConfig, GenericBatcher, BATCHER_BINDING,
+};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
 #[durable_object(fetch)]
-struct Batcher(GenericBatcher<tlog_tiles::SequenceMetadata>);
+struct Batcher(GenericBatcher<StaticCTSequenceMetadata>);
 
 impl DurableObject for Batcher {
     fn new(state: State, env: Env) -> Self {

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -234,10 +234,12 @@ async fn add_chain_or_pre_chain(
 
     // Check if entry is cached and return right away if so.
     if params.enable_dedup {
-        if let Some(metadata) = get_cached_metadata(&load_cache_kv(env, name)?, &lookup_key).await?
+        if let Some(metadata) =
+            get_cached_metadata::<SequenceMetadata>(&load_cache_kv(env, name)?, &lookup_key)
+                .await?
         {
             log::debug!("{name}: Entry is cached");
-            let entry = StaticCTLogEntry::new(pending_entry, metadata);
+            let entry = StaticCTLogEntry::new(pending_entry, metadata.0, metadata.1);
             let sct = static_ct_api::signed_certificate_timestamp(signing_key, &entry)
                 .map_err(|e| e.to_string())?;
             return Response::from_json(&sct);

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -3,7 +3,7 @@
 
 //! Entrypoint for the static CT submission APIs.
 
-use crate::{load_roots, load_signing_key, SequenceMetadata, CONFIG};
+use crate::{load_roots, load_signing_key, StaticCTSequenceMetadata, CONFIG};
 use config::TemporalInterval;
 use generic_log_worker::{
     batcher_id_from_lookup_key, deserialize, get_cached_metadata, get_durable_object_stub,
@@ -234,12 +234,18 @@ async fn add_chain_or_pre_chain(
 
     // Check if entry is cached and return right away if so.
     if params.enable_dedup {
-        if let Some(metadata) =
-            get_cached_metadata::<SequenceMetadata>(&load_cache_kv(env, name)?, &lookup_key)
-                .await?
+        if let Some(metadata) = get_cached_metadata::<StaticCTSequenceMetadata>(
+            &load_cache_kv(env, name)?,
+            &lookup_key,
+        )
+        .await?
         {
             log::debug!("{name}: Entry is cached");
-            let entry = StaticCTLogEntry::new(pending_entry, metadata.0, metadata.1);
+            let entry = StaticCTLogEntry::new(
+                pending_entry,
+                metadata.leaf_index(),
+                metadata.timestamp(),
+            );
             let sct = static_ct_api::signed_certificate_timestamp(signing_key, &entry)
                 .map_err(|e| e.to_string())?;
             return Response::from_json(&sct);
@@ -302,7 +308,7 @@ async fn add_chain_or_pre_chain(
         // Return the response from the sequencing directly to the client.
         return Ok(response);
     }
-    let metadata = deserialize::<SequenceMetadata>(&response.bytes().await?)?;
+    let metadata = deserialize::<StaticCTSequenceMetadata>(&response.bytes().await?)?;
     if params.num_batchers == 0 && params.enable_dedup {
         // Write sequenced entry to the long-term deduplication cache in Workers
         // KV as there are no batchers configured to do it for us.
@@ -315,8 +321,8 @@ async fn add_chain_or_pre_chain(
     }
     let entry = StaticCTLogEntry {
         inner: pending_entry,
-        leaf_index: metadata.0,
-        timestamp: metadata.1,
+        leaf_index: metadata.leaf_index(),
+        timestamp: metadata.timestamp(),
     };
     let sct = static_ct_api::signed_certificate_timestamp(signing_key, &entry)
         .map_err(|e| e.to_string())?;

--- a/crates/ct_worker/src/lib.rs
+++ b/crates/ct_worker/src/lib.rs
@@ -11,7 +11,7 @@ use signed_note::KeyName;
 use static_ct_api::StaticCTCheckpointSigner;
 use std::collections::HashMap;
 use std::sync::{LazyLock, OnceLock};
-use tlog_tiles::{CheckpointSigner, Ed25519CheckpointSigner, SequenceMetadata};
+use tlog_tiles::{CheckpointSigner, Ed25519CheckpointSigner};
 use worker::{Env, Result};
 use x509_util::CertPool;
 
@@ -19,7 +19,10 @@ mod batcher_do;
 mod ccadb_roots_cron;
 mod cleaner_do;
 mod frontend_worker;
+mod sequence_metadata;
 mod sequencer_do;
+
+pub(crate) use sequence_metadata::StaticCTSequenceMetadata;
 
 // Application configuration.
 static CONFIG: LazyLock<AppConfig> = LazyLock::new(|| {

--- a/crates/ct_worker/src/sequence_metadata.rs
+++ b/crates/ct_worker/src/sequence_metadata.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+//! [`StaticCTSequenceMetadata`] — the per-entry metadata produced by the
+//! static-ct-api sequencer.
+
+use generic_log_worker::{
+    deserialize_sequence_metadata_entries, serialize_sequence_metadata_entries, SequencerMetadata,
+};
+use serde::{Deserialize, Serialize};
+use tlog_tiles::{LeafIndex, LookupKey, UnixTimestamp};
+
+/// Sequencer metadata for a static-ct-api log entry.
+///
+/// Wire-format constraints (do not change without migration):
+///
+/// 1. **Durable Object dedup ring buffer**: 32-byte binary layout
+///    `[16-byte lookup key | 8-byte leaf_index BE | 8-byte timestamp BE]`,
+///    handled via [`serialize_sequence_metadata_entries`] /
+///    [`deserialize_sequence_metadata_entries`].
+/// 2. **KV long-term dedup cache metadata**: JSON array `[leaf_index, timestamp]`.
+///    Preserved automatically because this is a tuple struct (serde serializes
+///    tuple structs as JSON arrays).
+/// 3. **DO→Worker RPC**: `bitcode` sequence of the two u64 fields. Also
+///    preserved by the tuple-struct layout.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct StaticCTSequenceMetadata(pub LeafIndex, pub UnixTimestamp);
+
+impl StaticCTSequenceMetadata {
+    /// Return the leaf index.
+    #[must_use]
+    pub fn leaf_index(&self) -> LeafIndex {
+        self.0
+    }
+
+    /// Return the sequencing timestamp (milliseconds since the Unix epoch).
+    #[must_use]
+    pub fn timestamp(&self) -> UnixTimestamp {
+        self.1
+    }
+}
+
+impl SequencerMetadata for StaticCTSequenceMetadata {
+    fn new(
+        leaf_index: LeafIndex,
+        timestamp: UnixTimestamp,
+        _old_tree_size: u64,
+        _new_tree_size: u64,
+    ) -> Self {
+        Self(leaf_index, timestamp)
+    }
+
+    fn serialize_cache_entries(entries: &[(LookupKey, Self)]) -> Vec<u8> {
+        let pairs: Vec<(LookupKey, (u64, u64))> =
+            entries.iter().map(|(k, m)| (*k, (m.0, m.1))).collect();
+        serialize_sequence_metadata_entries(&pairs)
+    }
+
+    fn deserialize_cache_entries(buf: &[u8]) -> Result<Vec<(LookupKey, Self)>, String> {
+        let pairs = deserialize_sequence_metadata_entries(buf)?;
+        Ok(pairs
+            .into_iter()
+            .map(|(k, (idx, ts))| (k, Self(idx, ts)))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Confirm the JSON wire format used by the KV long-term dedup cache
+    /// metadata matches the historical `(LeafIndex, UnixTimestamp)` tuple shape
+    /// (i.e. `[leaf_index, timestamp]`). Changing this would orphan pre-existing
+    /// KV entries from deployed logs.
+    #[test]
+    fn test_kv_json_format_unchanged() {
+        let m = StaticCTSequenceMetadata(42, 1000);
+        let json = serde_json::to_string(&m).unwrap();
+        assert_eq!(json, "[42,1000]");
+
+        let parsed: StaticCTSequenceMetadata = serde_json::from_str("[42,1000]").unwrap();
+        assert_eq!(parsed, m);
+    }
+}

--- a/crates/ct_worker/src/sequencer_do.rs
+++ b/crates/ct_worker/src/sequencer_do.rs
@@ -5,7 +5,7 @@
 
 use std::time::Duration;
 
-use crate::{load_checkpoint_signers, load_origin, CONFIG};
+use crate::{load_checkpoint_signers, load_origin, StaticCTSequenceMetadata, CONFIG};
 use generic_log_worker::{
     empty_checkpoint_callback, get_durable_object_name, GenericSequencer, SequencerConfig,
     SEQUENCER_BINDING,
@@ -15,7 +15,7 @@ use static_ct_api::StaticCTLogEntry;
 use worker::*;
 
 #[durable_object(alarm)]
-struct Sequencer(GenericSequencer<StaticCTLogEntry>);
+struct Sequencer(GenericSequencer<StaticCTLogEntry, StaticCTSequenceMetadata>);
 
 impl DurableObject for Sequencer {
     fn new(state: State, env: Env) -> Self {

--- a/crates/generic_log_worker/src/batcher_do.rs
+++ b/crates/generic_log_worker/src/batcher_do.rs
@@ -7,10 +7,9 @@
 //! Entries are assigned to Batcher shards with consistent hashing on the cache key.
 
 use crate::{
-    deserialize, get_durable_object_stub, load_cache_kv, obs, serialize, CacheSerialize,
-    LookupKey, BATCH_ENDPOINT, ENTRY_ENDPOINT, SEQUENCER_BINDING,
+    deserialize, get_durable_object_stub, load_cache_kv, obs, serialize, LookupKey,
+    SequencerMetadata, BATCH_ENDPOINT, ENTRY_ENDPOINT, SEQUENCER_BINDING,
 };
-use serde::{de::DeserializeOwned, Serialize};
 use base64::prelude::*;
 use futures_util::future::{join_all, select, Either};
 use std::{
@@ -27,9 +26,12 @@ use worker::*;
 /// A Durable Object that buffers incoming log entries and submits them to the
 /// Sequencer in batches.
 ///
-/// `M` is the sequence metadata type produced for each entry after sequencing
-/// (i.e., [`LogEntry::Metadata`](tlog_tiles::LogEntry::Metadata)).
-pub struct GenericBatcher<M> {
+/// `M` is the [`SequencerMetadata`] produced for each entry after sequencing.
+/// The batcher does not inspect the entry contents, so it only needs to know
+/// the metadata type (not the full [`LogEntry`]).
+///
+/// [`LogEntry`]: tlog_tiles::LogEntry
+pub struct GenericBatcher<M: SequencerMetadata> {
     env: Env,
     config: BatcherConfig,
     state: State,
@@ -67,7 +69,7 @@ impl<M: Clone + Default> Default for Batch<M> {
     }
 }
 
-impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Default + Copy + 'static> GenericBatcher<M> {
+impl<M: SequencerMetadata> GenericBatcher<M> {
     /// Returns a new batcher with the given config.
     ///
     /// # Panics
@@ -196,7 +198,7 @@ impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Default + Copy +
     }
 }
 
-impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Default + Copy + 'static> GenericBatcher<M> {
+impl<M: SequencerMetadata> GenericBatcher<M> {
     /// Submit the current pending batch to be sequenced.
     ///
     /// # Errors

--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -26,11 +26,9 @@ use std::cell::RefCell;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 
-use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use serde::de::DeserializeOwned;
-use std::io::Write;
 pub use tlog_tiles::LookupKey;
-use tlog_tiles::{PendingLogEntry, SequenceMetadata};
+use tlog_tiles::{LeafIndex, PendingLogEntry, UnixTimestamp};
 use tokio::sync::Mutex;
 use util::now_millis;
 use worker::{
@@ -227,7 +225,7 @@ struct DedupCache<M> {
     storage: Storage,
 }
 
-impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Copy + Default + 'static> CacheWrite<M> for DedupCache<M> {
+impl<M: SequencerMetadata> CacheWrite<M> for DedupCache<M> {
     /// Write entries to both the short-term deduplication cache and its backup in DO Storage.
     async fn put_entries(&self, entries: &[(LookupKey, M)]) -> Result<()> {
         if entries.is_empty() {
@@ -238,7 +236,7 @@ impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Copy + Default +
     }
 }
 
-impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Copy + Default + 'static> CacheRead<M> for DedupCache<M> {
+impl<M: SequencerMetadata> CacheRead<M> for DedupCache<M> {
     /// Check the short-term deduplication cache only. The long-term deduplication
     /// cache gets checked by the Worker frontend when handling add-chain requests.
     fn get_entry(&self, key: &LookupKey) -> Option<M> {
@@ -309,7 +307,7 @@ fn dedup_cache_fifo_key(idx: u32) -> String {
     format!("fifo:{idx}")
 }
 
-impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Copy + Default + 'static> DedupCache<M> {
+impl<M: SequencerMetadata> DedupCache<M> {
     // Batches are written at most once per second, and we only need them to
     // deduplicate entries long enough for KV's eventual consistency guarantees
     // (~60s). Cap at 128 so we can use a single get_multiple call to get all
@@ -358,7 +356,7 @@ impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Copy + Default +
         for value in map.values() {
             let batch = serde_wasm_bindgen::from_value::<ByteBuf>(value?)?;
             self.memory
-                .put_entries(&deserialize_entries(&batch.into_vec())?);
+                .put_entries(&M::deserialize_cache_entries(&batch.into_vec())?);
         }
 
         info!(
@@ -406,7 +404,7 @@ impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Copy + Default +
         self.storage
             .put::<&ByteBuf>(
                 &Self::fifo_key(insert_idx),
-                &ByteBuf::from(serialize_entries(entries)),
+                &ByteBuf::from(M::serialize_cache_entries(entries)),
             )
             .await?;
 
@@ -415,88 +413,129 @@ impl<M: CacheSerialize + Serialize + DeserializeOwned + Clone + Copy + Default +
     }
 }
 
-/// Serialization format for the `DedupCache` DO storage ring buffer.
+/// Metadata produced by the sequencer for each log entry.
 ///
-/// Each metadata type defines its own binary format so that the format can be
-/// kept stable across upgrades.  `SequenceMetadata` uses the original
-/// 32-bytes-per-entry binary format (16-byte key, 8-byte `leaf_index`,
-/// 8-byte `timestamp`, all big-endian); other types use `serde_json`.
+/// This type is:
+/// - constructed by the sequencer via [`new`](SequencerMetadata::new), which
+///   supplies the leaf index, sequencing timestamp, and pre/post-batch tree sizes
+/// - stored in the sequencer's deduplication cache (serialized via
+///   [`serialize_cache_entries`](SequencerMetadata::serialize_cache_entries))
+/// - returned to the Worker frontend over the DO→Worker wire as the response to
+///   an `add-entry` request
 ///
-/// **NOTE**: Changing this format for a deployed log will result in a `DedupCache::load`
-/// error during sequencer initialization. The sequencer's
-/// [current behavior](https://github.com/cloudflare/azul/blob/ddc4ec7c5432efed4cd5e4308f6026ffa91bc6f6/crates/generic_log_worker/src/sequencer_do.rs#L234)
-/// is to log the error and continue without the short-term deduplication cache.
-pub trait CacheSerialize: Sized {
-    /// Serialize a batch of `(LookupKey, Self)` pairs to bytes.
-    fn serialize_entries(entries: &[(LookupKey, Self)]) -> Vec<u8>;
-    /// Deserialize a batch of `(LookupKey, Self)` pairs from bytes.
+/// The default implementations of the cache-serialization methods use
+/// `serde_json`. Applications that need a different wire format (e.g. a
+/// fixed-width binary layout for backward compatibility with existing
+/// Durable Object storage) should override them.
+pub trait SequencerMetadata:
+    Serialize
+    + DeserializeOwned
+    + Send
+    + Sync
+    + Clone
+    + Copy
+    + std::fmt::Debug
+    + Default
+    + PartialEq
+    + Eq
+    + 'static
+{
+    /// Construct a value from the raw sequencer output. Called once per entry
+    /// at sequencing time.
+    ///
+    /// Every log entry has a `leaf_index` and sequencing `timestamp`; these two
+    /// are always populated. `old_tree_size` and `new_tree_size` are the tree
+    /// sizes immediately before and after the sequencing batch that included
+    /// this entry. They are unused by the default `SequenceMetadata` shape but
+    /// are exposed here so log-specific metadata types can carry them (for
+    /// example, an IETF MTC worker uses them to identify the covering subtree
+    /// for an inclusion proof without enumerating candidates).
+    fn new(
+        leaf_index: LeafIndex,
+        timestamp: UnixTimestamp,
+        old_tree_size: u64,
+        new_tree_size: u64,
+    ) -> Self;
+
+    /// Serialize a batch of `(LookupKey, Self)` pairs for the dedup cache ring
+    /// buffer stored in Durable Object storage.
+    ///
+    /// **NOTE**: Changing this format for a deployed log will result in a
+    /// `DedupCache::load` error during sequencer initialization. The current
+    /// behavior is to log the error and continue without the short-term
+    /// deduplication cache.
+    fn serialize_cache_entries(entries: &[(LookupKey, Self)]) -> Vec<u8> {
+        serde_json::to_vec(entries).expect("serializing cache entries to JSON")
+    }
+
+    /// Deserialize a batch of `(LookupKey, Self)` pairs from the dedup cache
+    /// ring buffer in Durable Object storage.
     ///
     /// # Errors
     ///
     /// Returns a `String` describing the error if the bytes are malformed.
-    /// The `String` can be converted to a `worker::Error` via `From<String>`.
-    fn deserialize_entries(buf: &[u8]) -> std::result::Result<Vec<(LookupKey, Self)>, String>;
-}
-
-/// `SequenceMetadata` uses the original 32-byte binary format for backward
-/// compatibility with existing Durable Object storage.
-impl CacheSerialize for SequenceMetadata {
-    fn serialize_entries(entries: &[(LookupKey, Self)]) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(32 * entries.len());
-        for (k, (idx, ts)) in entries {
-            buf.write_all(k).unwrap();
-            buf.write_u64::<BigEndian>(*idx).unwrap();
-            buf.write_u64::<BigEndian>(*ts).unwrap();
-        }
-        buf
-    }
-
-    fn deserialize_entries(buf: &[u8]) -> std::result::Result<Vec<(LookupKey, Self)>, String> {
-        if !buf.len().is_multiple_of(32) {
-            return Err("invalid buffer length".into());
-        }
-        let mut entries = Vec::with_capacity(buf.len() / 32);
-        let mut cursor = std::io::Cursor::new(buf);
-        while usize::try_from(cursor.position()).unwrap_or(usize::MAX) < buf.len() {
-            let mut key = LookupKey::default();
-            std::io::Read::read_exact(&mut cursor, &mut key)
-                .map_err(|e| format!("reading key: {e}"))?;
-            let idx = cursor
-                .read_u64::<BigEndian>()
-                .map_err(|e| format!("reading `leaf_index`: {e}"))?;
-            let ts = cursor
-                .read_u64::<BigEndian>()
-                .map_err(|e| format!("reading `timestamp`: {e}"))?;
-            entries.push((key, (idx, ts)));
-        }
-        Ok(entries)
+    fn deserialize_cache_entries(
+        buf: &[u8],
+    ) -> std::result::Result<Vec<(LookupKey, Self)>, String> {
+        serde_json::from_slice(buf).map_err(|e| format!("deserializing cache entries: {e}"))
     }
 }
 
-/// Implement `CacheSerialize` via `serde_json` for a given type.
-#[macro_export]
-macro_rules! impl_json_cache_serialize {
-    ($t:ty) => {
-        impl $crate::CacheSerialize for $t {
-            fn serialize_entries(entries: &[($crate::LookupKey, Self)]) -> Vec<u8> {
-                serde_json::to_vec(entries).expect("serializing cache entries to JSON")
-            }
-            fn deserialize_entries(
-                buf: &[u8],
-            ) -> ::std::result::Result<Vec<($crate::LookupKey, Self)>, String> {
-                serde_json::from_slice(buf)
-                    .map_err(|e| format!("deserializing cache entries: {e}"))
-            }
-        }
-    };
+/// A `(LookupKey, (leaf_index, timestamp))` pair as consumed by
+/// [`serialize_sequence_metadata_entries`] / [`deserialize_sequence_metadata_entries`].
+pub type SequenceMetadataEntry = (LookupKey, (LeafIndex, UnixTimestamp));
+
+/// Serialize a batch of [`SequenceMetadataEntry`] values using the fixed
+/// 32-byte binary format:
+///
+/// `[16-byte lookup key | 8-byte leaf_index BE | 8-byte timestamp BE]`
+///
+/// Used by [`SequencerMetadata`] impls that need to preserve backward
+/// compatibility with existing Durable Object dedup cache storage. Any change
+/// to this format will result in a [`DedupCache::load`] error for deployed
+/// logs.
+#[must_use]
+pub fn serialize_sequence_metadata_entries(entries: &[SequenceMetadataEntry]) -> Vec<u8> {
+    use byteorder::{BigEndian, WriteBytesExt};
+    use std::io::Write as _;
+    let mut buf = Vec::with_capacity(32 * entries.len());
+    for (k, (idx, ts)) in entries {
+        buf.write_all(k).unwrap();
+        buf.write_u64::<BigEndian>(*idx).unwrap();
+        buf.write_u64::<BigEndian>(*ts).unwrap();
+    }
+    buf
 }
 
-fn serialize_entries<M: CacheSerialize>(entries: &[(LookupKey, M)]) -> Vec<u8> {
-    M::serialize_entries(entries)
-}
-
-fn deserialize_entries<M: CacheSerialize>(buf: &[u8]) -> Result<Vec<(LookupKey, M)>> {
-    M::deserialize_entries(buf).map_err(Into::into)
+/// Deserialize a batch of [`SequenceMetadataEntry`] values from the 32-byte
+/// binary format produced by [`serialize_sequence_metadata_entries`].
+///
+/// # Errors
+///
+/// Returns an error string if `buf.len()` is not a multiple of 32 or if the
+/// underlying byteorder reads fail.
+pub fn deserialize_sequence_metadata_entries(
+    buf: &[u8],
+) -> std::result::Result<Vec<SequenceMetadataEntry>, String> {
+    use byteorder::{BigEndian, ReadBytesExt};
+    if !buf.len().is_multiple_of(32) {
+        return Err("invalid buffer length".into());
+    }
+    let mut entries = Vec::with_capacity(buf.len() / 32);
+    let mut cursor = std::io::Cursor::new(buf);
+    while usize::try_from(cursor.position()).unwrap_or(usize::MAX) < buf.len() {
+        let mut key = LookupKey::default();
+        std::io::Read::read_exact(&mut cursor, &mut key)
+            .map_err(|e| format!("reading key: {e}"))?;
+        let idx = cursor
+            .read_u64::<BigEndian>()
+            .map_err(|e| format!("reading `leaf_index`: {e}"))?;
+        let ts = cursor
+            .read_u64::<BigEndian>()
+            .map_err(|e| format!("reading `timestamp`: {e}"))?;
+        entries.push((key, (idx, ts)));
+    }
+    Ok(entries)
 }
 
 // A fixed-size in-memory FIFO cache. `M` is the sequence metadata type stored
@@ -809,13 +848,24 @@ impl ObjectBackend for CachedRoObjectBucket {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tlog_tiles::SequenceMetadata;
 
-    /// A minimal metadata type that uses the JSON cache format, for testing
-    /// `serialize_entries`/`deserialize_entries` with non-binary serialization.
-    #[derive(Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+    /// A minimal [`SequencerMetadata`] that uses the default JSON cache format,
+    /// for testing non-binary serialization paths.
+    #[derive(
+        Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize,
+    )]
     struct TestMetadata(u64);
-    impl_json_cache_serialize!(TestMetadata);
+
+    impl SequencerMetadata for TestMetadata {
+        fn new(
+            leaf_index: LeafIndex,
+            _timestamp: UnixTimestamp,
+            _old_tree_size: u64,
+            _new_tree_size: u64,
+        ) -> Self {
+            Self(leaf_index)
+        }
+    }
 
     // ==================== HeadTailValidation Tests ====================
 
@@ -945,51 +995,17 @@ mod tests {
         assert!(keys.is_empty());
     }
 
-    // ==================== serialize/deserialize_entries Tests ====================
-
-    #[test]
-    fn test_serialize_deserialize_entries_roundtrip() {
-        let entries = vec![
-            ([1u8; 16], (100u64, 200u64)),
-            ([2u8; 16], (300u64, 400u64)),
-            ([0xffu8; 16], (u64::MAX, u64::MAX)),
-        ];
-        let serialized = serialize_entries(&entries);
-        let deserialized = deserialize_entries(&serialized).unwrap();
-        assert_eq!(entries, deserialized);
-    }
-
-    #[test]
-    fn test_serialize_deserialize_empty() {
-        let entries: Vec<(LookupKey, SequenceMetadata)> = vec![];
-        let serialized = serialize_entries(&entries);
-        let deserialized = deserialize_entries::<SequenceMetadata>(&serialized).unwrap();
-        assert!(deserialized.is_empty());
-    }
-
-    #[test]
-    fn test_deserialize_invalid_length() {
-        // SequenceMetadata uses the binary format (32 bytes per entry:
-        // 16-byte LookupKey + 8-byte leaf_index + 8-byte timestamp).
-        // A buffer that is not a multiple of 32 bytes should fail.
-        let buf = vec![0u8; 31]; // Not a multiple of 32
-        assert!(deserialize_entries::<SequenceMetadata>(&buf).is_err());
-    }
-
-    #[test]
-    fn test_deserialize_invalid_length_one_extra() {
-        let buf = vec![0u8; 33]; // 32 + 1
-        assert!(deserialize_entries::<SequenceMetadata>(&buf).is_err());
-    }
+    // ==================== serialize/deserialize_cache_entries Tests ====================
 
     #[test]
     fn test_serialize_deserialize_json_roundtrip() {
-        // TestMetadata uses the JSON format; verify entries survive a serialize/deserialize cycle.
+        // TestMetadata uses the default JSON format; verify entries survive
+        // a serialize/deserialize cycle.
         let key1 = LookupKey::from([1u8; 16]);
         let key2 = LookupKey::from([2u8; 16]);
         let entries = vec![(key1, TestMetadata(42)), (key2, TestMetadata(99))];
-        let serialized = serialize_entries(&entries);
-        let deserialized = deserialize_entries::<TestMetadata>(&serialized).unwrap();
+        let serialized = TestMetadata::serialize_cache_entries(&entries);
+        let deserialized = TestMetadata::deserialize_cache_entries(&serialized).unwrap();
         assert_eq!(deserialized.len(), 2);
         assert_eq!(deserialized[0].0, key1);
         assert_eq!(deserialized[0].1 .0, 42);
@@ -999,9 +1015,9 @@ mod tests {
 
     #[test]
     fn test_deserialize_invalid_json() {
-        // TestMetadata uses the JSON format; invalid JSON should fail deserialization.
+        // TestMetadata uses the default JSON format; invalid JSON should fail.
         let buf = b"not valid json";
-        assert!(deserialize_entries::<TestMetadata>(buf).is_err());
+        assert!(TestMetadata::deserialize_cache_entries(buf).is_err());
     }
 
     // ==================== MemoryCache Tests ====================
@@ -1020,7 +1036,7 @@ mod tests {
     #[test]
     fn test_memory_cache_multiple_entries() {
         let cache = MemoryCache::new(10);
-        let entries: Vec<(LookupKey, SequenceMetadata)> = (0..5u8)
+        let entries: Vec<(LookupKey, (u64, u64))> = (0..5u8)
             .map(|i| ([i; 16], (u64::from(i), u64::from(i) * 100)))
             .collect();
 
@@ -1065,7 +1081,7 @@ mod tests {
     #[test]
     fn test_memory_cache_batch_put() {
         let cache = MemoryCache::new(5);
-        let entries: Vec<(LookupKey, SequenceMetadata)> =
+        let entries: Vec<(LookupKey, (u64, u64))> =
             (0..3u8).map(|i| ([i; 16], (u64::from(i), 0))).collect();
 
         cache.put_entries(&entries);
@@ -1078,41 +1094,58 @@ mod tests {
 
     #[test]
     fn test_fifo_key_generation() {
-        assert_eq!(DedupCache::<SequenceMetadata>::fifo_key(0), "fifo:0");
-        assert_eq!(DedupCache::<SequenceMetadata>::fifo_key(127), "fifo:127");
-        assert_eq!(DedupCache::<SequenceMetadata>::fifo_key(128), "fifo:128");
-        assert_eq!(DedupCache::<SequenceMetadata>::fifo_key(u32::MAX), format!("fifo:{}", u32::MAX));
+        assert_eq!(DedupCache::<TestMetadata>::fifo_key(0), "fifo:0");
+        assert_eq!(DedupCache::<TestMetadata>::fifo_key(127), "fifo:127");
+        assert_eq!(DedupCache::<TestMetadata>::fifo_key(128), "fifo:128");
+        assert_eq!(
+            DedupCache::<TestMetadata>::fifo_key(u32::MAX),
+            format!("fifo:{}", u32::MAX)
+        );
     }
 
-    /// Regression test: confirm the `SequenceMetadata` binary wire format has
-    /// not changed.  Any change here would corrupt the dedup ring buffer in
-    /// Durable Object storage for deployed CT and bootstrap MTC workers.
-    ///
-    /// Format: `[16-byte key | 8-byte leaf_index BE | 8-byte timestamp BE]`
+    // ==================== sequence_metadata binary format Tests ====================
+
+    /// Confirm the shared 32-byte binary cache format is exactly
+    /// `[16-byte key | 8-byte leaf_index BE | 8-byte timestamp BE]`.
+    /// Any change would corrupt deployed workers' DO dedup ring buffer.
     #[test]
-    fn test_sequence_metadata_cache_format_unchanged() {
+    fn test_sequence_metadata_binary_format_unchanged() {
         let key: LookupKey = [
-            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+            0x0e, 0x0f,
         ];
-        let leaf_index: u64 = 0x0102030405060708;
-        let timestamp: u64  = 0x0a0b0c0d0e0f1011;
+        let leaf_index: u64 = 0x0102_0304_0506_0708;
+        let timestamp: u64 = 0x0a0b_0c0d_0e0f_1011;
 
-        let entries: Vec<(LookupKey, SequenceMetadata)> = vec![(key, (leaf_index, timestamp))];
-        let serialized = serialize_entries(&entries);
+        let entries = vec![(key, (leaf_index, timestamp))];
+        let serialized = serialize_sequence_metadata_entries(&entries);
 
-        // Manually construct the expected 32-byte buffer.
         let mut expected = Vec::with_capacity(32);
         expected.extend_from_slice(&key);
         expected.extend_from_slice(&leaf_index.to_be_bytes());
         expected.extend_from_slice(&timestamp.to_be_bytes());
 
-        assert_eq!(serialized, expected,
-            "SequenceMetadata binary format has changed — this will corrupt \
-             existing Durable Object dedup cache storage");
+        assert_eq!(
+            serialized, expected,
+            "sequence_metadata binary format has changed — this will corrupt \
+             existing Durable Object dedup cache storage"
+        );
 
-        // Round-trip.
-        let deserialized = deserialize_entries::<SequenceMetadata>(&serialized).unwrap();
+        let deserialized = deserialize_sequence_metadata_entries(&serialized).unwrap();
         assert_eq!(deserialized, entries);
+    }
+
+    #[test]
+    fn test_sequence_metadata_binary_empty() {
+        let entries: Vec<(LookupKey, (u64, u64))> = vec![];
+        let serialized = serialize_sequence_metadata_entries(&entries);
+        let deserialized = deserialize_sequence_metadata_entries(&serialized).unwrap();
+        assert!(deserialized.is_empty());
+    }
+
+    #[test]
+    fn test_sequence_metadata_binary_invalid_length() {
+        assert!(deserialize_sequence_metadata_entries(&[0u8; 31]).is_err());
+        assert!(deserialize_sequence_metadata_entries(&[0u8; 33]).is_err());
     }
 }

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -23,7 +23,6 @@ use crate::{
     util::now_millis,
     CacheRead, CacheWrite, LockBackend, LookupKey, ObjectBackend, SequencerConfig,
 };
-use serde::de::DeserializeOwned;
 use anyhow::{anyhow, bail};
 use futures_util::future::try_join_all;
 use log::{debug, error, info, trace, warn};
@@ -39,6 +38,7 @@ use std::{
     sync::LazyLock,
 };
 use thiserror::Error;
+use crate::SequencerMetadata;
 use tlog_tiles::{
     Hash, HashReader, LogEntry, PendingLogEntry, PreloadedTlogTileReader, Proof, Subtree,
     TileHashReader, TileIterator, TlogError, TlogTile, TlogTileRecorder, TreeWithTimestamp,
@@ -109,7 +109,7 @@ impl<P: PendingLogEntry, M: Copy + Debug + Default + 'static> Default for PoolSt
     }
 }
 
-impl<E: PendingLogEntry, M: Serialize + DeserializeOwned + Copy + Debug + Default + 'static> PoolState<E, M> {
+impl<E: PendingLogEntry, M: SequencerMetadata> PoolState<E, M> {
     // Check if the key is already in the pool. If so, return a Receiver from
     // which to read the entry metadata when it is sequenced.
     fn check(&self, key: &LookupKey) -> Option<AddLeafResult<M>> {
@@ -718,7 +718,7 @@ pub(crate) fn add_leaf_to_pool<E, M>(
 ) -> AddLeafResult<M>
 where
     E: PendingLogEntry,
-    M: Serialize + DeserializeOwned + Copy + Debug + Default + 'static,
+    M: SequencerMetadata,
 {
     let hash = entry.lookup_key();
     let mut state = state.borrow_mut();
@@ -744,13 +744,13 @@ where
 ///
 /// Will return an error if sequencing fails with an error that requires the
 /// sequencer to be re-initialized to get into a good state.
-pub(crate) async fn sequence<L: LogEntry>(
-    pool_state: &RefCell<PoolState<L::Pending, L::Metadata>>,
+pub(crate) async fn sequence<L: LogEntry, M: SequencerMetadata>(
+    pool_state: &RefCell<PoolState<L::Pending, M>>,
     sequence_state: &RefCell<SequenceState>,
     config: &SequencerConfig,
     object: &impl ObjectBackend,
     lock: &impl LockBackend,
-    cache: &impl CacheWrite<L::Metadata>,
+    cache: &impl CacheWrite<M>,
     metrics: &SequencerMetrics,
 ) -> Result<(), anyhow::Error> {
     let Some(entries) = pool_state.borrow_mut().take(
@@ -765,7 +765,7 @@ pub(crate) async fn sequence<L: LogEntry>(
 
     metrics.seq_pool_size.observe(entries.len().as_f64());
 
-    let result = match sequence_entries::<L>(
+    let result = match sequence_entries::<L, M>(
         sequence_state,
         config,
         object,
@@ -816,13 +816,13 @@ enum SequenceError {
 /// If a non-fatal sequencing error occurs, pending requests will receive an error but the log will continue as normal.
 /// If a fatal sequencing error occurs, the ephemeral log state must be reloaded before the next sequencing.
 #[allow(clippy::too_many_lines)]
-async fn sequence_entries<L: LogEntry>(
+async fn sequence_entries<L: LogEntry, M: SequencerMetadata>(
     sequence_state: &RefCell<SequenceState>,
     config: &SequencerConfig,
     object: &impl ObjectBackend,
     lock: &impl LockBackend,
-    cache: &impl CacheWrite<L::Metadata>,
-    entries: Vec<(L::Pending, Sender<L::Metadata>)>,
+    cache: &impl CacheWrite<M>,
+    entries: Vec<(L::Pending, Sender<M>)>,
     metrics: &SequencerMetrics,
 ) -> Result<(), SequenceError> {
     let name = &config.name;
@@ -870,10 +870,10 @@ async fn sequence_entries<L: LogEntry>(
         }
 
         // Add the entry and metadata to our lists of things sequenced.
-        // L::make_metadata provides the application-specific metadata type,
-        // which may include leaf_index, timestamp, and the old and new sizes
-        // of the tree (for subtree inclusion proofs).
-        let metadata = L::make_metadata(n, timestamp, old_size, new_size);
+        // `M::new` constructs the application-specific metadata, which may
+        // include leaf_index, timestamp, and the old and new tree sizes (e.g.
+        // for subtree inclusion proofs).
+        let metadata = M::new(n, timestamp, old_size, new_size);
         cache_metadata.push((entry.lookup_key(), metadata));
         sequenced_metadata.push((sender, metadata));
 
@@ -1378,8 +1378,25 @@ pub async fn upload_issuers(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tlog_tiles::SequenceMetadata;
     use crate::{empty_checkpoint_callback, util};
+    use tlog_tiles::LeafIndex;
+
+    /// Local metadata type used to exercise the sequencer and batcher logic
+    /// end-to-end. Kept as a `(LeafIndex, UnixTimestamp)` tuple so existing
+    /// tests can destructure with `let (leaf_index, timestamp) = ...`. The
+    /// JSON cache serialization defaults are fine for tests.
+    type SequenceMetadata = (LeafIndex, UnixTimestamp);
+
+    impl SequencerMetadata for SequenceMetadata {
+        fn new(
+            leaf_index: LeafIndex,
+            timestamp: UnixTimestamp,
+            _old_tree_size: u64,
+            _new_tree_size: u64,
+        ) -> Self {
+            (leaf_index, timestamp)
+        }
+    }
 
     use anyhow::ensure;
     use ed25519_dalek::SigningKey as Ed25519SigningKey;
@@ -2471,7 +2488,7 @@ mod tests {
             }
         }
         fn sequence(&mut self) -> Result<(), anyhow::Error> {
-            block_on(sequence::<StaticCTLogEntry>(
+            block_on(sequence::<StaticCTLogEntry, SequenceMetadata>(
                 &self.pool_state,
                 &self.sequence_state,
                 &self.config,
@@ -2495,7 +2512,7 @@ mod tests {
             &mut self,
             entries: Vec<(StaticCTPendingLogEntry, Sender<SequenceMetadata>)>,
         ) {
-            block_on(sequence_entries::<StaticCTLogEntry>(
+            block_on(sequence_entries::<StaticCTLogEntry, SequenceMetadata>(
                 &self.sequence_state,
                 &self.config,
                 &self.object,

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -882,7 +882,7 @@ async fn sequence_entries<L: LogEntry>(
             aux_tile.extend(entry.aux_entry());
         }
 
-        let sequenced_entry = L::new(entry, metadata);
+        let sequenced_entry = L::new(entry, n, timestamp);
         let tile_leaf = sequenced_entry.to_data_tile_entry();
         let merkle_tree_leaf = sequenced_entry.merkle_tree_leaf();
         metrics.seq_leaf_size.observe(tile_leaf.len().as_f64());

--- a/crates/generic_log_worker/src/sequencer_do.rs
+++ b/crates/generic_log_worker/src/sequencer_do.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     serialize,
     util::now_millis,
-    CacheSerialize, DedupCache, LookupKey, MemoryCache, ObjectBucket, BATCH_ENDPOINT,
+    DedupCache, LookupKey, MemoryCache, ObjectBucket, SequencerMetadata, BATCH_ENDPOINT,
     CLEANER_BINDING, ENTRY_ENDPOINT,
 };
 use futures_util::future::join_all;
@@ -31,14 +31,14 @@ use worker::{Env, Error as WorkerError, Request, Response, State};
 // It should hold at least <maximum-entries-per-second> x <kv-eventual-consistency-time (60s)> entries.
 const MEMORY_CACHE_SIZE: usize = 300_000;
 
-pub struct GenericSequencer<L: LogEntry> {
+pub struct GenericSequencer<L: LogEntry, M: SequencerMetadata> {
     env: Env,
-    do_state: State,                                  // implements LockBackend
-    public_bucket: RwLock<ObjectBucket>,              // implements ObjectBackend
-    cache: DedupCache<L::Metadata>,                   // implements CacheRead, CacheWrite
+    do_state: State,                     // implements LockBackend
+    public_bucket: RwLock<ObjectBucket>, // implements ObjectBackend
+    cache: DedupCache<M>,                // implements CacheRead, CacheWrite
     config: SequencerConfig,
     sequence_state: RefCell<SequenceState>,
-    pool_state: RefCell<PoolState<L::Pending, L::Metadata>>,
+    pool_state: RefCell<PoolState<L::Pending, M>>,
     initialized: RefCell<bool>,
     init_mux: Mutex<()>,
     wshim: Option<Wshim>,
@@ -62,7 +62,7 @@ pub struct SequencerConfig {
     pub env_label: String,
 }
 
-impl<L: LogEntry<Metadata: CacheSerialize>> GenericSequencer<L> {
+impl<L: LogEntry, M: SequencerMetadata> GenericSequencer<L, M> {
     /// Return a new sequencer with the given config.
     ///
     /// # Panics
@@ -175,7 +175,7 @@ impl<L: LogEntry<Metadata: CacheSerialize>> GenericSequencer<L> {
             .set_alarm(self.config.sequence_interval)
             .await?;
 
-        if log_ops::sequence::<L>(
+        if log_ops::sequence::<L, M>(
             &self.pool_state,
             &self.sequence_state,
             &self.config,
@@ -219,7 +219,7 @@ impl<L: LogEntry<Metadata: CacheSerialize>> GenericSequencer<L> {
     }
 }
 
-impl<L: LogEntry<Metadata: CacheSerialize>> GenericSequencer<L> {
+impl<L: LogEntry, M: SequencerMetadata> GenericSequencer<L, M> {
     // Initialize the durable object when it is started on a new machine (e.g., after eviction or a deployment).
     async fn initialize(&self, metrics: &SequencerMetrics) -> Result<(), WorkerError> {
         // This can be triggered by the alarm() or fetch() handlers, so lock state to avoid a race condition.
@@ -313,7 +313,7 @@ impl<L: LogEntry<Metadata: CacheSerialize>> GenericSequencer<L> {
         &self,
         pending_entries: Vec<PendingLogEntryBlob>,
         metrics: &SequencerMetrics,
-    ) -> Result<Vec<(LookupKey, L::Metadata)>, WorkerError> {
+    ) -> Result<Vec<(LookupKey, M)>, WorkerError> {
         // Safe to unwrap config here as the log must be initialized.
         let mut futures = Vec::with_capacity(pending_entries.len());
         let mut lookup_keys = Vec::with_capacity(pending_entries.len());

--- a/crates/static_ct_api/src/static_ct.rs
+++ b/crates/static_ct_api/src/static_ct.rs
@@ -295,11 +295,15 @@ impl LogEntry for StaticCTLogEntry {
         None
     }
 
-    fn new(pending: StaticCTPendingLogEntry, metadata: Self::Metadata) -> Self {
+    fn new(
+        pending: StaticCTPendingLogEntry,
+        leaf_index: LeafIndex,
+        timestamp: UnixTimestamp,
+    ) -> Self {
         StaticCTLogEntry {
             inner: pending,
-            leaf_index: metadata.0,
-            timestamp: metadata.1,
+            leaf_index,
+            timestamp,
         }
     }
 
@@ -519,7 +523,11 @@ impl RFC6962NoteVerifier {
             .map_err(|_| NoteError::Format)?
             .to_vec();
         let key_id = Sha256::digest(&pkix);
-        let id = signed_note::compute_key_id(&name, &[SignatureType::RFC6962TreeHead as u8], &key_id[..]);
+        let id = signed_note::compute_key_id(
+            &name,
+            &[SignatureType::RFC6962TreeHead as u8],
+            &key_id[..],
+        );
 
         Ok(Self {
             name,
@@ -774,7 +782,7 @@ mod tests {
             precert_opt: None,
             chain_fingerprints: vec![[0; 32], [1; 32], [2; 32]],
         };
-        let entry = StaticCTLogEntry::new(inner, (123, 456));
+        let entry = StaticCTLogEntry::new(inner, 123, 456);
         let tile: Vec<u8> = (0..5).flat_map(|_| entry.to_data_tile_entry()).collect();
         let mut tile_reader: &[u8] = tile.as_ref();
 

--- a/crates/static_ct_api/src/static_ct.rs
+++ b/crates/static_ct_api/src/static_ct.rs
@@ -121,7 +121,7 @@ use signed_note::{KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType
 use std::io::Read;
 use tlog_tiles::{
     CheckpointSigner, CheckpointText, Hash, LeafIndex, LogEntry, LookupKey, PathElem,
-    PendingLogEntry, SequenceMetadata, UnixTimestamp,
+    PendingLogEntry, UnixTimestamp,
 };
 
 #[repr(u16)]
@@ -280,16 +280,6 @@ impl LogEntry for StaticCTLogEntry {
     const REQUIRE_CHECKPOINT_TIMESTAMP: bool = true;
     type Pending = StaticCTPendingLogEntry;
     type ParseError = StaticCTError;
-    type Metadata = SequenceMetadata;
-
-    fn make_metadata(
-        leaf_index: LeafIndex,
-        timestamp: UnixTimestamp,
-        _old_tree_size: u64,
-        _new_tree_size: u64,
-    ) -> Self::Metadata {
-        (leaf_index, timestamp)
-    }
 
     fn initial_entry() -> Option<Self::Pending> {
         None

--- a/crates/tlog_tiles/src/entries.rs
+++ b/crates/tlog_tiles/src/entries.rs
@@ -94,7 +94,11 @@ pub trait LogEntry: core::fmt::Debug + Sized {
     /// useful anywhere else.
     fn initial_entry() -> Option<Self::Pending>;
 
-    fn new(pending: Self::Pending, metadata: Self::Metadata) -> Self;
+    /// Construct a sequenced log entry from a pending entry plus the two
+    /// sequencer-generated values common to every tlog application: the leaf
+    /// index and the sequencing timestamp. Application-specific sequencer
+    /// metadata (e.g. tree sizes) is handled outside this trait.
+    fn new(pending: Self::Pending, leaf_index: LeafIndex, timestamp: UnixTimestamp) -> Self;
 
     /// Returns the Merkle tree leaf hash for this entry. For tlog-tiles, this is the Merkle Tree Hash
     /// (according to <https://datatracker.ietf.org/doc/html/rfc6962#section-2.1>)
@@ -203,7 +207,7 @@ impl LogEntry for TlogTilesLogEntry {
         None
     }
 
-    fn new(pending: Self::Pending, _metadata: Self::Metadata) -> Self {
+    fn new(pending: Self::Pending, _leaf_index: LeafIndex, _timestamp: UnixTimestamp) -> Self {
         Self { inner: pending }
     }
 
@@ -237,7 +241,7 @@ mod tests {
     #[test]
     fn test_parse_tile_entry() {
         let inner = TlogTilesPendingLogEntry { data: vec![1; 100] };
-        let entry = TlogTilesLogEntry::new(inner, (123, 456));
+        let entry = TlogTilesLogEntry::new(inner, 123, 456);
         let tile: Vec<u8> = (0..5).flat_map(|_| entry.to_data_tile_entry()).collect();
         let mut tile_reader: &[u8] = tile.as_ref();
 

--- a/crates/tlog_tiles/src/entries.rs
+++ b/crates/tlog_tiles/src/entries.rs
@@ -1,7 +1,7 @@
 use length_prefixed::{ReadLengthPrefixedBytesExt, WriteLengthPrefixedBytesExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::{fmt::Debug, io::Read, marker::PhantomData};
+use std::{io::Read, marker::PhantomData};
 
 use crate::{Hash, PathElem, TlogError};
 
@@ -13,15 +13,6 @@ pub type UnixTimestamp = u64;
 
 /// Index of a leaf in the Merkle tree.
 pub type LeafIndex = u64;
-
-/// Default sequence metadata type: `(LeafIndex, UnixTimestamp)`.
-///
-/// Used by all tlog applications that don't need tree-size information.
-/// Applications that need additional metadata (e.g. the IETF MTC worker, which
-/// needs `old_tree_size` and `new_tree_size` to compute subtree signature keys
-/// without enumeration) define their own type via the [`LogEntry::Metadata`]
-/// associated type.
-pub type SequenceMetadata = (LeafIndex, UnixTimestamp);
 
 /// An opaque `PendingLogEntry` that can be passed around without requiring full
 /// deserialization.
@@ -59,35 +50,6 @@ pub trait LogEntry: core::fmt::Debug + Sized {
 
     /// The error type for [`Self::parse_from_tile_entry`]
     type ParseError: std::error::Error + Send + Sync + 'static;
-
-    /// The metadata produced by the sequencer for each entry.  Transmitted from
-    /// the sequencing backend to the frontend as the response to an `add-entry`
-    /// request.
-    ///
-    /// Most applications use the default [`SequenceMetadata`] = `(LeafIndex,
-    /// UnixTimestamp)`.  Applications that need additional sequencer-computed
-    /// values (e.g. tree sizes for subtree key lookup) define their own type.
-    type Metadata: Serialize
-        + DeserializeOwned
-        + Send
-        + Sync
-        + Clone
-        + Copy
-        + Debug
-        + Default
-        + 'static;
-
-    /// Construct a [`Self::Metadata`] value from the sequencer's raw output.
-    ///
-    /// Called once per entry at sequencing time.  The `SequenceMetadata`
-    /// implementation ignores `old_tree_size` and `new_tree_size`; other
-    /// implementations may use all four parameters.
-    fn make_metadata(
-        leaf_index: LeafIndex,
-        timestamp: UnixTimestamp,
-        old_tree_size: u64,
-        new_tree_size: u64,
-    ) -> Self::Metadata;
 
     /// Returns an optional initial entry to add into the log. This is used for
     /// the initial `null_entry` in Merkle Tree Certificates, but likely not
@@ -192,16 +154,6 @@ impl LogEntry for TlogTilesLogEntry {
     const REQUIRE_CHECKPOINT_TIMESTAMP: bool = false;
     type Pending = TlogTilesPendingLogEntry;
     type ParseError = TlogError;
-    type Metadata = SequenceMetadata;
-
-    fn make_metadata(
-        leaf_index: LeafIndex,
-        timestamp: UnixTimestamp,
-        _old_tree_size: u64,
-        _new_tree_size: u64,
-    ) -> Self::Metadata {
-        (leaf_index, timestamp)
-    }
 
     fn initial_entry() -> Option<Self::Pending> {
         None


### PR DESCRIPTION
This PR refactors some of the changes introduced in https://github.com/cloudflare/azul/pull/210 for cleaner API boundaries, and setting up for the IETF MTC worker which will need to pass the old and new tree sizes from Sequencer to Frontend Worker in addition to the existing leaf index and timestamp fields.

Motivation: cleaner API boundaries between spec-level and Workers-level
crates. Previously tlog_tiles (a published crate implementing the public
c2sp.org/tlog-tiles spec) carried a Metadata associated type on LogEntry
that existed only to describe Cloudflare Durable Object dedup cache wire
formats -- a concern of the sequencer/batcher/frontend runtime, not of the
tlog spec. Moving this concept into generic_log_worker keeps tlog_tiles
focused on the spec and lets each worker own the metadata shape (and wire
format) that matches its own deployment constraints. AGENTS.md is updated
to codify this boundary.

* Decouple sequencer metadata from LogEntry via per-worker SequencerMetadata types

  Introduces a SequencerMetadata trait in generic_log_worker that captures the
  sequencer-level responsibilities previously attached to LogEntry::Metadata:

    - constructing metadata for a sequenced entry (make)
    - serializing/deserializing it in the short-term dedup cache ring buffer
      stored in Durable Object storage (serialize_cache_entries /
      deserialize_cache_entries; defaults use serde_json)

  Values of a SequencerMetadata type also flow over the wire as the per-entry
  response from the Sequencer DO to the Batcher DO and on to the Worker
  frontend (via bitcode), and -- for ct_worker -- back out as JSON metadata in
  the long-term KV dedup cache. Each worker's SequencerMetadata type must
  preserve these wire formats across upgrades.

  LogEntry no longer has a Metadata associated type; GenericSequencer is now
  generic over <L: LogEntry, M: SequencerMetadata>, and GenericBatcher is
  generic over <M: SequencerMetadata> alone (it never inspects entry contents).
  The CacheSerialize trait and impl_json_cache_serialize! macro are removed.

  Each worker now owns its metadata type as a local tuple struct newtype over
  (LeafIndex, UnixTimestamp):

    - ct_worker::StaticCTSequenceMetadata preserves both the 32-byte binary DO
      cache format and the `[leaf_index, timestamp]` JSON format used by the
      long-term KV dedup cache (automatic for tuple structs under serde).

    - bootstrap_mtc_worker::BootstrapMtcSequenceMetadata preserves the same
      32-byte binary DO cache format so existing ring-buffer entries continue
      to deserialize after deploy. (Bootstrap does not use the long-term KV
      cache, so no JSON wire format constraint applies.)

  The shared binary format lives in generic_log_worker as the free functions
  serialize_sequence_metadata_entries / deserialize_sequence_metadata_entries,
  with a regression test pinning the 32-byte layout.

* Simplify LogEntry::new to take (leaf_index, timestamp) instead of Metadata

  The metadata argument was only used to pass leaf_index and timestamp into the
  sequenced entry struct; only StaticCTLogEntry actually read the fields. Taking
  these two values directly removes a layer of indirection and decouples
  LogEntry::new from the Metadata associated type, paving the way for separating
  sequencer metadata from entry-construction metadata.
