### PR TITLE
Move cosignature_v1 to a new tlog_cosignature crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,7 @@ dependencies = [
  "sha2",
  "signed_note",
  "static_ct_api",
+ "tlog_cosignature",
  "tlog_tiles",
  "tlog_witness",
  "tokio",
@@ -2944,11 +2945,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tlog_cosignature"
+version = "0.2.0"
+dependencies = [
+ "byteorder",
+ "ed25519-dalek",
+ "rand",
+ "signed_note",
+ "tlog_tiles",
+]
+
+[[package]]
 name = "tlog_tiles"
 version = "0.2.0"
 dependencies = [
  "base64",
- "byteorder",
  "ed25519-dalek",
  "length_prefixed",
  "rand",
@@ -3743,6 +3754,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "signed_note",
+ "tlog_cosignature",
  "tlog_tiles",
  "tlog_witness",
  "witness_worker_config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/signed_note",
     "crates/signed_note_wasm",
     "crates/static_ct_api",
+    "crates/tlog_cosignature",
     "crates/tlog_tiles",
     "crates/tlog_tiles_wasm",
     "crates/tlog_witness",
@@ -41,6 +42,7 @@ default-members = [
     "crates/signed_note",
     "crates/signed_note_wasm",
     "crates/static_ct_api",
+    "crates/tlog_cosignature",
     "crates/tlog_tiles",
     "crates/tlog_tiles_wasm",
     "crates/tlog_witness",
@@ -121,6 +123,7 @@ signature = "3.0.0-rc.10"
 signed_note = { path = "crates/signed_note", version = "0.2.0" }
 static_ct_api = { path = "crates/static_ct_api", version = "0.2.0" }
 thiserror = "2.0"
+tlog_cosignature = { path = "crates/tlog_cosignature", version = "0.2.0" }
 tlog_tiles = { path = "crates/tlog_tiles", version = "0.2.0" }
 tlog_witness = { path = "crates/tlog_witness", version = "0.2.0" }
 tokio = { version = "1", features = ["sync"] }

--- a/crates/integration_tests/Cargo.toml
+++ b/crates/integration_tests/Cargo.toml
@@ -29,6 +29,7 @@ sha2.workspace = true
 signed_note.workspace = true
 static_ct_api.workspace = true
 bootstrap_mtc_api.workspace = true
+tlog_cosignature.workspace = true
 tlog_tiles.workspace = true
 tlog_witness.workspace = true
 sct_validator.workspace = true

--- a/crates/integration_tests/tests/tlog_witness.rs
+++ b/crates/integration_tests/tests/tlog_witness.rs
@@ -259,7 +259,7 @@ fn verify_witness_signature(checkpoint: &Note, sigs: &[NoteSignature], meta: &Me
     let witness_vk = ed25519_dalek::VerifyingKey::from_public_key_der(&meta.witness_public_key)
         .expect("witness SPKI");
     let name = KeyName::new(meta.witness_name.clone()).expect("KeyName for witness");
-    let v = tlog_tiles::CosignatureV1NoteVerifier::new(name, witness_vk);
+    let v = tlog_cosignature::CosignatureV1NoteVerifier::new(name, witness_vk);
     let augmented = Note::new(checkpoint.text(), sigs).expect("assemble augmented note");
     let (verified, _unverified) = augmented
         .verify(&VerifierList::new(vec![Box::new(v)]))

--- a/crates/tlog_cosignature/Cargo.toml
+++ b/crates/tlog_cosignature/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tlog_cosignature"
+readme = "README.md"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "An implementation of c2sp.org/tlog-cosignature"
+categories = ["cryptography"]
+keywords = ["transparency", "cosignature", "checkpoint", "crypto", "pki"]
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+byteorder.workspace = true
+ed25519-dalek.workspace = true
+signed_note.workspace = true
+tlog_tiles.workspace = true
+
+[dev-dependencies]
+rand.workspace = true

--- a/crates/tlog_cosignature/README.md
+++ b/crates/tlog_cosignature/README.md
@@ -1,0 +1,33 @@
+# tlog_cosignature
+
+An implementation of [`c2sp.org/tlog-cosignature`](https://c2sp.org/tlog-cosignature):
+*Transparency Log Cosignatures*.
+
+A *cosignature* is a statement by a cosigner that it verified the
+consistency of a [checkpoint](https://c2sp.org/tlog-checkpoint) (or, in
+future revisions of the spec, a subtree). Log clients combine cosignatures
+from multiple cosigners to prevent split-view attacks before trusting an
+inclusion proof.
+
+This crate provides signers and verifiers for the cosignature formats
+specified by the C2SP document. Today only the Ed25519 `cosignature/v1`
+format is implemented; the ML-DSA-44 `subtree/v1` format will be added
+in a follow-up.
+
+## What's in scope
+
+- [`CosignatureV1CheckpointSigner`] / [`CosignatureV1NoteVerifier`]: the
+  Ed25519 `cosignature/v1` signed-message format. The signed message is
+  `cosignature/v1\ntime <ts>\n<note body>` and the timestamped signature
+  is the 64-byte Ed25519 signature prefixed with a big-endian `u64`
+  POSIX timestamp.
+
+## What's out of scope
+
+- HTTP transports for requesting cosignatures (see `tlog_witness` for
+  `c2sp.org/tlog-witness` parsers/serializers).
+- Persistent state for a witness — that's a deployment concern.
+
+## License
+
+The project is licensed under the [BSD-3-Clause License](../../LICENSE).

--- a/crates/tlog_cosignature/src/cosignature_v1.rs
+++ b/crates/tlog_cosignature/src/cosignature_v1.rs
@@ -7,7 +7,7 @@ use ed25519_dalek::{
 };
 use signed_note::{KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
 
-use crate::{CheckpointSigner, CheckpointText, UnixTimestamp};
+use tlog_tiles::{CheckpointSigner, CheckpointText, UnixTimestamp};
 
 /// Implementation of [`CheckpointSigner`] that produces a timestamped Ed25519 cosignature/v1 (alg 0x04 from <c2sp.org/signed-note>).
 pub struct CosignatureV1CheckpointSigner {
@@ -140,7 +140,7 @@ impl NoteVerifier for CosignatureV1NoteVerifier {
 #[cfg(test)]
 mod tests {
 
-    use crate::{open_checkpoint, record_hash, TreeWithTimestamp};
+    use tlog_tiles::{open_checkpoint, record_hash, TreeWithTimestamp};
 
     use super::*;
     use signed_note::VerifierList;

--- a/crates/tlog_cosignature/src/lib.rs
+++ b/crates/tlog_cosignature/src/lib.rs
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+//! An implementation of [c2sp.org/tlog-cosignature][spec].
+//!
+//! A *cosignature* is a statement by a cosigner that it verified the
+//! consistency of a [checkpoint][]. Log clients combine cosignatures from
+//! multiple cosigners to prevent split-view attacks before trusting an
+//! inclusion proof.
+//!
+//! This crate provides signers and verifiers for the cosignature formats
+//! specified by the C2SP document. Today only the Ed25519 `cosignature/v1`
+//! format is implemented (in the [`cosignature_v1`] module); the
+//! ML-DSA-44 `subtree/v1` format will be added in a follow-up alongside
+//! support for signing arbitrary subtrees.
+//!
+//! HTTP transports for requesting cosignatures are out of scope; see
+//! [`tlog_witness`] for parsers/serializers of the
+//! [c2sp.org/tlog-witness](https://c2sp.org/tlog-witness) protocol.
+//!
+//! [spec]: https://c2sp.org/tlog-cosignature
+//! [checkpoint]: https://c2sp.org/tlog-checkpoint
+//! [`tlog_witness`]: https://docs.rs/tlog_witness
+
+pub mod cosignature_v1;
+
+pub use cosignature_v1::{CosignatureV1CheckpointSigner, CosignatureV1NoteVerifier};

--- a/crates/tlog_tiles/Cargo.toml
+++ b/crates/tlog_tiles/Cargo.toml
@@ -26,7 +26,6 @@ serde_json.workspace = true
 
 [dependencies]
 base64.workspace = true
-byteorder.workspace = true
 ed25519-dalek.workspace = true
 length_prefixed.workspace = true
 rand.workspace = true

--- a/crates/tlog_tiles/src/lib.rs
+++ b/crates/tlog_tiles/src/lib.rs
@@ -17,13 +17,11 @@
 //! - [ct_test.go](https://cs.opensource.google/go/x/mod/+/refs/tags/v0.21.0:sumdb/tlog/ct_test.go)
 
 pub mod checkpoint;
-pub mod cosignature_v1;
 pub mod entries;
 pub mod tile;
 pub mod tlog;
 
 pub use checkpoint::*;
-pub use cosignature_v1::*;
 pub use entries::*;
 pub use tile::*;
 pub use tlog::*;

--- a/crates/tlog_witness/src/lib.rs
+++ b/crates/tlog_witness/src/lib.rs
@@ -28,8 +28,8 @@
 //!   verifier. The parsers here return the checkpoint [`Note`] with its
 //!   signatures still attached so the caller can inspect them.
 //! - Cosignature production: producing a `cosignature/v1` signature is
-//!   handled by [`tlog_tiles::CosignatureV1CheckpointSigner`] (or any other
-//!   [`tlog_tiles::CheckpointSigner`] impl).
+//!   handled by [`tlog_cosignature::CosignatureV1CheckpointSigner`] (or any
+//!   other [`tlog_tiles::CheckpointSigner`] impl).
 //! - Consistency-proof verification: use
 //!   [`tlog_tiles::verify_consistency_proof`] directly.
 //! - Persistent state for the "latest cosigned checkpoint per origin" check
@@ -39,6 +39,7 @@
 //! [spec]: https://c2sp.org/tlog-witness
 //! [add]: https://c2sp.org/tlog-witness#add-checkpoint
 //! [`Note`]: signed_note::Note
+//! [`tlog_cosignature::CosignatureV1CheckpointSigner`]: https://docs.rs/tlog_cosignature/latest/tlog_cosignature/cosignature_v1/struct.CosignatureV1CheckpointSigner.html
 
 mod add_checkpoint;
 

--- a/crates/witness_worker/Cargo.toml
+++ b/crates/witness_worker/Cargo.toml
@@ -40,6 +40,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 signed_note.workspace = true
+tlog_cosignature.workspace = true
 tlog_tiles.workspace = true
 tlog_witness.workspace = true
 worker.workspace = true

--- a/crates/witness_worker/src/lib.rs
+++ b/crates/witness_worker/src/lib.rs
@@ -25,7 +25,7 @@ use ed25519_dalek::{
 use signed_note::{Ed25519NoteVerifier, KeyName, NoteVerifier, VerifierList};
 use std::collections::HashMap;
 use std::sync::{LazyLock, OnceLock};
-use tlog_tiles::CosignatureV1CheckpointSigner;
+use tlog_cosignature::CosignatureV1CheckpointSigner;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 


### PR DESCRIPTION
## Summary

Move `cosignature_v1` out of `tlog_tiles` into a new `tlog_cosignature` crate, mirroring how the [c2sp.org/tlog-cosignature](https://c2sp.org/tlog-cosignature) spec is layered under (not part of) `tlog-tiles`.

The new `tlog_cosignature` crate gives that spec its own home; `tlog_tiles` keeps the tlog/checkpoint primitives.

## Layout

- `tlog_cosignature::cosignature_v1`: Ed25519 `cosignature/v1` `CheckpointSigner` and `NoteVerifier`. Byte-for-byte identical behavior; only the import path changes.
- `tlog_tiles`: no longer hosts the `cosignature_v1` module, and drops its `byteorder` dependency (the only consumer of which was that file).

## Callers updated

- `witness_worker` imports from `tlog_cosignature`.
- `integration_tests` imports from `tlog_cosignature` (used in the `tlog_witness` test).
- `tlog_witness` lib doc cross-references `tlog_cosignature::CosignatureV1CheckpointSigner`.

## Followup

A future PR will add a `subtree_v1` module to `tlog_cosignature` implementing the ML-DSA-44 signed-message format from the same spec, covering arbitrary subtrees in addition to whole-tree checkpoints. That, combined with the C2SP `tlog-witness` `sign-subtree` wire format addition (PR #245 there), is what was originally proposed by #221 — split here for reviewability.

## Testing

`cargo clippy --workspace --all-targets -- -Dwarnings -Dclippy::pedantic`, `cargo test`, `cargo fmt --all --check`, `cargo machete` all pass locally.
