### PR TITLE
Fix cargo fmt and clippy complaints, and use latest rust 1.95 toolchain in CI

### DIFF
--- a/.github/workflows/bonk.yml
+++ b/.github/workflows/bonk.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-
+      - run: rustup update stable && rustup default stable
       - name: Run Bonk
         uses: ask-bonk/ask-bonk/github@main
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,10 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
       - name: Clippy (required)
         run: cargo clippy -- -D warnings
       - name: Clippy (pedantic, advisory)
-        run: cargo clippy --tests -- -W clippy::pedantic
+        run: cargo clippy --workspace --all-targets -- -Dwarnings -Dclippy::pedantic
         continue-on-error: true
       - name: Unused dependencies (advisory)
         run: cargo install cargo-machete --quiet && cargo machete
@@ -32,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
       - name: Build
         run: cargo build --tests --workspace --verbose
 
@@ -40,5 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
       - name: Run tests
         run: cargo test --verbose

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,11 +77,13 @@ npx wrangler -e=${ENV} tail
 ✅ **Always:** Before pushing any commit, run the pre-push checks locally and confirm they pass:
 
 ```bash
-cargo clippy --workspace --all-targets -- -D warnings   # lint; CI fails on any warning
-cargo test --workspace --lib --bins                     # unit tests (integration_tests requires wrangler dev; skip or run separately)
-cargo fmt --all --check                                 # formatting; advisory in CI, but easy to fix
-cargo machete                                           # unused-dependency check; advisory in CI, but easy to fix
+cargo clippy --workspace --all-targets -- -Dwarnings -Dclippy::pedantic # lint everything (including fuzz)
+cargo test                                                              # unit tests; uses default-members, so integration_tests and fuzz are skipped
+cargo fmt --all --check                                                 # advisory in CI, easy to fix
+cargo machete                                                           # unused-dependency check; advisory in CI, easy to fix
 ```
+
+`integration_tests` is excluded from the default test run because it requires a live `wrangler dev` instance (invoke it explicitly once wrangler is running; see the integration test workflow below). `fuzz` is excluded because it is the cargo-fuzz harness crate, run via `cargo fuzz run <target>` on a nightly toolchain. Both are still linted.
 
 If any step fails, fix the issue in the commit it belongs to (use `git commit --fixup=<sha>` + `git rebase --autosquash`) rather than layering a separate "fix lint" commit on top.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,19 @@ members = [
     "crates/x509_util",
     "fuzz",
 ]
