### PR TITLE
Add tlog_subtree_signature crate with sign-subtree wire-format and binary-format support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,6 +2943,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tlog_subtree_signature"
+version = "0.2.0"
+dependencies = [
+ "base64",
+ "byteorder",
+ "length_prefixed",
+ "signature",
+ "signed_note",
+ "thiserror 2.0.17",
+ "tlog_tiles",
+]
+
+[[package]]
 name = "tlog_tiles"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/signed_note",
     "crates/signed_note_wasm",
     "crates/static_ct_api",
+    "crates/tlog_subtree_signature",
     "crates/tlog_tiles",
     "crates/tlog_tiles_wasm",
     "crates/x509_util",
@@ -38,6 +39,7 @@ default-members = [
     "crates/signed_note",
     "crates/signed_note_wasm",
     "crates/static_ct_api",
+    "crates/tlog_subtree_signature",
     "crates/tlog_tiles",
     "crates/tlog_tiles_wasm",
     "crates/x509_util",
@@ -115,6 +117,7 @@ signature = "3.0.0-rc.10"
 signed_note = { path = "crates/signed_note", version = "0.2.0" }
 static_ct_api = { path = "crates/static_ct_api", version = "0.2.0" }
 thiserror = "2.0"
+tlog_subtree_signature = { path = "crates/tlog_subtree_signature", version = "0.2.0" }
 tlog_tiles = { path = "crates/tlog_tiles", version = "0.2.0" }
 tokio = { version = "1", features = ["sync"] }
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/tlog_subtree_signature/Cargo.toml
+++ b/crates/tlog_subtree_signature/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tlog_subtree_signature"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Wire-format parsers, serializers, and the mtc-subtree/v1 binary signing format for the sign-subtree cosigner endpoint"
+categories = ["cryptography"]
+keywords = ["transparency", "subtree", "cosignature", "checkpoint"]
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+base64.workspace = true
+byteorder.workspace = true
+length_prefixed.workspace = true
+signature.workspace = true
+signed_note.workspace = true
+thiserror.workspace = true
+tlog_tiles.workspace = true

--- a/crates/tlog_subtree_signature/src/crypto.rs
+++ b/crates/tlog_subtree_signature/src/crypto.rs
@@ -1,0 +1,398 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+//! Binary signing format and signer/verifier abstraction for subtree
+//! cosignatures.
+//!
+//! The current binary message format is `mtc-subtree/v1\n\0`, defined in
+//! [draft-ietf-plants-merkle-tree-certs-02 §5.4.1][mtc-541]. This crate
+//! anticipates the format being renamed / restructured when the `sign-subtree`
+//! protocol migrates into its own C2SP specification (provisionally
+//! `c2sp.org/tlog-subtree-signature`), so the public helpers below are named
+//! without the `mtc-` prefix; the string `mtc-subtree/v1` appears only inside
+//! `serialize_subtree_signature_input` where the wire format demands it.
+//!
+//! Signing and verification are abstracted by the [`RawSigner`] and
+//! [`RawVerifier`] traits — this crate is algorithm-agnostic. Concrete
+//! implementations (Ed25519, ML-DSA-44, …) live in downstream crates.
+//!
+//! [mtc-541]: https://www.ietf.org/archive/id/draft-ietf-plants-merkle-tree-certs-02.html#name-signature-format
+
+use byteorder::{BigEndian, WriteBytesExt};
+use length_prefixed::WriteLengthPrefixedBytesExt;
+use signed_note::{KeyName, NoteError, NoteVerifier};
+use tlog_tiles::{Hash, LeafIndex, HASH_SIZE};
+
+use base64::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Algorithm-agnostic signer / verifier traits
+// ---------------------------------------------------------------------------
+
+/// A signer producing raw signature bytes over an arbitrary byte message.
+///
+/// Implementations hold a private key and any algorithm-specific state. This
+/// crate does not care which algorithm they use; the returned bytes are
+/// whatever a paired [`RawVerifier`] will consume.
+pub trait RawSigner {
+    /// Sign `msg`, returning the algorithm's raw signature bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if signing fails (e.g. entropy exhaustion for
+    /// randomized schemes).
+    fn try_sign(&self, msg: &[u8]) -> Result<Vec<u8>, signature::Error>;
+}
+
+/// A verifier checking raw signature bytes against a message.
+///
+/// Implementations hold a public key. Paired with a [`RawSigner`] for the
+/// same algorithm.
+pub trait RawVerifier {
+    /// Return true iff `sig` is a valid signature of `msg`.
+    fn verify(&self, msg: &[u8], sig: &[u8]) -> bool;
+}
+
+// ---------------------------------------------------------------------------
+// Binary signing input
+// ---------------------------------------------------------------------------
+
+/// Serialize the binary message a subtree signer signs, per
+/// draft-ietf-plants-merkle-tree-certs-02 §5.4.1.
+///
+/// ```text
+/// opaque HashValue[HASH_SIZE];
+/// opaque TrustAnchorID<1..2^8-1>;
+/// struct {
+///     TrustAnchorID log_id;
+///     uint64 start;
+///     uint64 end;
+///     HashValue hash;
+/// } MTCSubtree;
+/// struct {
+///     uint8 label[16] = "mtc-subtree/v1\n\0";
+///     TrustAnchorID cosigner_id;
+///     MTCSubtree subtree;
+/// } MTCSubtreeSignatureInput;
+/// ```
+///
+/// The `cosigner_id` and `log_id` are opaque byte strings from this crate's
+/// point of view; callers encode them in whatever scheme the spec demands
+/// (today: BER-encoded `TrustAnchorID` relative OIDs from the MTC draft).
+///
+/// # Panics
+///
+/// Panics if writing to an internal buffer fails, which should never happen
+/// for an in-memory `Vec`.
+#[must_use]
+pub fn serialize_subtree_signature_input(
+    cosigner_id: &[u8],
+    log_id: &[u8],
+    start: LeafIndex,
+    end: LeafIndex,
+    root_hash: &Hash,
+) -> Vec<u8> {
+    let mut buffer: Vec<u8> = b"mtc-subtree/v1\n\x00".to_vec();
+    buffer.write_length_prefixed(cosigner_id, 1).unwrap();
+    buffer.write_length_prefixed(log_id, 1).unwrap();
+    buffer.write_u64::<BigEndian>(start).unwrap();
+    buffer.write_u64::<BigEndian>(end).unwrap();
+    buffer.extend(root_hash.0);
+    buffer
+}
+
+// ---------------------------------------------------------------------------
+// Subtree signing
+// ---------------------------------------------------------------------------
+
+/// Sign a subtree, returning the raw signature bytes of
+/// `signer` applied to [`serialize_subtree_signature_input`].
+///
+/// # Errors
+///
+/// Returns an error if `signer.try_sign` fails.
+pub fn sign_subtree<S: RawSigner + ?Sized>(
+    signer: &S,
+    cosigner_id: &[u8],
+    log_id: &[u8],
+    start: LeafIndex,
+    end: LeafIndex,
+    root_hash: &Hash,
+) -> Result<Vec<u8>, signature::Error> {
+    let input = serialize_subtree_signature_input(cosigner_id, log_id, start, end, root_hash);
+    signer.try_sign(&input)
+}
+
+// ---------------------------------------------------------------------------
+// Note verifier over subtree-format notes
+// ---------------------------------------------------------------------------
+
+/// [`NoteVerifier`] that accepts a subtree signed note and validates the
+/// attached signature against the `mtc-subtree/v1` binary format.
+///
+/// The [`NoteVerifier::verify`] input is the raw *note text* — the Appendix
+/// C.1 format `<origin>\n<start> <end>\n<base64-hash>\n` — which this
+/// implementation parses to reconstruct the binary signing input, then
+/// delegates to the wrapped [`RawVerifier`].
+///
+/// The `name` and `key_id` exposed via the trait impl are whatever the
+/// caller supplies at construction time; this crate does not prescribe a
+/// name-format convention (MTC uses `oid/{id_rdna_trustanchor_id}.{log_id}`
+/// with a key ID derived via `signed_note::compute_key_id` over
+/// `\xffmtc-subtree/v1`, but that is a caller concern).
+#[derive(Clone)]
+pub struct SubtreeNoteVerifier<V: RawVerifier> {
+    name: KeyName,
+    key_id: u32,
+    cosigner_id: Vec<u8>,
+    log_id: Vec<u8>,
+    verifier: V,
+}
+
+impl<V: RawVerifier> SubtreeNoteVerifier<V> {
+    /// Build a verifier bound to a specific `(name, key_id, cosigner_id,
+    /// log_id, verifier)`. The `name` and `key_id` are what incoming note
+    /// signature lines must match for this verifier to consider them. The
+    /// `cosigner_id` / `log_id` are the opaque bytes baked into the
+    /// reconstructed binary signing input.
+    pub fn new(
+        name: KeyName,
+        key_id: u32,
+        cosigner_id: Vec<u8>,
+        log_id: Vec<u8>,
+        verifier: V,
+    ) -> Self {
+        Self {
+            name,
+            key_id,
+            cosigner_id,
+            log_id,
+            verifier,
+        }
+    }
+}
+
+impl<V: RawVerifier> NoteVerifier for SubtreeNoteVerifier<V> {
+    fn name(&self) -> &KeyName {
+        &self.name
+    }
+
+    fn key_id(&self) -> u32 {
+        self.key_id
+    }
+
+    fn verify(&self, msg: &[u8], sig_bytes: &[u8]) -> bool {
+        let Some((start, end, hash)) = parse_subtree_note_body_for_verify(msg) else {
+            return false;
+        };
+        let input =
+            serialize_subtree_signature_input(&self.cosigner_id, &self.log_id, start, end, &hash);
+        self.verifier.verify(&input, sig_bytes)
+    }
+
+    fn extract_timestamp_millis(&self, _sig: &[u8]) -> Result<Option<u64>, NoteError> {
+        Ok(None)
+    }
+}
+
+/// Minimal parser of the subtree note body text `<origin>\n<start> <end>\n<base64-hash>\n`.
+///
+/// Returns `None` on any malformation so that [`NoteVerifier::verify`] can
+/// report "signature did not verify" without exposing parse errors. The
+/// richer-error sibling is the private `parse_subtree_note_body` in
+/// `lib.rs`, which [`crate::parse_sign_subtree_request`] uses to
+/// distinguish error categories.
+fn parse_subtree_note_body_for_verify(msg: &[u8]) -> Option<(LeafIndex, LeafIndex, Hash)> {
+    let text = std::str::from_utf8(msg).ok()?;
+    let mut lines = text.splitn(4, '\n');
+    let _origin = lines.next()?;
+    let range_line = lines.next()?;
+    let hash_line = lines.next()?;
+
+    let mut parts = range_line.splitn(2, ' ');
+    let start: LeafIndex = parts.next()?.parse().ok()?;
+    let end: LeafIndex = parts.next()?.parse().ok()?;
+    if start > end {
+        return None;
+    }
+
+    let hash_bytes = BASE64_STANDARD.decode(hash_line).ok()?;
+    let hash_arr: [u8; HASH_SIZE] = hash_bytes.try_into().ok()?;
+    Some((start, end, Hash(hash_arr)))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin the binary message layout: label + length-prefixed `cosigner_id` +
+    /// length-prefixed `log_id` + BE u64 start + BE u64 end + 32-byte hash.
+    ///
+    /// Changing this format would invalidate every previously-produced
+    /// subtree signature, so any change here must be paired with the
+    /// corresponding spec-level version bump.
+    #[test]
+    fn serialize_subtree_signature_input_format_unchanged() {
+        // These are BER-encoded `RelativeOID` values matching the MTC
+        // `TrustAnchorID` encoding scheme from
+        // draft-ietf-plants-merkle-tree-certs §4.1: each arc is a big-endian
+        // base-128 integer with the continuation bit set on all but the last
+        // byte. Representative values for a Cloudflare-style (experimental)
+        // arc `1.3.6.1.4.1.44363.48.{1,2}`, matching the encoding used by
+        // `bootstrap_mtc_api::RelativeOid` today.
+        let cosigner_id = b"\x82\xda\x4b\x30\x02"; // RelativeOID 44363.48.2
+        let log_id = b"\x82\xda\x4b\x30\x01"; // RelativeOID 44363.48.1
+        let start: u64 = 0x0102_0304_0506_0708;
+        let end: u64 = 0x0910_1112_1314_1516;
+        let hash = Hash([0x42u8; HASH_SIZE]);
+        let out = serialize_subtree_signature_input(cosigner_id, log_id, start, end, &hash);
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"mtc-subtree/v1\n\x00");
+        expected.push(u8::try_from(cosigner_id.len()).unwrap());
+        expected.extend_from_slice(cosigner_id);
+        expected.push(u8::try_from(log_id.len()).unwrap());
+        expected.extend_from_slice(log_id);
+        expected.extend_from_slice(&start.to_be_bytes());
+        expected.extend_from_slice(&end.to_be_bytes());
+        expected.extend_from_slice(&[0x42u8; HASH_SIZE]);
+
+        assert_eq!(out, expected, "mtc-subtree/v1 binary format changed");
+    }
+
+    /// A counting [`RawSigner`] that records the message it was asked to
+    /// sign, so tests can assert the input [`sign_subtree`] hands off.
+    struct CaptureSigner {
+        captured: std::cell::RefCell<Option<Vec<u8>>>,
+    }
+
+    impl RawSigner for CaptureSigner {
+        fn try_sign(&self, msg: &[u8]) -> Result<Vec<u8>, signature::Error> {
+            *self.captured.borrow_mut() = Some(msg.to_vec());
+            Ok(vec![0xccu8; 64])
+        }
+    }
+
+    #[test]
+    fn sign_subtree_hands_off_expected_bytes() {
+        let signer = CaptureSigner {
+            captured: std::cell::RefCell::new(None),
+        };
+        let cosigner_id = b"\x05\x02";
+        let log_id = b"\x05\x01";
+        let hash = Hash([0x11u8; HASH_SIZE]);
+
+        let sig = sign_subtree(&signer, cosigner_id, log_id, 4, 8, &hash).unwrap();
+        assert_eq!(sig, vec![0xccu8; 64]);
+
+        let captured = signer.captured.into_inner().unwrap();
+        let expected = serialize_subtree_signature_input(cosigner_id, log_id, 4, 8, &hash);
+        assert_eq!(captured, expected);
+    }
+
+    /// A toy verifier that accepts iff the signature bytes match a
+    /// pre-canned value. Used to test `SubtreeNoteVerifier` without touching
+    /// real crypto.
+    struct ToyVerifier {
+        expected_sig: Vec<u8>,
+    }
+
+    impl RawVerifier for ToyVerifier {
+        fn verify(&self, _msg: &[u8], sig: &[u8]) -> bool {
+            sig == self.expected_sig
+        }
+    }
+
+    #[test]
+    fn subtree_note_verifier_happy_path() {
+        let cosigner_id = b"\x05\x02".to_vec();
+        let log_id = b"\x05\x01".to_vec();
+        let hash = Hash([0x77u8; HASH_SIZE]);
+        let start = 4u64;
+        let end = 8u64;
+
+        // Build a raw signature that our ToyVerifier will accept.
+        let canned_sig = vec![0xffu8; 64];
+        let verifier = SubtreeNoteVerifier::new(
+            KeyName::new("oid/test".to_owned()).unwrap(),
+            0xdead_beef,
+            cosigner_id.clone(),
+            log_id.clone(),
+            ToyVerifier {
+                expected_sig: canned_sig.clone(),
+            },
+        );
+
+        // Reconstruct the note body text that the verifier will parse.
+        let hash_b64 = BASE64_STANDARD.encode(hash.0);
+        let note_body = format!("oid/test\n{start} {end}\n{hash_b64}\n");
+
+        assert!(verifier.verify(note_body.as_bytes(), &canned_sig));
+        assert!(!verifier.verify(note_body.as_bytes(), b"wrong-sig"));
+    }
+
+    #[test]
+    fn subtree_note_verifier_rejects_malformed_text() {
+        let verifier = SubtreeNoteVerifier::new(
+            KeyName::new("oid/test".to_owned()).unwrap(),
+            0,
+            Vec::new(),
+            Vec::new(),
+            ToyVerifier {
+                expected_sig: vec![],
+            },
+        );
+        // Non-UTF-8.
+        assert!(!verifier.verify(&[0xff, 0xfe, 0xfd], &[]));
+        // Missing range line.
+        assert!(!verifier.verify(b"oid/test\n", &[]));
+        // Non-numeric range.
+        assert!(!verifier.verify(b"oid/test\nfour eight\nAAAA\n", &[]));
+        // start > end.
+        let hash_b64 = BASE64_STANDARD.encode([0u8; HASH_SIZE]);
+        let body = format!("oid/test\n8 4\n{hash_b64}\n");
+        assert!(!verifier.verify(body.as_bytes(), &[]));
+    }
+
+    /// The origin line (first line of the subtree note body) is not
+    /// authenticated by the binary signing input — that input only covers
+    /// `cosigner_id`, `log_id`, `start`, `end`, and the hash. Pin this
+    /// behavior so nobody silently starts binding origin later without
+    /// thinking through the spec implications.
+    ///
+    /// Concretely: two note bodies that differ only in their first-line
+    /// origin must both verify against the same signature, provided
+    /// `(start, end, hash)` match what was signed.
+    #[test]
+    fn subtree_note_verifier_does_not_authenticate_origin() {
+        let cosigner_id = b"\x05\x02".to_vec();
+        let log_id = b"\x05\x01".to_vec();
+        let hash = Hash([0x33u8; HASH_SIZE]);
+        let start = 0u64;
+        let end = 16u64;
+
+        let canned_sig = vec![0xcdu8; 64];
+        let verifier = SubtreeNoteVerifier::new(
+            KeyName::new("oid/test".to_owned()).unwrap(),
+            0x1234_5678,
+            cosigner_id,
+            log_id,
+            ToyVerifier {
+                expected_sig: canned_sig.clone(),
+            },
+        );
+
+        let hash_b64 = BASE64_STANDARD.encode(hash.0);
+        let body_a = format!("oid/origin-a\n{start} {end}\n{hash_b64}\n");
+        let body_b = format!("oid/origin-b\n{start} {end}\n{hash_b64}\n");
+
+        // Same canned signature, different origins: both verify, because
+        // origin is not part of the binary signing input.
+        assert!(verifier.verify(body_a.as_bytes(), &canned_sig));
+        assert!(verifier.verify(body_b.as_bytes(), &canned_sig));
+    }
+}

--- a/crates/tlog_subtree_signature/src/lib.rs
+++ b/crates/tlog_subtree_signature/src/lib.rs
@@ -1,0 +1,825 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+//! Wire-format parsers and serializers for the `sign-subtree` cosigner endpoint.
+//!
+//! A cosigner exposes `POST <prefix>/sign-subtree` so that other parties can
+//! obtain cosignatures on an already-known subtree hash without learning any
+//! additional log state. The protocol was originally specified in
+//! [draft-ietf-plants-merkle-tree-certs-02 §C.2][mtc-c2]. The plan is to lift
+//! it into a standalone C2SP specification (provisional URL
+//! `c2sp.org/tlog-subtree-signature`); this crate exists to be the
+//! transport-layer Rust implementation that ships with that spec, independent
+//! of any particular log type.
+//!
+//! The request body is a newline-delimited concatenation of three blocks:
+//!
+//! 1. A **subtree signed note** carrying the subtree interval and hash. The
+//!    note may already have zero or more signatures; the endpoint MAY require
+//!    at least one (e.g. from the requester) as a `DoS` mitigation.
+//! 2. A **checkpoint signed note**, signed by the cosigner being asked to
+//!    cosign the subtree. Its tree size must be at least `end` of the requested
+//!    subtree.
+//! 3. Zero or more **subtree consistency proof** lines, each a base64-encoded
+//!    hash.
+//!
+//! On success the response body is a sequence of [`signed_note::NoteSignature`]
+//! lines (each starting with an em dash, U+2014), one per cosignature the
+//! server wishes to return.
+//!
+//! # What this crate provides
+//!
+//! Server side (cosigner receiving the request):
+//!
+//! - [`SignSubtreeRequest`]: a parsed request body; exposes the subtree
+//!   [`Note`], the parsed [`SubtreeNoteBody`], the checkpoint
+//!   [`CheckpointText`], and the consistency-proof [`Hash`] list. No semantic
+//!   checks (signature verification, proof verification) are performed at parse
+//!   time — callers run those against their own policy.
+//! - [`parse_sign_subtree_request`] / [`serialize_sign_subtree_response`].
+//!
+//! Client side (requester):
+//!
+//! - [`serialize_subtree_note_body`]: builds the text body of a subtree signed
+//!   note (`<origin>\n<start> <end>\n<base64-hash>\n`).
+//! - [`serialize_sign_subtree_request`] / [`parse_sign_subtree_response`].
+//!
+//! Shared:
+//!
+//! - [`MAX_CONSISTENCY_PROOF_HASHES`] (= 63) and
+//!   [`TlogSubtreeSignatureError`].
+//!
+//! Binary signing format (via the [`crypto`] module):
+//!
+//! - [`serialize_subtree_signature_input`]: build the `mtc-subtree/v1\n\0`
+//!   binary message a subtree signer actually signs (§5.4.1).
+//! - [`sign_subtree`]: convenience wrapper that calls
+//!   [`serialize_subtree_signature_input`] and hands the bytes to a
+//!   [`RawSigner`].
+//! - [`SubtreeNoteVerifier`]: a [`signed_note::NoteVerifier`] that accepts a
+//!   subtree signed note, reconstructs the binary signing input from the
+//!   note text, and delegates verification to a caller-supplied
+//!   [`RawVerifier`].
+//!
+//! The binary message label `mtc-subtree/v1` is kept as-is for wire
+//! compatibility with current IETF MTC deployments; when the C2SP spec
+//! settles on a new label (e.g. via [C2SP#237]'s `subtree/v1`),
+//! [`serialize_subtree_signature_input`] will gain a second encoding and
+//! existing clients can migrate in lockstep with the spec.
+//!
+//! # What this crate does not provide
+//!
+//! - Concrete signing keys. This crate is algorithm-agnostic: plug in your
+//!   own Ed25519 or ML-DSA signer via the [`RawSigner`] / [`RawVerifier`]
+//!   traits. A concrete multi-algorithm implementation will land with the
+//!   planned `ietf_mtc_api` crate.
+//! - Consistency-proof verification. Use
+//!   [`tlog_tiles::verify_subtree_consistency_proof`] for that.
+//! - Key-name / key-ID conventions. The MTC scheme uses
+//!   `oid/{id_rdna_trustanchor_id}.{log_id}` with a key ID derived via
+//!   `signed_note::compute_key_id` over `\xffmtc-subtree/v1`, but that is a
+//!   caller concern; [`SubtreeNoteVerifier`] takes a pre-computed
+//!   [`signed_note::KeyName`] and key ID.
+//! - Persistent state for the cosigner.
+//!
+//! [C2SP#237]: https://github.com/C2SP/C2SP/pull/237
+//!
+//! [mtc-c2]: https://www.ietf.org/archive/id/draft-ietf-plants-merkle-tree-certs-02.html#appendix-C.2
+//! [`Note`]: signed_note::Note
+//! [`CheckpointText`]: tlog_tiles::CheckpointText
+
+pub mod crypto;
+
+pub use crypto::{
+    serialize_subtree_signature_input, sign_subtree, RawSigner, RawVerifier, SubtreeNoteVerifier,
+};
+
+use base64::prelude::*;
+use signed_note::{Note, NoteSignature};
+use tlog_tiles::{CheckpointText, Hash, LeafIndex, MalformedCheckpointTextError, HASH_SIZE};
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors produced by the parsers and serializers in this crate.
+#[derive(Debug, thiserror::Error)]
+pub enum TlogSubtreeSignatureError {
+    /// The request body was malformed at the framing layer (missing
+    /// blank-line separators, etc.) or one of its sections failed to parse.
+    #[error("malformed request: {0}")]
+    MalformedRequest(String),
+
+    /// The response body was malformed.
+    #[error("malformed response: {0}")]
+    MalformedResponse(String),
+
+    /// A consistency proof exceeded
+    /// [`MAX_CONSISTENCY_PROOF_HASHES`]. Returned both on parse
+    /// (incoming request body has too many proof lines) and on serialize
+    /// (caller tried to build an outgoing request with an oversize proof
+    /// slice).
+    #[error("consistency proof exceeds {MAX_CONSISTENCY_PROOF_HASHES} hashes (got {0})")]
+    ConsistencyProofTooLarge(usize),
+
+    /// An embedded signed note (subtree, checkpoint, or signature line) failed
+    /// to parse.
+    #[error("signed note: {0:?}")]
+    Note(signed_note::NoteError),
+
+    /// A checkpoint note's text body did not parse as a valid
+    /// `CheckpointText`.
+    #[error("checkpoint text: {0:?}")]
+    CheckpointText(MalformedCheckpointTextError),
+}
+
+/// Type alias used in fn signatures for brevity.
+pub type Result<T> = core::result::Result<T, TlogSubtreeSignatureError>;
+
+// ---------------------------------------------------------------------------
+// Request parsing
+// ---------------------------------------------------------------------------
+
+/// A parsed `sign-subtree` request body.
+///
+/// Contains the three sections of the body: the subtree signed note, the
+/// cosigner-signed checkpoint, and the (possibly empty) consistency proof.
+/// Signatures on the subtree note and the checkpoint are *not* verified at
+/// parse time — the caller runs signature verification and proof verification
+/// against its own policy.
+#[derive(Debug)]
+pub struct SignSubtreeRequest {
+    /// The subtree signed note. Carries the subtree interval `[start, end)`
+    /// and subtree hash in its text body. The caller inspects the note's
+    /// signature list to decide whether any required signatures (e.g. from
+    /// the requester) are present.
+    pub subtree: Note,
+    /// The parsed subtree body (origin, start, end, hash). Present because
+    /// re-parsing [`Note::text`] everywhere would be error-prone.
+    pub subtree_body: SubtreeNoteBody,
+    /// The parsed checkpoint the caller claims the cosigner has signed. The
+    /// caller runs signature verification against this note's signer list
+    /// using its own [`signed_note::NoteVerifier`].
+    pub checkpoint_note: Note,
+    /// The parsed checkpoint text, for convenience. `checkpoint.size()` must
+    /// be at least `subtree_body.end` to serve as a legitimate tree head for
+    /// the requested subtree.
+    pub checkpoint: CheckpointText,
+    /// Consistency proof hashes, in order. Empty if the subtree is trivially
+    /// contained in the checkpoint (e.g. `subtree.end == checkpoint.size()`).
+    pub consistency_proof: Vec<Hash>,
+}
+
+/// The parsed text body of a subtree signed note.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubtreeNoteBody {
+    pub origin: String,
+    pub start: LeafIndex,
+    pub end: LeafIndex,
+    pub hash: Hash,
+}
+
+/// Maximum number of consistency-proof lines a client may send.
+///
+/// A subtree consistency proof has at most 63 hashes, since a Merkle tree
+/// built over a 64-bit-indexed log has depth ≤ 63.
+pub const MAX_CONSISTENCY_PROOF_HASHES: usize = 63;
+
+/// Parse a `sign-subtree` request body.
+///
+/// The body format is:
+///
+/// ```text
+/// <subtree signed note>
+/// \n
+/// <checkpoint signed note signed by the cosigner>
+/// \n
+/// <zero or more base64-encoded consistency-proof hashes, one per line>
+/// ```
+///
+/// # Errors
+///
+/// Returns [`TlogSubtreeSignatureError::MalformedRequest`] if the framing or
+/// any of the embedded structures is malformed, [`ConsistencyProofTooLarge`]
+/// if the consistency proof has more than [`MAX_CONSISTENCY_PROOF_HASHES`]
+/// lines, [`Note`] if a signed note fails to parse, or [`CheckpointText`] if
+/// the checkpoint note's text body is not a valid checkpoint.
+///
+/// [`ConsistencyProofTooLarge`]: TlogSubtreeSignatureError::ConsistencyProofTooLarge
+/// [`Note`]: TlogSubtreeSignatureError::Note
+/// [`CheckpointText`]: TlogSubtreeSignatureError::CheckpointText
+///
+/// # Wire-format TODO (feedback for the spec)
+///
+/// The body uses a blank line (`\n\n`) as the inter-section separator, but
+/// each c2sp.org/signed-note *already* contains a blank line between its text
+/// body and its signature block. A standalone parser cannot locate section
+/// boundaries without exploiting the invariant "each note contains exactly
+/// one internal `\n\n`" (what this function does), or by peeking ahead to
+/// distinguish signature lines (which start with `— `) from the start of
+/// the next section. Neither is obvious from the spec text.
+///
+/// Two cleaner alternatives worth proposing while the spec is still being
+/// drafted upstream:
+///
+/// 1. **Length-prefixed sections.** Each section is preceded by a fixed
+///    header line such as `subtree-note: <len>\n`,
+///    `checkpoint-note: <len>\n`, `consistency-proof: <count>\n`. Keeps the
+///    body text-friendly while making section boundaries unambiguous and
+///    streamable.
+///
+/// 2. **Binary framing.** Replace the concatenated-notes body with a TLS
+///    presentation-language `struct` carrying explicit-length opaque fields
+///    for each note and a fixed-length-hash vector for the consistency
+///    proof. Most consumers of this endpoint are already binary-speaking
+///    (CA, cosigner, monitor) and the signed-note text format is an artifact
+///    of the transport rather than a direct requirement of the protocol.
+pub fn parse_sign_subtree_request(body: &[u8]) -> Result<SignSubtreeRequest> {
+    // The wire format is `<subtree_note>\n<checkpoint_note>\n<proof>`.
+    //
+    // A signed note itself contains exactly one internal `\n\n` (between its
+    // text block and its signatures). The two note-terminating blank lines
+    // (the "\n"s before each separator) mean the body contains, in order:
+    //
+    //     \n\n (inside subtree note)
+    //     \n\n (separator between subtree and checkpoint)
+    //     \n\n (inside checkpoint note)
+    //     \n\n (separator between checkpoint and proof)
+    //
+    // So we slice at the 2nd and 4th `\n\n` boundaries.
+    let boundaries: Vec<usize> = body
+        .windows(2)
+        .enumerate()
+        .filter_map(|(i, w)| (w == b"\n\n").then_some(i))
+        .take(4)
+        .collect();
+    if boundaries.len() < 4 {
+        return Err(TlogSubtreeSignatureError::MalformedRequest(
+            "body is missing required blank-line separators".into(),
+        ));
+    }
+    // boundaries[1] is the separator after the subtree note.
+    // boundaries[3] is the separator after the checkpoint note.
+    let subtree_bytes = &body[..=boundaries[1]]; // includes trailing \n of note
+    let checkpoint_bytes = &body[boundaries[1] + 2..=boundaries[3]];
+    let proof_bytes = &body[boundaries[3] + 2..];
+
+    // Parse the subtree signed note.
+    let subtree = Note::from_bytes(subtree_bytes).map_err(TlogSubtreeSignatureError::Note)?;
+    let subtree_body = parse_subtree_note_body(subtree.text()).ok_or_else(|| {
+        TlogSubtreeSignatureError::MalformedRequest("malformed subtree note body".into())
+    })?;
+
+    // Parse the checkpoint signed note.
+    let checkpoint_note =
+        Note::from_bytes(checkpoint_bytes).map_err(TlogSubtreeSignatureError::Note)?;
+    let checkpoint = CheckpointText::from_bytes(checkpoint_note.text())
+        .map_err(TlogSubtreeSignatureError::CheckpointText)?;
+
+    // Parse the consistency proof: one base64 hash per line.
+    let consistency_proof = parse_consistency_proof(proof_bytes)?;
+
+    Ok(SignSubtreeRequest {
+        subtree,
+        subtree_body,
+        checkpoint_note,
+        checkpoint,
+        consistency_proof,
+    })
+}
+
+/// Parse a consistency-proof block (one base64 hash per line, possibly empty).
+fn parse_consistency_proof(buf: &[u8]) -> Result<Vec<Hash>> {
+    let text = std::str::from_utf8(buf).map_err(|_| {
+        TlogSubtreeSignatureError::MalformedRequest("consistency proof is not valid UTF-8".into())
+    })?;
+    // Trim a trailing newline so "a\nb\n" and "a\nb" both yield two lines.
+    let trimmed = text.strip_suffix('\n').unwrap_or(text);
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Count the proof lines up front so the error reports the actual size.
+    let line_count = trimmed.split('\n').count();
+    if line_count > MAX_CONSISTENCY_PROOF_HASHES {
+        return Err(TlogSubtreeSignatureError::ConsistencyProofTooLarge(
+            line_count,
+        ));
+    }
+    let mut hashes = Vec::new();
+    for line in trimmed.split('\n') {
+        let decoded = BASE64_STANDARD.decode(line).map_err(|e| {
+            TlogSubtreeSignatureError::MalformedRequest(format!(
+                "decoding consistency proof line: {e}"
+            ))
+        })?;
+        let arr: [u8; HASH_SIZE] = decoded.try_into().map_err(|v: Vec<u8>| {
+            TlogSubtreeSignatureError::MalformedRequest(format!(
+                "consistency proof hash is {} bytes, want {HASH_SIZE}",
+                v.len()
+            ))
+        })?;
+        hashes.push(Hash(arr));
+    }
+    Ok(hashes)
+}
+
+/// Parse a subtree note text body:
+/// ```text
+/// <origin>\n<start> <end>\n<base64-hash>\n
+/// ```
+fn parse_subtree_note_body(msg: &[u8]) -> Option<SubtreeNoteBody> {
+    let text = std::str::from_utf8(msg).ok()?;
+    let mut lines = text.splitn(4, '\n');
+    let origin = lines.next()?.to_owned();
+    let range_line = lines.next()?;
+    let hash_line = lines.next()?;
+
+    let mut parts = range_line.splitn(2, ' ');
+    let start: LeafIndex = parts.next()?.parse().ok()?;
+    let end: LeafIndex = parts.next()?.parse().ok()?;
+    if start > end {
+        return None;
+    }
+
+    let hash_bytes = BASE64_STANDARD.decode(hash_line).ok()?;
+    let hash_arr: [u8; HASH_SIZE] = hash_bytes.try_into().ok()?;
+    Some(SubtreeNoteBody {
+        origin,
+        start,
+        end,
+        hash: Hash(hash_arr),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Response serialization
+// ---------------------------------------------------------------------------
+
+/// Serialize a `sign-subtree` response body: one `— name b64sig\n` line per
+/// signature, in order.
+///
+/// A successful §C.2 response must contain at least one signature, so callers
+/// should not pass an empty slice for a 200 response; a debug assertion
+/// catches this in debug builds. Release builds return an empty `Vec` to
+/// preserve the total function contract.
+#[must_use]
+pub fn serialize_sign_subtree_response(sigs: &[NoteSignature]) -> Vec<u8> {
+    debug_assert!(
+        !sigs.is_empty(),
+        "sign-subtree response must contain at least one signature (§C.2)"
+    );
+    let mut out = Vec::new();
+    for sig in sigs {
+        out.extend_from_slice(&sig.to_bytes());
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Client-side helpers (requester building outgoing requests / parsing replies)
+// ---------------------------------------------------------------------------
+
+/// Serialize the text body of a subtree signed note:
+/// `<origin>\n<start> <end>\n<base64-hash>\n`.
+///
+/// The returned bytes are suitable for passing to [`signed_note::Note::new`]
+/// as the note text, together with any already-attached signatures.
+#[must_use]
+pub fn serialize_subtree_note_body(body: &SubtreeNoteBody) -> Vec<u8> {
+    let hash_b64 = BASE64_STANDARD.encode(body.hash.0);
+    format!(
+        "{}\n{} {}\n{}\n",
+        body.origin, body.start, body.end, hash_b64
+    )
+    .into_bytes()
+}
+
+/// Serialize a full `sign-subtree` request body.
+///
+/// Layout:
+///
+/// ```text
+/// <subtree_note.to_bytes()>
+/// \n
+/// <checkpoint_note.to_bytes()>
+/// \n
+/// <one base64 hash per line from consistency_proof>
+/// ```
+///
+/// The caller is responsible for providing a fully-assembled `subtree_note`
+/// (with whatever signatures the target endpoint requires, typically the
+/// requester's own subtree cosignature as a DoS-mitigation signal) and
+/// `checkpoint_note` (typically the cosigner's own signed checkpoint, whose
+/// tree size must cover `subtree.end`). This function performs no semantic
+/// validation.
+///
+/// # Errors
+///
+/// Returns [`TlogSubtreeSignatureError::ConsistencyProofTooLarge`] if
+/// `consistency_proof.len() > MAX_CONSISTENCY_PROOF_HASHES`.
+pub fn serialize_sign_subtree_request(
+    subtree_note: &Note,
+    checkpoint_note: &Note,
+    consistency_proof: &[Hash],
+) -> Result<Vec<u8>> {
+    if consistency_proof.len() > MAX_CONSISTENCY_PROOF_HASHES {
+        return Err(TlogSubtreeSignatureError::ConsistencyProofTooLarge(
+            consistency_proof.len(),
+        ));
+    }
+    let mut out = subtree_note.to_bytes();
+    out.push(b'\n');
+    out.extend_from_slice(&checkpoint_note.to_bytes());
+    out.push(b'\n');
+    for h in consistency_proof {
+        out.extend_from_slice(BASE64_STANDARD.encode(h.0).as_bytes());
+        out.push(b'\n');
+    }
+    Ok(out)
+}
+
+/// Parse a `sign-subtree` response body.
+///
+/// The body is a sequence of note signature lines, each starting with an em
+/// dash (U+2014) and terminated by a newline. Returns one [`NoteSignature`]
+/// per line.
+///
+/// Callers should verify each returned signature with the appropriate
+/// [`signed_note::NoteVerifier`] (one per cosigner key) before using it.
+///
+/// # Errors
+///
+/// Returns [`TlogSubtreeSignatureError::MalformedResponse`] if the body is
+/// not valid UTF-8 or is empty (a successful response must contain at least
+/// one signature line). Returns [`TlogSubtreeSignatureError::Note`] if any
+/// individual line fails [`NoteSignature::from_bytes`] parsing.
+pub fn parse_sign_subtree_response(body: &[u8]) -> Result<Vec<NoteSignature>> {
+    let text = std::str::from_utf8(body).map_err(|_| {
+        TlogSubtreeSignatureError::MalformedResponse("response is not valid UTF-8".into())
+    })?;
+    let trimmed = text.strip_suffix('\n').unwrap_or(text);
+    if trimmed.is_empty() {
+        return Err(TlogSubtreeSignatureError::MalformedResponse(
+            "response must contain at least one signature line".into(),
+        ));
+    }
+    let mut sigs = Vec::new();
+    for line in trimmed.split('\n') {
+        let sig =
+            NoteSignature::from_bytes(line.as_bytes()).map_err(TlogSubtreeSignatureError::Note)?;
+        sigs.push(sig);
+    }
+    Ok(sigs)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use signed_note::KeyName;
+
+    /// Build a minimal valid body of three sections: subtree note, checkpoint
+    /// note, and consistency proof. Uses a made-up bogus signature so we
+    /// exercise parsing without needing keys.
+    fn build_request(proof_hashes: &[[u8; 32]]) -> Vec<u8> {
+        // Subtree note: origin + "start end" + base64 hash, then one signature line.
+        let subtree_hash_b64 = BASE64_STANDARD.encode([0x11u8; 32]);
+        let subtree_text = format!("oid/1.3.6.1.4.1.32473.1\n4 8\n{subtree_hash_b64}\n");
+        // Craft a plausible signature line: "— <name> <base64(4-byte-id || sig)>"
+        let sig_bytes = vec![0u8; 64];
+        let mut keyed = vec![0xaau8, 0xbb, 0xcc, 0xdd];
+        keyed.extend(&sig_bytes);
+        let subtree_sig_line = format!(
+            "— oid/1.3.6.1.4.1.32473.1 {}\n",
+            BASE64_STANDARD.encode(&keyed)
+        );
+        let subtree_note = format!("{subtree_text}\n{subtree_sig_line}");
+
+        // Checkpoint note.
+        let checkpoint_hash_b64 = BASE64_STANDARD.encode([0x22u8; 32]);
+        let checkpoint_text = format!("oid/1.3.6.1.4.1.32473.1\n8\n{checkpoint_hash_b64}\n");
+        let mut keyed = vec![0x11u8, 0x22, 0x33, 0x44];
+        keyed.extend(vec![1u8; 64]);
+        let checkpoint_sig_line = format!(
+            "— oid/1.3.6.1.4.1.32473.1 {}\n",
+            BASE64_STANDARD.encode(&keyed)
+        );
+        let checkpoint_note = format!("{checkpoint_text}\n{checkpoint_sig_line}");
+
+        // Consistency proof.
+        let mut proof = String::new();
+        for h in proof_hashes {
+            proof.push_str(&BASE64_STANDARD.encode(h));
+            proof.push('\n');
+        }
+
+        format!("{subtree_note}\n{checkpoint_note}\n{proof}").into_bytes()
+    }
+
+    #[test]
+    fn parse_request_no_proof() {
+        let body = build_request(&[]);
+        let req = parse_sign_subtree_request(&body).unwrap();
+        assert_eq!(req.subtree_body.origin, "oid/1.3.6.1.4.1.32473.1");
+        assert_eq!(req.subtree_body.start, 4);
+        assert_eq!(req.subtree_body.end, 8);
+        assert_eq!(req.subtree_body.hash.0, [0x11u8; 32]);
+        assert_eq!(req.checkpoint.size(), 8);
+        assert_eq!(req.checkpoint.hash().0, [0x22u8; 32]);
+        assert!(req.consistency_proof.is_empty());
+    }
+
+    #[test]
+    fn parse_request_with_proof() {
+        let body = build_request(&[[0x33u8; 32], [0x44u8; 32]]);
+        let req = parse_sign_subtree_request(&body).unwrap();
+        assert_eq!(req.consistency_proof.len(), 2);
+        assert_eq!(req.consistency_proof[0].0, [0x33u8; 32]);
+        assert_eq!(req.consistency_proof[1].0, [0x44u8; 32]);
+    }
+
+    #[test]
+    fn parse_request_missing_blank_line() {
+        // No blank line after the subtree note at all.
+        let body = b"oid/x\n4 8\nAAAA\n\xe2\x80\x94 oid/x sig\n";
+        assert!(matches!(
+            parse_sign_subtree_request(body).unwrap_err(),
+            TlogSubtreeSignatureError::MalformedRequest(_)
+        ));
+    }
+
+    #[test]
+    fn parse_request_malformed_subtree() {
+        // Subtree note body has a non-numeric start.
+        let bad_text =
+            "oid/x\nfour eight\n".to_string() + &BASE64_STANDARD.encode([0u8; 32]) + "\n";
+        let mut keyed = vec![0u8, 0, 0, 0];
+        keyed.extend(vec![0u8; 64]);
+        let sig_line = format!("— oid/x {}\n", BASE64_STANDARD.encode(&keyed));
+        let subtree = format!("{bad_text}\n{sig_line}");
+        let chk_text = format!("oid/x\n8\n{}\n", BASE64_STANDARD.encode([0u8; 32]));
+        let chk = format!("{chk_text}\n{sig_line}");
+        let body = format!("{subtree}\n{chk}\n");
+        assert!(parse_sign_subtree_request(body.as_bytes()).is_err());
+    }
+
+    #[test]
+    fn parse_request_too_many_proof_hashes() {
+        let mut hashes = Vec::new();
+        for _ in 0..=MAX_CONSISTENCY_PROOF_HASHES {
+            hashes.push([0x55u8; 32]);
+        }
+        let body = build_request(&hashes);
+        let err = parse_sign_subtree_request(&body).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TlogSubtreeSignatureError::ConsistencyProofTooLarge(n)
+                    if n == MAX_CONSISTENCY_PROOF_HASHES + 1
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// The maximum proof length ([`MAX_CONSISTENCY_PROOF_HASHES`]) must parse
+    /// successfully; only strictly more than that errors out.
+    #[test]
+    fn parse_request_exact_max_proof_hashes() {
+        let hashes = vec![[0x66u8; 32]; MAX_CONSISTENCY_PROOF_HASHES];
+        let body = build_request(&hashes);
+        let req = parse_sign_subtree_request(&body).expect("63-hash proof should parse");
+        assert_eq!(req.consistency_proof.len(), MAX_CONSISTENCY_PROOF_HASHES);
+    }
+
+    /// A trailing blank line after the final hash is rejected, rather than
+    /// silently skipped: `"<hash>\n\n"` parses into `["<hash>", ""]` after
+    /// `strip_suffix('\n')`, and the empty second line fails base64 decoding
+    /// as a [`MalformedRequest`].
+    ///
+    /// [`MalformedRequest`]: TlogSubtreeSignatureError::MalformedRequest
+    #[test]
+    fn parse_request_rejects_blank_trailing_proof_line() {
+        // Build a request with one valid proof hash, then append a stray
+        // newline (so the final proof block is `<hash>\n\n`).
+        let hash_b64 = BASE64_STANDARD.encode([0x77u8; 32]);
+        let mut body = build_request(&[[0x77u8; 32]]);
+        // build_request already ends with `<hash_b64>\n`; add a second `\n`.
+        body.push(b'\n');
+        // Sanity: body now ends with two newlines after the hash.
+        assert!(body.ends_with(format!("{hash_b64}\n\n").as_bytes()));
+        let err = parse_sign_subtree_request(&body).unwrap_err();
+        assert!(
+            matches!(err, TlogSubtreeSignatureError::MalformedRequest(_)),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_request_bad_proof_length() {
+        let subtree_hash_b64 = BASE64_STANDARD.encode([0u8; 32]);
+        let subtree_text = format!("oid/x\n0 4\n{subtree_hash_b64}\n");
+        let mut keyed = vec![0u8; 4];
+        keyed.extend(vec![0u8; 64]);
+        let sig_line = format!("— oid/x {}\n", BASE64_STANDARD.encode(&keyed));
+        let subtree = format!("{subtree_text}\n{sig_line}");
+        let chk_text = format!("oid/x\n4\n{subtree_hash_b64}\n");
+        let chk = format!("{chk_text}\n{sig_line}");
+        // 16-byte hash (wrong size) rather than 32.
+        let bad_hash = BASE64_STANDARD.encode([0u8; 16]);
+        let body = format!("{subtree}\n{chk}\n{bad_hash}\n");
+        let err = parse_sign_subtree_request(body.as_bytes()).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("32"), "unexpected error: {msg}");
+    }
+
+    /// Passing an empty slice trips the debug assertion in
+    /// [`serialize_sign_subtree_response`] (a successful §C.2 response must
+    /// contain at least one signature).
+    #[test]
+    #[should_panic(expected = "sign-subtree response must contain at least one signature")]
+    #[cfg(debug_assertions)]
+    fn serialize_response_empty_panics_in_debug() {
+        let _ = serialize_sign_subtree_response(&[]);
+    }
+
+    /// Release builds tolerate the empty slice and return an empty `Vec` to
+    /// preserve the total function contract.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn serialize_response_empty_is_total_in_release() {
+        assert!(serialize_sign_subtree_response(&[]).is_empty());
+    }
+
+    #[test]
+    fn serialize_response_roundtrip() {
+        let name = KeyName::new("oid/1.3.6.1.4.1.32473.1".to_owned()).unwrap();
+        let id = 0xdead_beef;
+        let sig = vec![0x42u8; 64];
+        let ns = NoteSignature::new(name, id, sig);
+        let bytes = serialize_sign_subtree_response(std::slice::from_ref(&ns));
+        let line = std::str::from_utf8(&bytes).unwrap();
+        assert!(line.starts_with("— oid/1.3.6.1.4.1.32473.1 "));
+        assert!(line.ends_with('\n'));
+
+        // Round-trip through NoteSignature::from_bytes.
+        let parsed = NoteSignature::from_bytes(line.trim_end_matches('\n').as_bytes()).unwrap();
+        assert_eq!(parsed.name(), ns.name());
+        assert_eq!(parsed.id(), ns.id());
+        assert_eq!(parsed.signature(), ns.signature());
+    }
+
+    #[test]
+    fn serialize_response_multiple() {
+        let name = KeyName::new("oid/x".to_owned()).unwrap();
+        let ns1 = NoteSignature::new(name.clone(), 1, vec![0u8; 64]);
+        let ns2 = NoteSignature::new(name, 2, vec![1u8; 64]);
+        let bytes = serialize_sign_subtree_response(&[ns1, ns2]);
+        let text = std::str::from_utf8(&bytes).unwrap();
+        assert_eq!(text.matches('\n').count(), 2);
+        assert_eq!(text.matches("— ").count(), 2);
+    }
+
+    // ---- Client-side helpers ----
+
+    #[test]
+    fn serialize_subtree_note_body_format() {
+        let body = SubtreeNoteBody {
+            origin: "oid/1.3.6.1.4.1.32473.1".to_owned(),
+            start: 4,
+            end: 8,
+            hash: Hash([0x11u8; 32]),
+        };
+        let bytes = serialize_subtree_note_body(&body);
+        let text = std::str::from_utf8(&bytes).unwrap();
+        let hash_b64 = BASE64_STANDARD.encode([0x11u8; 32]);
+        assert_eq!(text, format!("oid/1.3.6.1.4.1.32473.1\n4 8\n{hash_b64}\n"));
+    }
+
+    #[test]
+    fn serialize_subtree_note_body_roundtrips_through_parser() {
+        let body = SubtreeNoteBody {
+            origin: "oid/x".to_owned(),
+            start: 0,
+            end: 16,
+            hash: Hash([0x99u8; 32]),
+        };
+        let text = serialize_subtree_note_body(&body);
+        let parsed = parse_subtree_note_body(&text).unwrap();
+        assert_eq!(parsed, body);
+    }
+
+    /// Build a request via [`serialize_sign_subtree_request`], feed it into
+    /// [`parse_sign_subtree_request`], and confirm every section is recovered.
+    #[test]
+    fn serialize_parse_request_roundtrip() {
+        // Subtree note: text body from SubtreeNoteBody + one fake signature.
+        let subtree_body = SubtreeNoteBody {
+            origin: "oid/1.3.6.1.4.1.32473.1".to_owned(),
+            start: 4,
+            end: 8,
+            hash: Hash([0x11u8; 32]),
+        };
+        let subtree_text = serialize_subtree_note_body(&subtree_body);
+        let ca_name = KeyName::new("oid/1.3.6.1.4.1.32473.1".to_owned()).unwrap();
+        let subtree_signature = NoteSignature::new(ca_name.clone(), 0xdead_beef, vec![0x42u8; 64]);
+        let subtree_note =
+            Note::new(&subtree_text, std::slice::from_ref(&subtree_signature)).unwrap();
+
+        // Checkpoint note with a plausible CheckpointText body.
+        let checkpoint_hash_b64 = BASE64_STANDARD.encode([0x22u8; 32]);
+        let checkpoint_text =
+            format!("oid/1.3.6.1.4.1.32473.1\n8\n{checkpoint_hash_b64}\n").into_bytes();
+        let checkpoint_signature = NoteSignature::new(ca_name, 0xcafe_cafe, vec![0x24u8; 64]);
+        let checkpoint_note = Note::new(
+            &checkpoint_text,
+            std::slice::from_ref(&checkpoint_signature),
+        )
+        .unwrap();
+
+        let proof = vec![Hash([0x33u8; 32]), Hash([0x44u8; 32])];
+
+        let body = serialize_sign_subtree_request(&subtree_note, &checkpoint_note, &proof).unwrap();
+        let req = parse_sign_subtree_request(&body).unwrap();
+
+        assert_eq!(req.subtree_body, subtree_body);
+        assert_eq!(req.checkpoint.size(), 8);
+        assert_eq!(req.checkpoint.hash().0, [0x22u8; 32]);
+        assert_eq!(req.consistency_proof, proof);
+    }
+
+    #[test]
+    fn serialize_request_rejects_oversize_proof() {
+        let subtree_body = SubtreeNoteBody {
+            origin: "oid/x".to_owned(),
+            start: 0,
+            end: 1,
+            hash: Hash([0u8; 32]),
+        };
+        let subtree_text = serialize_subtree_note_body(&subtree_body);
+        let name = KeyName::new("oid/x".to_owned()).unwrap();
+        let sig = NoteSignature::new(name, 0x1111_1111, vec![0x5au8; 64]);
+        let subtree_note = Note::new(&subtree_text, std::slice::from_ref(&sig)).unwrap();
+        let chk_text = format!("oid/x\n1\n{}\n", BASE64_STANDARD.encode([0u8; 32])).into_bytes();
+        let checkpoint_note = Note::new(&chk_text, std::slice::from_ref(&sig)).unwrap();
+        let proof = vec![Hash([0u8; 32]); MAX_CONSISTENCY_PROOF_HASHES + 1];
+        let err =
+            serialize_sign_subtree_request(&subtree_note, &checkpoint_note, &proof).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                TlogSubtreeSignatureError::ConsistencyProofTooLarge(n)
+                    if n == MAX_CONSISTENCY_PROOF_HASHES + 1
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_response_single_line() {
+        let name = KeyName::new("oid/mirror".to_owned()).unwrap();
+        let ns = NoteSignature::new(name, 0xabcd_ef01, vec![0x7fu8; 64]);
+        let body = serialize_sign_subtree_response(std::slice::from_ref(&ns));
+        let sigs = parse_sign_subtree_response(&body).unwrap();
+        assert_eq!(sigs.len(), 1);
+        assert_eq!(sigs[0].name(), ns.name());
+        assert_eq!(sigs[0].id(), ns.id());
+        assert_eq!(sigs[0].signature(), ns.signature());
+    }
+
+    #[test]
+    fn parse_response_multiple() {
+        let name = KeyName::new("oid/mirror".to_owned()).unwrap();
+        let ns1 = NoteSignature::new(name.clone(), 0x1111_1111, vec![0u8; 64]);
+        let ns2 = NoteSignature::new(name, 0x2222_2222, vec![1u8; 64]);
+        let body = serialize_sign_subtree_response(&[ns1.clone(), ns2.clone()]);
+        let sigs = parse_sign_subtree_response(&body).unwrap();
+        assert_eq!(sigs.len(), 2);
+        assert_eq!(sigs[0].id(), ns1.id());
+        assert_eq!(sigs[1].id(), ns2.id());
+    }
+
+    #[test]
+    fn parse_response_empty() {
+        assert!(matches!(
+            parse_sign_subtree_response(b"").unwrap_err(),
+            TlogSubtreeSignatureError::MalformedResponse(_)
+        ));
+        assert!(matches!(
+            parse_sign_subtree_response(b"\n").unwrap_err(),
+            TlogSubtreeSignatureError::MalformedResponse(_)
+        ));
+    }
+
+    #[test]
+    fn parse_response_bad_line() {
+        // "\xE2\x80\x94" is the UTF-8 encoding of the em-dash (U+2014).
+        let body = b"\xE2\x80\x94 oid/mirror notvalidbase64!!\n";
+        assert!(matches!(
+            parse_sign_subtree_response(body).unwrap_err(),
+            TlogSubtreeSignatureError::Note(_)
+        ));
+    }
+}


### PR DESCRIPTION
Introduces a new spec-level crate, separate from `ietf_mtc_api`, for the
`sign-subtree` cosigner endpoint. The endpoint is currently specified in
draft-ietf-plants-merkle-tree-certs-02 §C.2; the intent is for it to
migrate into a standalone C2SP specification (provisional URL
`c2sp.org/tlog-subtree-signature`), and this crate is positioned to ship
with that future spec.

Scope:

  HTTP wire format (top-level module):

  Server side (cosigner receiving the request):
  - `SignSubtreeRequest`, `SubtreeNoteBody`
  - `parse_sign_subtree_request`
  - `serialize_sign_subtree_response`

  Client side (requester):
  - `serialize_subtree_note_body`
  - `serialize_sign_subtree_request`
  - `parse_sign_subtree_response`

  Shared:
  - `MAX_CONSISTENCY_PROOF_HASHES = 63`
  - `TlogSubtreeSignatureError`

  Binary signing format (`crypto` module, re-exported at crate root):

  - `serialize_subtree_signature_input` — produce the `mtc-subtree/v1\n\0`
    binary message a subtree signer actually signs (§5.4.1). Opaque-bytes
    interface: `cosigner_id` and `log_id` are `&[u8]` so the crate doesn't
    depend on any particular identity encoding (MTC uses BER-encoded
    `TrustAnchorID`; future C2SP spec may use something else).
  - `RawSigner` / `RawVerifier` traits: algorithm-agnostic abstraction
    over "produce raw sig bytes for a message" / "check raw sig bytes for
    a message". Concrete implementations (Ed25519, ML-DSA-44, ...) live
    in downstream crates; today the only workspace ones are in
    `ietf_mtc_api` (`MtcSigningKey` / `MtcVerifyingKey`).
  - `sign_subtree(signer, cosigner_id, log_id, start, end, hash)` —
    convenience wrapper that builds the binary input and hands it to the
    signer.
  - `SubtreeNoteVerifier<V: RawVerifier>` — a `signed_note::NoteVerifier`
    that accepts a subtree signed note, reconstructs the binary signing
    input from the note text body, and delegates to the wrapped
    `RawVerifier`. Caller supplies `KeyName`, key ID, and identity bytes;
    this crate does not prescribe name-format or key-ID conventions.

The label `mtc-subtree/v1` is kept as-is for wire compatibility with
current IETF MTC deployments. When the C2SP spec settles on a new label
(e.g. via [C2SP#237]'s `subtree/v1`), `serialize_subtree_signature_input`
will gain a second encoding and existing clients can migrate in lockstep.

Out of scope (stays in `ietf_mtc_api`):

  - Multi-algorithm key enums (`MtcSigningKey` / `MtcVerifyingKey`). They
    become `RawSigner` / `RawVerifier` impls in a follow-up commit.
  - `TrustAnchorID` / `ID_RDNA_TRUSTANCHOR_ID` and the MTC `oid/…`
    key-name scheme. The new crate takes an opaque `KeyName` + key ID.
  - `MtcCosigner` and `ParsedMtcProof`. These remain MTC-CA-specific.

Tests: 21 unit tests (17 wire-format + 4 binary-format) pin the request /
response round-trip, malformed-input rejection, the `mtc-subtree/v1`
binary layout, and the `SubtreeNoteVerifier` happy-path + malformed-text
paths. The binary-format layout test mirrors the pattern used by
`SequenceMetadata::serialize_cache_entries` — any change to the format
would fail loudly and visibly.

The `parse_sign_subtree_request` doc comment carries forward a TODO from
the original `ietf_mtc_api::sign_subtree` module: the `\n\n` blank-line
separator between sections is ambiguous with the intra-note
text/signatures boundary. Two cleaner alternatives (length-prefixed
sections; TLS-binary framing) are sketched for upstream discussion.

Follow-ups:

  - `lvalenta/ietf-mtc-v2` drops the duplicate parsers +
    `serialize_mtc_subtree_signature_input` from `ietf_mtc_api`; its
    `MtcCosigner::sign_subtree` becomes a thin wrapper over
    `tlog_subtree_signature::sign_subtree`, and `MtcSubtreeNoteVerifier`
    becomes a thin wrapper that fixes the MTC identity convention in
    place around `SubtreeNoteVerifier`.
  - `lvalenta/tlog-witness` gains a `/sign-subtree` endpoint using this
    crate's parsers + `ietf_mtc_api` for the MTC signing semantics.

[C2SP#237]: https://github.com/C2SP/C2SP/pull/237