-# Exclude integration_tests from the default test run — it requires a live
-# wrangler dev instance and will hang if run without one.
-# Run explicitly with: cargo test -p integration_tests --test static_ct_api
+# Exclude two kinds of crates from the default `cargo <cmd>` run:
+#   * `integration_tests`: requires a live wrangler dev instance and will
+#     hang if run without one. Invoke explicitly with, e.g.
+#     `cargo test -p integration_tests --test static_ct_api`.
+#   * `fuzz`: cargo-fuzz targets that depend on `libfuzzer-sys` and a
+#     nightly toolchain / sanitizer runtime. Invoke explicitly with
+#     `cargo fuzz run <target>`.
 default-members = [
+    "crates/bootstrap_mtc_api",
+    "crates/bootstrap_mtc_worker",
     "crates/ct_worker",
     "crates/generic_log_worker",
     "crates/length_prefixed",
-    "crates/bootstrap_mtc_api",
-    "crates/bootstrap_mtc_worker",
     "crates/sct_validator",
     "crates/signed_note",
     "crates/signed_note_wasm",
@@ -37,7 +41,6 @@ default-members = [
     "crates/tlog_tiles",
     "crates/tlog_tiles_wasm",
     "crates/x509_util",
-    "fuzz",
 ]
 
 [workspace.package]

--- a/crates/bootstrap_mtc_api/src/landmark.rs
+++ b/crates/bootstrap_mtc_api/src/landmark.rs
@@ -448,8 +448,7 @@ mod tests {
 
         assert_eq!(
             num_active, max_active_landmarks,
-            "Serialized file should have num_active_landmarks = {}",
-            max_active_landmarks
+            "Serialized file should have num_active_landmarks = {max_active_landmarks}"
         );
 
         // File should contain num_active + 1 lines of tree sizes

--- a/crates/bootstrap_mtc_api/src/lib.rs
+++ b/crates/bootstrap_mtc_api/src/lib.rs
@@ -839,7 +839,7 @@ mod tests {
             .extensions
             .as_mut()
             .unwrap_or(&mut Vec::new())
-            .sort_by(|a, b| b.extn_id.cmp(&a.extn_id));
+            .sort_by_key(|b| std::cmp::Reverse(b.extn_id));
 
         // Still valid.
         validate_correspondence(&log_entry, &raw_chain, &roots).unwrap();

--- a/crates/bootstrap_mtc_worker/src/batcher_do.rs
+++ b/crates/bootstrap_mtc_worker/src/batcher_do.rs
@@ -1,7 +1,5 @@
 use crate::{BootstrapMtcSequenceMetadata, CONFIG};
-use generic_log_worker::{
-    get_durable_object_name, BatcherConfig, GenericBatcher, BATCHER_BINDING,
-};
+use generic_log_worker::{get_durable_object_name, BatcherConfig, GenericBatcher, BATCHER_BINDING};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 

--- a/crates/bootstrap_mtc_worker/src/cleaner_do.rs
+++ b/crates/bootstrap_mtc_worker/src/cleaner_do.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use crate::{load_checkpoint_cosigner, load_origin, CONFIG};
-use generic_log_worker::{get_durable_object_name, CleanerConfig, GenericCleaner, CLEANER_BINDING};
 use bootstrap_mtc_api::BootstrapMtcPendingLogEntry;
+use generic_log_worker::{get_durable_object_name, CleanerConfig, GenericCleaner, CLEANER_BINDING};
 use signed_note::VerifierList;
 use tlog_tiles::{CheckpointSigner, PendingLogEntry};
 #[allow(clippy::wildcard_imports)]

--- a/crates/bootstrap_mtc_worker/src/frontend_worker.rs
+++ b/crates/bootstrap_mtc_worker/src/frontend_worker.rs
@@ -3,7 +3,13 @@
 
 //! Entrypoint for the static CT submission APIs.
 
-use crate::{load_checkpoint_cosigner, load_origin, load_roots, BootstrapMtcSequenceMetadata, CONFIG};
+use crate::{
+    load_checkpoint_cosigner, load_origin, load_roots, BootstrapMtcSequenceMetadata, CONFIG,
+};
+use bootstrap_mtc_api::{
+    serialize_signatureless_cert, AddEntryRequest, AddEntryResponse, BootstrapMtcLogEntry,
+    GetRootsResponse, LandmarkSequence, ID_RDNA_TRUSTANCHOR_ID, LANDMARK_BUNDLE_KEY, LANDMARK_KEY,
+};
 use der::{
     asn1::{UtcTime, Utf8StringRef},
     Any, Encode, Tag,
@@ -16,10 +22,6 @@ use generic_log_worker::{
     serialize,
     util::now_millis,
     ObjectBackend, ObjectBucket, ENTRY_ENDPOINT,
-};
-use bootstrap_mtc_api::{
-    serialize_signatureless_cert, AddEntryRequest, AddEntryResponse, BootstrapMtcLogEntry,
-    GetRootsResponse, LandmarkSequence, ID_RDNA_TRUSTANCHOR_ID, LANDMARK_BUNDLE_KEY, LANDMARK_KEY,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
@@ -302,7 +304,10 @@ fn build_validity(
     let not_after = UtcTime::from_unix_duration(now + Duration::from_secs(max_lifetime_secs))
         .map_err(|e| e.to_string())?;
 
-    Ok(Validity::new(Time::UtcTime(not_before), Time::UtcTime(not_after)))
+    Ok(Validity::new(
+        Time::UtcTime(not_before),
+        Time::UtcTime(not_after),
+    ))
 }
 
 /// Returns the issuer cert for SCT validation. For multi-cert chains, that's

--- a/crates/bootstrap_mtc_worker/src/lib.rs
+++ b/crates/bootstrap_mtc_worker/src/lib.rs
@@ -4,9 +4,9 @@
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 
 use crate::ccadb_roots_cron::{update_ccadb_roots, CCADB_ROOTS_FILENAME, CCADB_ROOTS_NAMESPACE};
+use bootstrap_mtc_api::{MtcCosigner, TrustAnchorID};
 use config::AppConfig;
 use ed25519_dalek::SigningKey as Ed25519SigningKey;
-use bootstrap_mtc_api::{MtcCosigner, TrustAnchorID};
 use p256::pkcs8::DecodePrivateKey;
 use signed_note::KeyName;
 use std::collections::HashMap;

--- a/crates/bootstrap_mtc_worker/src/sequencer_do.rs
+++ b/crates/bootstrap_mtc_worker/src/sequencer_do.rs
@@ -6,15 +6,15 @@
 use std::{collections::VecDeque, time::Duration};
 
 use crate::{load_checkpoint_cosigner, load_origin, BootstrapMtcSequenceMetadata, CONFIG};
+use bootstrap_mtc_api::{
+    BootstrapMtcLogEntry, LandmarkSequence, LANDMARK_BUNDLE_KEY, LANDMARK_CHECKPOINT_KEY,
+    LANDMARK_KEY,
+};
 use generic_log_worker::{
     get_durable_object_name, load_public_bucket,
     log_ops::{prove_subtree_consistency, ProofError},
     CachedRoObjectBucket, CheckpointCallbacker, GenericSequencer, ObjectBucket, SequencerConfig,
     SEQUENCER_BINDING,
-};
-use bootstrap_mtc_api::{
-    BootstrapMtcLogEntry, LandmarkSequence, LANDMARK_BUNDLE_KEY, LANDMARK_CHECKPOINT_KEY,
-    LANDMARK_KEY,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
@@ -86,7 +86,11 @@ fn checkpoint_callback(env: &Env, name: &str) -> CheckpointCallbacker {
     let params = &CONFIG.logs[name];
     let bucket = load_public_bucket(env, name).unwrap();
     Box::new(
-        move |old_time: UnixTimestamp, new_time: UnixTimestamp, _old_tree_size: u64, _new_tree_size: u64, new_checkpoint_bytes: &[u8]| {
+        move |old_time: UnixTimestamp,
+              new_time: UnixTimestamp,
+              _old_tree_size: u64,
+              _new_tree_size: u64,
+              new_checkpoint_bytes: &[u8]| {
             let new_checkpoint = {
                 // TODO: Make more efficient. There are two unnecessary allocations here.
 

--- a/crates/ct_worker/src/batcher_do.rs
+++ b/crates/ct_worker/src/batcher_do.rs
@@ -1,7 +1,5 @@
 use crate::{StaticCTSequenceMetadata, CONFIG};
-use generic_log_worker::{
-    get_durable_object_name, BatcherConfig, GenericBatcher, BATCHER_BINDING,
-};
+use generic_log_worker::{get_durable_object_name, BatcherConfig, GenericBatcher, BATCHER_BINDING};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -234,18 +234,13 @@ async fn add_chain_or_pre_chain(
 
     // Check if entry is cached and return right away if so.
     if params.enable_dedup {
-        if let Some(metadata) = get_cached_metadata::<StaticCTSequenceMetadata>(
-            &load_cache_kv(env, name)?,
-            &lookup_key,
-        )
-        .await?
+        if let Some(metadata) =
+            get_cached_metadata::<StaticCTSequenceMetadata>(&load_cache_kv(env, name)?, &lookup_key)
+                .await?
         {
             log::debug!("{name}: Entry is cached");
-            let entry = StaticCTLogEntry::new(
-                pending_entry,
-                metadata.leaf_index(),
-                metadata.timestamp(),
-            );
+            let entry =
+                StaticCTLogEntry::new(pending_entry, metadata.leaf_index(), metadata.timestamp());
             let sct = static_ct_api::signed_certificate_timestamp(signing_key, &entry)
                 .map_err(|e| e.to_string())?;
             return Response::from_json(&sct);

--- a/crates/generic_log_worker/src/batcher_do.rs
+++ b/crates/generic_log_worker/src/batcher_do.rs
@@ -226,22 +226,21 @@ impl<M: SequencerMetadata> GenericBatcher<M> {
                 ..Default::default()
             },
         )?;
-        let sequenced_entries: HashMap<LookupKey, M> =
-            deserialize::<Vec<(LookupKey, M)>>(
-                &get_durable_object_stub(
-                    &self.env,
-                    &self.config.name,
-                    None,
-                    SEQUENCER_BINDING,
-                    self.config.location_hint.as_deref(),
-                )?
-                .fetch_with_request(req)
-                .await?
-                .bytes()
-                .await?,
+        let sequenced_entries: HashMap<LookupKey, M> = deserialize::<Vec<(LookupKey, M)>>(
+            &get_durable_object_stub(
+                &self.env,
+                &self.config.name,
+                None,
+                SEQUENCER_BINDING,
+                self.config.location_hint.as_deref(),
             )?
-            .into_iter()
-            .collect();
+            .fetch_with_request(req)
+            .await?
+            .bytes()
+            .await?,
+        )?
+        .into_iter()
+        .collect();
 
         // Send the sequenced entries to channel subscribers.
         batch.done.send_modify(|v| v.clone_from(&sequenced_entries));

--- a/crates/generic_log_worker/src/cleaner_do.rs
+++ b/crates/generic_log_worker/src/cleaner_do.rs
@@ -127,7 +127,7 @@ impl GenericCleaner {
 
         let name = &self.config.name;
         if !*self.initialized.borrow() {
-            log::info!("{name}: Initializing cleaner from alarm handler",);
+            log::info!("{name}: Initializing cleaner from alarm handler");
             self.initialize().await?;
         }
         // Schedule the next cleaning.

--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -167,10 +167,7 @@ pub fn load_cache_kv(env: &Env, name: &str) -> Result<kv::KvStore> {
 /// # Errors
 ///
 /// Returns an error if there are issues retrieving the metadata.
-pub async fn get_cached_metadata<M>(
-    kv: &KvStore,
-    lookup_key: &LookupKey,
-) -> Result<Option<M>>
+pub async fn get_cached_metadata<M>(kv: &KvStore, lookup_key: &LookupKey) -> Result<Option<M>>
 where
     M: Serialize + DeserializeOwned,
 {
@@ -190,11 +187,7 @@ where
 ///
 /// Returns an error if either the KV namespace doesn't exist, or if there is an
 /// exception when writing the value.
-pub async fn put_cache_entry_metadata<L, M>(
-    kv: &KvStore,
-    pending: &L,
-    metadata: M,
-) -> Result<()>
+pub async fn put_cache_entry_metadata<L, M>(kv: &KvStore, pending: &L, metadata: M) -> Result<()>
 where
     L: PendingLogEntry,
     M: Serialize,
@@ -494,6 +487,10 @@ pub type SequenceMetadataEntry = (LookupKey, (LeafIndex, UnixTimestamp));
 /// compatibility with existing Durable Object dedup cache storage. Any change
 /// to this format will result in a [`DedupCache::load`] error for deployed
 /// logs.
+///
+/// # Panics
+///
+/// Panics if writting to a pre-allocated buffer fails, which should never happen.
 #[must_use]
 pub fn serialize_sequence_metadata_entries(entries: &[SequenceMetadataEntry]) -> Vec<u8> {
     use byteorder::{BigEndian, WriteBytesExt};
@@ -851,9 +848,7 @@ mod tests {
 
     /// A minimal [`SequencerMetadata`] that uses the default JSON cache format,
     /// for testing non-binary serialization paths.
-    #[derive(
-        Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize,
-    )]
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
     struct TestMetadata(u64);
 
     impl SequencerMetadata for TestMetadata {

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -18,6 +18,7 @@
 //! - [ctlog_test.go](https://github.com/FiloSottile/sunlight/blob/36be227ff4599ac11afe3cec37a5febcd61da16a/internal/ctlog/ctlog_test.go)
 //! - [testlog_test.go](https://github.com/FiloSottile/sunlight/blob/36be227ff4599ac11afe3cec37a5febcd61da16a/internal/ctlog/testlog_test.go)
 
+use crate::SequencerMetadata;
 use crate::{
     obs::metrics::{millis_diff_as_secs, AsF64, SequencerMetrics},
     util::now_millis,
@@ -38,7 +39,6 @@ use std::{
     sync::LazyLock,
 };
 use thiserror::Error;
-use crate::SequencerMetadata;
 use tlog_tiles::{
     Hash, HashReader, LogEntry, PendingLogEntry, PreloadedTlogTileReader, Proof, Subtree,
     TileHashReader, TileIterator, TlogError, TlogTile, TlogTileRecorder, TreeWithTimestamp,
@@ -927,7 +927,10 @@ async fn sequence_entries<L: LogEntry, M: SequencerMetadata>(
         }
     }
 
-    assert_eq!(n, new_size, "loop must have processed exactly entries.len() entries");
+    assert_eq!(
+        n, new_size,
+        "loop must have processed exactly entries.len() entries"
+    );
 
     // Stage leftover partial data tile, if any.
     if new_size != old_size && !new_size.is_multiple_of(u64::from(TlogTile::FULL_WIDTH)) {
@@ -1072,7 +1075,10 @@ async fn sequence_entries<L: LogEntry, M: SequencerMetadata>(
 
     // Call the checkpoint callback. This is a no-op for CT, but is used to
     // update landmark checkpoints for MTC.
-    if let Err(e) = (config.checkpoint_callback)(old_time, timestamp, old_size, new_size, new.checkpoint()).await {
+    if let Err(e) =
+        (config.checkpoint_callback)(old_time, timestamp, old_size, new_size, new.checkpoint())
+            .await
+    {
         warn!("{name}: Checkpoint callback failed: {e}");
     }
 
@@ -1399,16 +1405,13 @@ mod tests {
     }
 
     use anyhow::ensure;
+    use crypto_common::Generate as _;
     use ed25519_dalek::SigningKey as Ed25519SigningKey;
     use futures_executor::block_on;
     use itertools::Itertools;
-    use crypto_common::Generate as _;
     use p256::ecdsa::SigningKey as EcdsaSigningKey;
     use prometheus::Registry;
-    use rand::{
-        rngs::SmallRng,
-        Rng, RngExt, SeedableRng,
-    };
+    use rand::{rngs::SmallRng, Rng, RngExt, SeedableRng};
     use signed_note::{KeyName, Note};
     use static_ct_api::{
         PrecertData, StaticCTCheckpointSigner, StaticCTLogEntry, StaticCTPendingLogEntry,
@@ -2533,7 +2536,11 @@ mod tests {
         fn add(&mut self, is_precert: bool) -> AddLeafResult<SequenceMetadata> {
             self.add_with_seed(is_precert, rand::rng().next_u64())
         }
-        fn add_with_seed(&mut self, is_precert: bool, seed: u64) -> AddLeafResult<SequenceMetadata> {
+        fn add_with_seed(
+            &mut self,
+            is_precert: bool,
+            seed: u64,
+        ) -> AddLeafResult<SequenceMetadata> {
             let mut rng = SmallRng::seed_from_u64(seed);
             let mut certificate = vec![0; rng.random_range(8..12)];
             rng.fill(&mut certificate[..]);

--- a/crates/integration_tests/src/assertions.rs
+++ b/crates/integration_tests/src/assertions.rs
@@ -33,10 +33,7 @@ use crate::client::{AddChainResponse, CtClient, LogV3JsonResponse};
 /// Returns an error if any invariant is violated.
 pub fn assert_sct_structure(sct: &AddChainResponse) -> Result<()> {
     if sct.sct_version != 0 {
-        bail!(
-            "expected sct_version == 0 (v1), got {}",
-            sct.sct_version
-        );
+        bail!("expected sct_version == 0 (v1), got {}", sct.sct_version);
     }
     if sct.id.len() != 32 {
         bail!("expected log id to be 32 bytes, got {}", sct.id.len());
@@ -88,7 +85,9 @@ pub fn assert_sct_signature(
         .context("decoding log verifying key")?;
 
     // Verify that the SCT log id matches the expected SHA-256(SPKI).
-    let pkix = vkey.to_public_key_der().context("re-encoding verifying key")?;
+    let pkix = vkey
+        .to_public_key_der()
+        .context("re-encoding verifying key")?;
     let expected_log_id: [u8; 32] = Sha256::digest(pkix.as_bytes()).into();
     if sct.id.as_slice() != expected_log_id {
         bail!(
@@ -123,7 +122,11 @@ pub fn assert_sct_signature(
     let der_signature = sig_bytes[4..].to_vec();
 
     let parsed_sct = ParsedSct {
-        log_id: sct.id.as_slice().try_into().context("SCT id not 32 bytes")?,
+        log_id: sct
+            .id
+            .as_slice()
+            .try_into()
+            .context("SCT id not 32 bytes")?,
         timestamp: sct.timestamp,
         extensions: sct.extensions.clone(),
         signature: SctSignature {
@@ -168,8 +171,13 @@ pub fn assert_sct_signature(
         effective_issuer_spki = &[];
     }
 
-    verify_sct_signature(&parsed_sct, &ct_log, effective_cert_der, effective_issuer_spki)
-        .context("SCT signature verification failed")?;
+    verify_sct_signature(
+        &parsed_sct,
+        &ct_log,
+        effective_cert_der,
+        effective_issuer_spki,
+    )
+    .context("SCT signature verification failed")?;
 
     Ok(())
 }
@@ -241,22 +249,21 @@ pub fn verify_checkpoint_bytes(
     let rfc6962_verifier = RFC6962NoteVerifier::new(key_name.clone(), &vkey)
         .context("constructing RFC6962NoteVerifier")?;
 
-    let verifiers: Vec<Box<dyn signed_note::NoteVerifier>> =
-        if let Some(wkey_der) = witness_key_der {
-            let ed25519_vkey = ed25519_dalek::VerifyingKey::from_public_key_der(wkey_der)
-                .context("decoding witness verifying key")?;
-            let encoded = signed_note::new_encoded_ed25519_verifier_key(&key_name, &ed25519_vkey);
-            let witness_verifier = Ed25519NoteVerifier::new_from_encoded_key(&encoded)
-                .context("constructing Ed25519NoteVerifier")?;
-            vec![Box::new(rfc6962_verifier), Box::new(witness_verifier)]
-        } else {
-            vec![Box::new(rfc6962_verifier)]
-        };
+    let verifiers: Vec<Box<dyn signed_note::NoteVerifier>> = if let Some(wkey_der) = witness_key_der
+    {
+        let ed25519_vkey = ed25519_dalek::VerifyingKey::from_public_key_der(wkey_der)
+            .context("decoding witness verifying key")?;
+        let encoded = signed_note::new_encoded_ed25519_verifier_key(&key_name, &ed25519_vkey);
+        let witness_verifier = Ed25519NoteVerifier::new_from_encoded_key(&encoded)
+            .context("constructing Ed25519NoteVerifier")?;
+        vec![Box::new(rfc6962_verifier), Box::new(witness_verifier)]
+    } else {
+        vec![Box::new(rfc6962_verifier)]
+    };
 
     let verifier_list = VerifierList::new(verifiers);
-    let (text, _timestamp) =
-        open_checkpoint(origin, &verifier_list, now_millis, checkpoint_bytes)
-            .context("opening checkpoint")?;
+    let (text, _timestamp) = open_checkpoint(origin, &verifier_list, now_millis, checkpoint_bytes)
+        .context("opening checkpoint")?;
 
     Ok(VerifiedCheckpoint { text })
 }
@@ -288,9 +295,7 @@ pub async fn assert_leaf_in_checkpoint(
     let tree_size = checkpoint.text.size();
 
     if leaf_index >= tree_size {
-        bail!(
-            "leaf_index {leaf_index} >= tree_size {tree_size}: entry not yet in checkpoint"
-        );
+        bail!("leaf_index {leaf_index} >= tree_size {tree_size}: entry not yet in checkpoint");
     }
 
     // Compute the hash storage index for this leaf.
@@ -334,10 +339,9 @@ pub async fn assert_leaf_in_checkpoint(
     // Compute the correct width from the verified tree_size.
     // The worker only stores the current (widest) partial tile — not narrower
     // historical versions — so we must request the tile at its current width.
-    let tile_width_from_tree =
-        u32::try_from(tree_size - tile_n * u64::from(TlogTile::FULL_WIDTH))
-            .unwrap_or(TlogTile::FULL_WIDTH)
-            .min(TlogTile::FULL_WIDTH);
+    let tile_width_from_tree = u32::try_from(tree_size - tile_n * u64::from(TlogTile::FULL_WIDTH))
+        .unwrap_or(TlogTile::FULL_WIDTH)
+        .min(TlogTile::FULL_WIDTH);
     let data_tile = TlogTile::new(0, tile_n, tile_width_from_tree, Some(PathElem::Data));
     let data_tile_path = data_tile.path();
     let tile_bytes = fetch_tile_with_retry(client, &data_tile_path)

--- a/crates/integration_tests/src/client.rs
+++ b/crates/integration_tests/src/client.rs
@@ -321,7 +321,10 @@ impl BootstrapMtcClient {
     }
 
     /// `POST /logs/:log/add-entry`
-    pub async fn add_entry(&self, chain: Vec<Vec<u8>>) -> Result<(u16, Option<BootstrapMtcAddEntryResponse>)> {
+    pub async fn add_entry(
+        &self,
+        chain: Vec<Vec<u8>>,
+    ) -> Result<(u16, Option<BootstrapMtcAddEntryResponse>)> {
         let body = AddChainRequest { chain };
         let resp = self
             .client
@@ -356,7 +359,10 @@ impl BootstrapMtcClient {
         let resp = self
             .client
             .post(self.url("get-certificate"))
-            .json(&Req { leaf_index, spki_der })
+            .json(&Req {
+                leaf_index,
+                spki_der,
+            })
             .send()
             .await
             .context("POST get-certificate")?;

--- a/crates/integration_tests/tests/bootstrap_mtc_api.rs
+++ b/crates/integration_tests/tests/bootstrap_mtc_api.rs
@@ -59,7 +59,8 @@ async fn ensure_initialized() {
 
             let log_name = integration_tests::client::bootstrap_mtc_log_name();
             let client = BootstrapMtcClient::new(&log_name);
-            let mtc_chain = make_bootstrap_mtc_chain(&log_name).expect("make_bootstrap_mtc_chain for warmup");
+            let mtc_chain =
+                make_bootstrap_mtc_chain(&log_name).expect("make_bootstrap_mtc_chain for warmup");
 
             // Wait until get-roots succeeds before attempting add-entry.
             // get-roots triggers the CCADB fetch that populates the ROOTS
@@ -68,13 +69,17 @@ async fn ensure_initialized() {
             let mut roots_ready = false;
             for _ in 0..MAX_ATTEMPTS {
                 match client.get_roots().await {
-                    Ok(_) => { roots_ready = true; break; }
+                    Ok(_) => {
+                        roots_ready = true;
+                        break;
+                    }
                     Err(_) => tokio::time::sleep(RETRY_DELAY).await,
                 }
             }
-            if !roots_ready {
-                panic!("bootstrap_mtc_worker get-roots never succeeded after {MAX_ATTEMPTS}s");
-            }
+            assert!(
+                roots_ready,
+                "bootstrap_mtc_worker get-roots never succeeded after {MAX_ATTEMPTS}s"
+            );
 
             for attempt in 0..MAX_ATTEMPTS {
                 // Submit an entry to trigger full initialization (DO startup,
@@ -134,10 +139,7 @@ async fn metadata_returns_valid_fields() {
     let meta = client.get_metadata().await.expect("metadata failed");
 
     // log_id and cosigner_id are dotted-decimal relative OIDs.
-    assert!(
-        !meta.log_id.is_empty(),
-        "log_id must be non-empty"
-    );
+    assert!(!meta.log_id.is_empty(), "log_id must be non-empty");
     assert!(
         meta.log_id.contains('.'),
         "log_id must be a dotted-decimal OID, got: {}",
@@ -215,16 +217,16 @@ async fn add_entry_with_garbage_chain_returns_400() {
 #[tokio::test]
 async fn unknown_log_returns_400() {
     let client = BootstrapMtcClient::new("this-log-does-not-exist");
-    let status = client
-        .get_status("get-roots")
-        .await
-        .expect("GET request");
+    let status = client.get_status("get-roots").await.expect("GET request");
     assert_eq!(status, 400, "expected 400 for unknown log");
 }
 
 /// After `add-entry`, the checkpoint tree size covers the returned `leaf_index`.
 #[tokio::test]
 async fn add_entry_appears_in_checkpoint() {
+    const MAX_RETRIES: u32 = 12;
+    const RETRY_DELAY_MS: u64 = 500;
+
     ensure_initialized().await;
     let client = BootstrapMtcClient::default_log();
     let mtc_chain = make_bootstrap_mtc_chain(&client.log).expect("generating MTC chain");
@@ -239,15 +241,10 @@ async fn add_entry_appears_in_checkpoint() {
     let min_size = resp.leaf_index + 1;
 
     // Retry until checkpoint covers the leaf or we time out.
-    const MAX_RETRIES: u32 = 12;
-    const RETRY_DELAY_MS: u64 = 500;
     let mut last_size = 0u64;
 
     for attempt in 0..MAX_RETRIES {
-        let checkpoint_bytes = client
-            .get_checkpoint()
-            .await
-            .expect("fetching checkpoint");
+        let checkpoint_bytes = client.get_checkpoint().await.expect("fetching checkpoint");
         // Parse tree size from the checkpoint text (second line).
         let text = String::from_utf8_lossy(&checkpoint_bytes);
         if let Some(size_str) = text.lines().nth(1) {
@@ -263,9 +260,7 @@ async fn add_entry_appears_in_checkpoint() {
         }
     }
 
-    panic!(
-        "checkpoint size {last_size} never reached {min_size} after {MAX_RETRIES} retries"
-    );
+    panic!("checkpoint size {last_size} never reached {min_size} after {MAX_RETRIES} retries");
 }
 
 /// After `add-entry`, `get-certificate` returns a parseable signatureless DER
@@ -275,6 +270,9 @@ async fn add_entry_appears_in_checkpoint() {
 /// It is skipped if `BOOTSTRAP_MTC_LOG_NAME` is set to a log with a longer interval.
 #[tokio::test]
 async fn get_certificate_returns_valid_cert() {
+    const MAX_RETRIES: u32 = 30;
+    const RETRY_DELAY_MS: u64 = 1_000;
+
     ensure_initialized().await;
     // This test only makes sense against a fast-landmark shard (dev2).
     // If someone overrides to a slow shard, skip rather than timeout.
@@ -299,9 +297,6 @@ async fn get_certificate_returns_valid_cert() {
 
     // Wait for a landmark to be produced (dev2 landmark_interval_secs = 10).
     // Retry get-certificate until it returns 200 (not 503 Retry-After).
-    const MAX_RETRIES: u32 = 30;
-    const RETRY_DELAY_MS: u64 = 1_000;
-
     let mut last_status = 0u16;
     for attempt in 0..MAX_RETRIES {
         let (s, cert_resp) = client
@@ -313,8 +308,7 @@ async fn get_certificate_returns_valid_cert() {
             let cert_resp = cert_resp.unwrap();
 
             // The returned data must be parseable DER (signatureless X.509).
-            Certificate::from_der(&cert_resp.data)
-                .expect("get-certificate returned invalid DER");
+            Certificate::from_der(&cert_resp.data).expect("get-certificate returned invalid DER");
 
             assert!(
                 cert_resp.landmark_id > 0,

--- a/crates/integration_tests/tests/static_ct_api.rs
+++ b/crates/integration_tests/tests/static_ct_api.rs
@@ -155,25 +155,25 @@ async fn get_roots_returns_valid_certs() {
 /// `GET /logs/:log/log.v3.json` returns 200 with all required fields.
 #[tokio::test]
 async fn log_v3_json_returns_valid_metadata() {
+    use p256::pkcs8::{DecodePublicKey, EncodePublicKey};
+    use sha2::{Digest, Sha256};
+
     let client = CtClient::default_log();
-    let meta = client
-        .get_log_v3_json()
-        .await
-        .expect("log.v3.json failed");
+    let meta = client.get_log_v3_json().await.expect("log.v3.json failed");
 
     assert_eq!(meta.log_id.len(), 32, "log_id must be 32 bytes");
     assert!(!meta.key.is_empty(), "key must be non-empty");
     assert!(meta.mmd > 0, "mmd must be positive");
-    assert!(!meta.submission_url.is_empty(), "submission_url must be set");
+    assert!(
+        !meta.submission_url.is_empty(),
+        "submission_url must be set"
+    );
 
     // Key must be a valid P-256 SPKI.
-    use p256::pkcs8::DecodePublicKey;
     p256::ecdsa::VerifyingKey::from_public_key_der(&meta.key)
         .expect("key must be a valid P-256 SPKI");
 
     // log_id must equal SHA-256(SPKI).
-    use p256::pkcs8::EncodePublicKey;
-    use sha2::{Digest, Sha256};
     let vkey = p256::ecdsa::VerifyingKey::from_public_key_der(&meta.key).unwrap();
     let pkix = vkey.to_public_key_der().unwrap();
     let expected_id: [u8; 32] = Sha256::digest(pkix.as_bytes()).into();

--- a/crates/signed_note/src/ed25519.rs
+++ b/crates/signed_note/src/ed25519.rs
@@ -44,7 +44,11 @@ impl NoteVerifier for Ed25519NoteVerifier {
 impl Ed25519NoteVerifier {
     #[must_use]
     pub fn new(name: KeyName, verifying_key: Ed25519VerifyingKey) -> Self {
-        let id = compute_key_id(&name, &[SignatureType::Ed25519 as u8], verifying_key.to_bytes().as_slice());
+        let id = compute_key_id(
+            &name,
+            &[SignatureType::Ed25519 as u8],
+            verifying_key.to_bytes().as_slice(),
+        );
         Self {
             name,
             id,
@@ -119,7 +123,11 @@ impl NoteSigner for Ed25519NoteSigner {
 impl Ed25519NoteSigner {
     #[must_use]
     pub fn new(name: KeyName, signing_key: Ed25519SigningKey) -> Self {
-        let id = compute_key_id(&name, &[SignatureType::Ed25519 as u8], signing_key.verifying_key().to_bytes().as_slice());
+        let id = compute_key_id(
+            &name,
+            &[SignatureType::Ed25519 as u8],
+            signing_key.verifying_key().to_bytes().as_slice(),
+        );
         Self {
             name,
             id,
@@ -159,7 +167,13 @@ impl Ed25519NoteSigner {
                     ed25519_dalek::SigningKey::try_from(key).map_err(|_| NoteError::Format)?;
 
                 // Must verify id after deriving public key.
-                if id != compute_key_id(&name, &[SignatureType::Ed25519 as u8], signing_key.verifying_key().to_bytes().as_slice()) {
+                if id
+                    != compute_key_id(
+                        &name,
+                        &[SignatureType::Ed25519 as u8],
+                        signing_key.verifying_key().to_bytes().as_slice(),
+                    )
+                {
                     return Err(NoteError::Id);
                 }
 
@@ -183,15 +197,15 @@ pub fn generate_encoded_ed25519_key<R: CryptoRng + ?Sized>(
     let signing_key = ed25519_dalek::SigningKey::generate(csprng);
     let signature_type = &[SignatureType::Ed25519 as u8];
 
-    let privkey = [
-        signature_type,
-        signing_key.to_bytes().as_slice(),
-    ]
-    .concat();
+    let privkey = [signature_type, signing_key.to_bytes().as_slice()].concat();
     let skey = format!(
         "PRIVATE+KEY+{}+{:08x}+{}",
         name,
-        compute_key_id(name, signature_type, signing_key.verifying_key().to_bytes().as_slice()),
+        compute_key_id(
+            name,
+            signature_type,
+            signing_key.verifying_key().to_bytes().as_slice()
+        ),
         BASE64_STANDARD.encode(privkey)
     );
     let vkey = new_encoded_ed25519_verifier_key(name, &signing_key.verifying_key());

--- a/crates/signed_note/src/lib.rs
+++ b/crates/signed_note/src/lib.rs
@@ -731,7 +731,11 @@ mod tests {
     fn test_from_ed25519() {
         let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rng());
         let verifying_key = signing_key.verifying_key();
-        let id = compute_key_id(&NAME, &[SignatureType::Ed25519 as u8], verifying_key.to_bytes().as_slice());
+        let id = compute_key_id(
+            &NAME,
+            &[SignatureType::Ed25519 as u8],
+            verifying_key.to_bytes().as_slice(),
+        );
         let vkey = new_encoded_ed25519_verifier_key(&NAME, &verifying_key);
         let verifier = Ed25519NoteVerifier::new_from_encoded_key(&vkey).unwrap();
 

--- a/crates/signed_note_wasm/src/lib.rs
+++ b/crates/signed_note_wasm/src/lib.rs
@@ -199,7 +199,11 @@ impl VerifierList {
 pub fn compute_key_id(name: &str, signature_type: &[u8], pubkey: &[u8]) -> Result<u32, JsValue> {
     let key_name = signed_note::KeyName::new(name.to_string())
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
-    Ok(signed_note::compute_key_id(&key_name, signature_type, pubkey))
+    Ok(signed_note::compute_key_id(
+        &key_name,
+        signature_type,
+        pubkey,
+    ))
 }
 
 /// Returns a vkey string: `<name>+<hex_key_id>+<base64(0x01 || pubkey)>`

--- a/crates/static_ct_api/src/rfc6962.rs
+++ b/crates/static_ct_api/src/rfc6962.rs
@@ -438,7 +438,7 @@ mod tests {
         new_exts: Option<&[Extension]>,
     ) -> Certificate {
         let mut owned = x509_util::OwnedCertificate::from(cert);
-        owned.tbs_certificate.extensions = new_exts.map(|exts| exts.to_vec());
+        owned.tbs_certificate.extensions = new_exts.map(<[x509_cert::ext::Extension]>::to_vec);
         Certificate::from_der(&owned.to_der().unwrap()).unwrap()
     }
 }

--- a/crates/tlog_tiles/src/cosignature_v1.rs
+++ b/crates/tlog_tiles/src/cosignature_v1.rs
@@ -83,7 +83,11 @@ pub struct CosignatureV1NoteVerifier {
 impl CosignatureV1NoteVerifier {
     #[must_use]
     pub fn new(name: KeyName, verifying_key: Ed25519VerifyingKey) -> Self {
-        let id = signed_note::compute_key_id(&name, &[SignatureType::CosignatureV1 as u8], verifying_key.to_bytes().as_slice());
+        let id = signed_note::compute_key_id(
+            &name,
+            &[SignatureType::CosignatureV1 as u8],
+            verifying_key.to_bytes().as_slice(),
+        );
         Self {
             name,
             id,

--- a/crates/x509_util/src/lib.rs
+++ b/crates/x509_util/src/lib.rs
@@ -599,9 +599,7 @@ fn verify_p256(spki: spki::SubjectPublicKeyInfoRef<'_>, tbs_der: &[u8], sig_byte
     let Ok(vk) = p256::ecdsa::VerifyingKey::try_from(spki) else {
         return false;
     };
-    p256::ecdsa::DerSignature::try_from(sig_bytes)
-        .map(|sig| vk.verify(tbs_der, &sig).is_ok())
-        .unwrap_or(false)
+    p256::ecdsa::DerSignature::try_from(sig_bytes).is_ok_and(|sig| vk.verify(tbs_der, &sig).is_ok())
 }
 
 /// Verify a P-384 ECDSA signature over `tbs_der` using the key in `spki`.
@@ -609,9 +607,7 @@ fn verify_p384(spki: spki::SubjectPublicKeyInfoRef<'_>, tbs_der: &[u8], sig_byte
     let Ok(vk) = p384::ecdsa::VerifyingKey::try_from(spki) else {
         return false;
     };
-    p384::ecdsa::DerSignature::try_from(sig_bytes)
-        .map(|sig| vk.verify(tbs_der, &sig).is_ok())
-        .unwrap_or(false)
+    p384::ecdsa::DerSignature::try_from(sig_bytes).is_ok_and(|sig| vk.verify(tbs_der, &sig).is_ok())
 }
 
 /// Verify a P-521 ECDSA signature over `tbs_der` using the key in `spki`.
@@ -619,9 +615,7 @@ fn verify_p521(spki: spki::SubjectPublicKeyInfoRef<'_>, tbs_der: &[u8], sig_byte
     let Ok(vk) = p521::ecdsa::VerifyingKey::try_from(spki) else {
         return false;
     };
-    p521::ecdsa::DerSignature::try_from(sig_bytes)
-        .map(|sig| vk.verify(tbs_der, &sig).is_ok())
-        .unwrap_or(false)
+    p521::ecdsa::DerSignature::try_from(sig_bytes).is_ok_and(|sig| vk.verify(tbs_der, &sig).is_ok())
 }
 
 /// Verify an RSA PKCS#1 v1.5 signature over `tbs_der` using the key in `spki`.
@@ -633,9 +627,7 @@ where
         return false;
     };
     let vk = rsa::pkcs1v15::VerifyingKey::<D>::new(rsa_key);
-    rsa::pkcs1v15::Signature::try_from(sig_bytes)
-        .map(|sig| vk.verify(tbs_der, &sig).is_ok())
-        .unwrap_or(false)
+    rsa::pkcs1v15::Signature::try_from(sig_bytes).is_ok_and(|sig| vk.verify(tbs_der, &sig).is_ok())
 }
 
 /// Validate Basic Constraints for a CA certificate.


### PR DESCRIPTION
Fix cargo fmt and clippy complaints, and use latest rust 1.95 toolchain in CI

Also remove "fuzz" from workspace.default-members so that `cargo test`
runs unit tests without also building the cargo-fuzz harness (which depends
on libfuzzer-sys and a nightly sanitizer runtime).  Fuzz targets are still
linted by `cargo clippy --workspace --all-targets` and run explicitly with
`cargo fuzz run <target>`.
