### PR TITLE
Add subtree_v1 ML-DSA-44 cosignatures to tlog_cosignature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,6 +1689,32 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-dsa"
+version = "0.1.0-rc.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5b2bb0ad6fa2b40396775bd56f51345171490fef993f46f91a876ecdbdaea55"
+dependencies = [
+ "const-oid",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8",
+ "rand_core",
+ "sha3",
+ "signature",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc7c90d33a0dac244570c26461d761ffaeadb3bfc2b17cc625ae2185cafdffae"
+dependencies = [
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -2658,6 +2694,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2950,6 +2996,8 @@ version = "0.2.0"
 dependencies = [
  "byteorder",
  "ed25519-dalek",
+ "length_prefixed",
+ "ml-dsa",
  "rand",
  "signed_note",
  "tlog_tiles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ jsonschema = "0.30"
 length_prefixed = { path = "crates/length_prefixed" }
 libfuzzer-sys = "0.4"
 log = { version = "0.4" }
+ml-dsa = "=0.1.0-rc.8"
 bootstrap_mtc_api = { version = "0.2.0", path = "crates/bootstrap_mtc_api" }
 p256 = { version = "0.14.0-rc.8", features = ["ecdsa"] }
 p384 = { version = "0.14.0-rc.8", features = ["ecdsa"] }
@@ -141,4 +142,4 @@ rsa = { version = "0.10.0-rc.17", default-features = false, features = ["sha2", 
 hashbrown = "0.15"
 spki = "0.8"
 const-oid = "0.10"
-pkcs8 = { version = "0.11.0-rc.11", features = ["pem"] }
+pkcs8 = { version = "=0.11.0-rc.11", features = ["pem"] }

--- a/crates/signed_note/src/lib.rs
+++ b/crates/signed_note/src/lib.rs
@@ -232,6 +232,7 @@ pub enum SignatureType {
     Ed25519 = 0x01,
     CosignatureV1 = 0x04,
     RFC6962TreeHead = 0x05,
+    MlDsa44 = 0x06,
     Undefined = 0xff,
 }
 
@@ -243,6 +244,7 @@ impl TryFrom<u8> for SignatureType {
             0x01 => Ok(SignatureType::Ed25519),
             0x04 => Ok(SignatureType::CosignatureV1),
             0x05 => Ok(SignatureType::RFC6962TreeHead),
+            0x06 => Ok(SignatureType::MlDsa44),
             0xff => Ok(SignatureType::Undefined),
             _ => Err(NoteError::UnknownSignatureType),
         }
@@ -253,13 +255,36 @@ impl TryFrom<u8> for SignatureType {
 pub struct KeyName(String);
 
 impl KeyName {
-    /// Return a valid key name according to <https://c2sp.org/signed-note#format>.
-    /// It must be non-empty and not have any Unicode spaces or pluses.
+    /// Maximum length, in bytes, of a key name's UTF-8 encoding.
+    ///
+    /// The signed-note spec does not itself impose a length cap, but every
+    /// C2SP-defined consumer that embeds a key name in a length-prefixed
+    /// wire format does so as a TLS-presentation `opaque<1..2^8-1>` —
+    /// notably the `cosigner_name` and `log_origin` fields of
+    /// [`tlog-cosignature`][cosig]'s ML-DSA-44 `cosigned_message` struct.
+    /// Capping `KeyName` at the same 255-byte limit means consumers can
+    /// rely on `as_str().as_bytes().len() <= MAX_LEN` without a redundant
+    /// runtime check at every encoding site, and an over-long key name
+    /// fails closed at construction rather than at first use.
+    ///
+    /// [cosig]: https://c2sp.org/tlog-cosignature
+    pub const MAX_LEN: usize = 255;
+
+    /// Return a valid key name according to <https://c2sp.org/signed-note#format>:
+    /// non-empty, with no Unicode spaces or `+` characters. Additionally
+    /// capped at [`Self::MAX_LEN`] bytes for compatibility with C2SP
+    /// consumers (see the constant for rationale).
     ///
     /// # Errors
-    /// Will return `Err` if the key name is empty or has Unicode spaces or pluses.
+    /// Returns [`NoteError::InvalidKeyName`] if the key name is empty,
+    /// contains Unicode whitespace or `+`, or exceeds
+    /// [`Self::MAX_LEN`] bytes when UTF-8-encoded.
     pub fn new(name: String) -> Result<Self, NoteError> {
-        if name.is_empty() || name.chars().any(char::is_whitespace) || name.contains('+') {
+        if name.is_empty()
+            || name.len() > Self::MAX_LEN
+            || name.chars().any(char::is_whitespace)
+            || name.contains('+')
+        {
             Err(NoteError::InvalidKeyName)
         } else {
             Ok(Self(name))
@@ -949,5 +974,35 @@ mod tests {
             })
             .unwrap_err();
         assert!(matches!(err, NoteError::MismatchedVerifier));
+    }
+
+    /// `KeyName::new` enforces the signed-note key-name rules plus the
+    /// 255-byte cap (see `KeyName::MAX_LEN` for rationale).
+    #[test]
+    fn test_key_name_validation() {
+        // Spec rules: empty, whitespace, '+' all rejected.
+        assert!(KeyName::new(String::new()).is_err());
+        assert!(KeyName::new("a b".into()).is_err());
+        assert!(KeyName::new("a+b".into()).is_err());
+        // Unicode whitespace, not just ASCII.
+        assert!(KeyName::new("a\u{00a0}b".into()).is_err());
+
+        // Length cap: 255 bytes ok, 256+ rejected.
+        let max = "a".repeat(KeyName::MAX_LEN);
+        assert_eq!(max.len(), KeyName::MAX_LEN);
+        KeyName::new(max).expect("max-length name accepted");
+
+        let over = "a".repeat(KeyName::MAX_LEN + 1);
+        let err = KeyName::new(over).unwrap_err();
+        assert!(matches!(err, NoteError::InvalidKeyName));
+
+        // The cap is in bytes, not characters: a multi-byte-char string
+        // whose char count is ≤ MAX_LEN but byte length exceeds it is
+        // rejected. "é" is 2 bytes in UTF-8.
+        let two_byte_chars = "é".repeat(KeyName::MAX_LEN / 2 + 1);
+        assert!(two_byte_chars.chars().count() <= KeyName::MAX_LEN);
+        assert!(two_byte_chars.len() > KeyName::MAX_LEN);
+        let err = KeyName::new(two_byte_chars).unwrap_err();
+        assert!(matches!(err, NoteError::InvalidKeyName));
     }
 }

--- a/crates/tlog_cosignature/Cargo.toml
+++ b/crates/tlog_cosignature/Cargo.toml
@@ -17,6 +17,8 @@ crate-type = ["rlib"]
 [dependencies]
 byteorder.workspace = true
 ed25519-dalek.workspace = true
+length_prefixed.workspace = true
+ml-dsa.workspace = true
 signed_note.workspace = true
 tlog_tiles.workspace = true
 

--- a/crates/tlog_cosignature/src/lib.rs
+++ b/crates/tlog_cosignature/src/lib.rs
@@ -9,10 +9,16 @@
 //! inclusion proof.
 //!
 //! This crate provides signers and verifiers for the cosignature formats
-//! specified by the C2SP document. Today only the Ed25519 `cosignature/v1`
-//! format is implemented (in the [`cosignature_v1`] module); the
-//! ML-DSA-44 `subtree/v1` format will be added in a follow-up alongside
-//! support for signing arbitrary subtrees.
+//! specified by the C2SP document:
+//!
+//! - [`cosignature_v1`]: the legacy Ed25519 timestamped checkpoint
+//!   cosignature (signed-note algorithm byte `0x04`). Locked to
+//!   start = 0; signs the checkpoint note body verbatim.
+//! - [`subtree_v1`]: an ML-DSA-44 cosignature over an arbitrary subtree
+//!   (signed-note algorithm byte `0x06`). The checkpoint case
+//!   (`start = 0`, `end = size`) is interchangeable with `cosignature/v1`
+//!   semantically; non-zero `start` cosignatures are used by tlog-witness'
+//!   `sign-subtree` API and by Merkle Tree certificates.
 //!
 //! HTTP transports for requesting cosignatures are out of scope; see
 //! [`tlog_witness`] for parsers/serializers of the
@@ -23,5 +29,7 @@
 //! [`tlog_witness`]: https://docs.rs/tlog_witness
 
 pub mod cosignature_v1;
+pub mod subtree_v1;
 
 pub use cosignature_v1::{CosignatureV1CheckpointSigner, CosignatureV1NoteVerifier};
+pub use subtree_v1::{SubtreeV1CheckpointSigner, SubtreeV1NoteVerifier};

--- a/crates/tlog_cosignature/src/subtree_v1.rs
+++ b/crates/tlog_cosignature/src/subtree_v1.rs
@@ -1,0 +1,804 @@
+// Copyright (c) 2025 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+//! `subtree/v1` cosignatures, per [c2sp.org/tlog-cosignature][spec].
+//!
+//! Compared to the older Ed25519 [`cosignature/v1`][cosignature_v1] format
+//! (which is locked to checkpoints), `subtree/v1` is a cosignature that
+//! signs an arbitrary subtree of the log. A "checkpoint cosignature" is
+//! the special case `start = 0`, `end = checkpoint_size`.
+//!
+//! # What this module provides
+//!
+//! - [`build_cosigned_message`]: pure body builder for the
+//!   [`cosigned_message`][spec] struct. Algorithm-independent — used by
+//!   both the C2SP signed-note flow below and by other consumers (notably
+//!   [draft-ietf-plants-merkle-tree-certs][mtc], which embeds the same
+//!   body inside an X.509 certificate's `signatureValue`).
+//! - [`timestamped_signature`]: pure wrapper builder for the
+//!   `BE u64 timestamp || raw signature` blob used inside signed-note
+//!   lines. Available as a building block for callers that need to
+//!   produce signed-note lines but supply their own algorithm.
+//! - [`SubtreeV1CheckpointSigner`] / [`SubtreeV1NoteVerifier`]:
+//!   ML-DSA-44 signer / verifier for the C2SP-mandated signed-note
+//!   variant. C2SP `tlog-cosignature` mandates ML-DSA-44 for
+//!   `subtree/v1`; these types are spec-faithful and not generic.
+//!
+//! Consumers needing a different signature algorithm (e.g. an MTC CA
+//! cosigner using ECDSA or RSA per its own X.509 SPKI) should use
+//! [`build_cosigned_message`] (and [`timestamped_signature`] if they
+//! need signed-note-line output) directly with their own signer/verifier
+//! types; the algorithm-independent body builder is the abstraction
+//! point.
+//!
+//! # Signed message
+//!
+//! The signed message is the [`cosigned_message`][spec] TLS-presentation
+//! struct from the cosignature spec:
+//!
+//! ```text
+//! struct {
+//!     uint8 label[12] = "subtree/v1\n\0";
+//!     opaque cosigner_name<1..2^8-1>;
+//!     uint64 timestamp;
+//!     opaque log_origin<1..2^8-1>;
+//!     uint64 start;
+//!     uint64 end;
+//!     uint8 hash[32];
+//! } cosigned_message;
+//! ```
+//!
+//! `cosigner_name` is the cosigner's signed-note key name. `log_origin`
+//! is the log's checkpoint-origin line *without* its trailing newline.
+//!
+//! `timestamp` is a POSIX-seconds value. It MAY be zero, in which case
+//! no statement is made about the signing time or the largest observed
+//! tree. If `start` is non-zero, `timestamp` MUST be zero. If
+//! `timestamp` is non-zero, `end` MUST be the size of the largest
+//! consistent tree the cosigner has observed for the log.
+//!
+//! # Wire format for signed-note lines
+//!
+//! The signed-note signature blob is the [`timestamped_signature`][spec]
+//! struct: a big-endian `u64` timestamp prefix followed by the raw
+//! algorithm-specific signature bytes. For ML-DSA-44 the signature is
+//! 2420 bytes; [`SubtreeV1CheckpointSigner`] produces this layout
+//! directly. Other consumers (e.g. MTC certificates) embed the raw
+//! signature without the timestamp prefix; the timestamp is conveyed
+//! by the `cosigned_message` body itself.
+//!
+//! # Key identity
+//!
+//! For the ML-DSA-44 signed-note variant, the key ID is derived per the
+//! spec as
+//! `SHA-256(<name> || "\n" || 0x06 || 1312-byte ML-DSA-44 cosigner public key)[:4]`.
+//! Algorithm byte `0x06` is [`SignatureType::MlDsa44`]. Other consumers
+//! that produce signed-note lines with different algorithms must derive
+//! their own key IDs per the C2SP `signed-note` spec.
+//!
+//! [spec]: https://c2sp.org/tlog-cosignature
+//! [mtc]: https://datatracker.ietf.org/doc/draft-ietf-plants-merkle-tree-certs/
+//! [cosignature_v1]: crate::cosignature_v1
+//! [`SignatureType::MlDsa44`]: signed_note::SignatureType::MlDsa44
+
+use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
+use length_prefixed::WriteLengthPrefixedBytesExt;
+use ml_dsa::{
+    signature::{Signer as MlDsaSigner, Verifier as MlDsaVerifier},
+    EncodedSignature as MlDsaEncodedSignature, ExpandedSigningKey as MlDsaExpandedSigningKey,
+    MlDsa44, Signature as MlDsaSignature, VerifyingKey as MlDsaVerifyingKey,
+};
+use signed_note::{KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
+use tlog_tiles::{CheckpointSigner, CheckpointText, Hash, Subtree, UnixTimestamp, HASH_SIZE};
+
+/// The fixed 12-byte label prefix domain-separating `subtree/v1` from
+/// other cosignature formats.
+const LABEL: &[u8; 12] = b"subtree/v1\n\0";
+
+/// The encoded ML-DSA-44 signature length per FIPS 204.
+///
+/// Derived from the public [`MlDsaEncodedSignature<MlDsa44>`] type
+/// rather than hardcoded: that type is `hybrid_array::Array<u8, N>`
+/// which is `#[repr(transparent)]` over `[u8; N]`, so its `size_of`
+/// equals the parameterized signature length the `ml-dsa` crate uses
+/// internally. The `SignatureParams` trait carrying the `SignatureSize`
+/// associated type is in a private module (`ml_dsa::param`) and so
+/// can't be named in projection syntax from outside the crate.
+///
+/// `subtree/v1` currently has a single codepoint
+/// (`SignatureType::MlDsa44 = 0x06`). If `tlog-cosignature` allocates
+/// further codepoints, the parser/verifier helpers would generalize
+/// over a per-algorithm descriptor and this constant would be
+/// replaced.
+const MLDSA_44_SIGNATURE_LEN: usize = core::mem::size_of::<MlDsaEncodedSignature<MlDsa44>>();
+
+/// The size in bytes of the ML-DSA-44 `timestamped_signature` blob: a
+/// big-endian `u64` timestamp prefix followed by the
+/// [`MLDSA_44_SIGNATURE_LEN`]-byte ML-DSA-44 signature.
+const TIMESTAMPED_SIGNATURE_LEN: usize = 8 + MLDSA_44_SIGNATURE_LEN;
+
+/// Build the [`cosigned_message`][spec] bytes for a `subtree/v1`
+/// cosignature.
+///
+/// This is the algorithm-independent body that every `subtree/v1`
+/// signature is computed over. Both the [C2SP `tlog-cosignature`][spec]
+/// signed-note flow ([`SubtreeV1CheckpointSigner`]) and other consumers
+/// (notably [draft-ietf-plants-merkle-tree-certs][mtc] CA cosigners,
+/// which sign with PKIX-defined algorithms and embed the raw signature
+/// inside an X.509 `signatureValue`) call this builder to produce the
+/// bytes they then sign with their own primitive.
+///
+/// `log_origin` is the checkpoint origin line *without* a trailing
+/// newline. `cosigner_name` is the signed-note key name of the cosigner.
+///
+/// `start` and `end` are taken as bare `u64`s rather than a typed
+/// [`Subtree`] because this builder is the low-level entry point for
+/// consumers that have already validated their inputs upstream (e.g.
+/// an MTC CA cosigner that constructed the `(start, end)` pair from a
+/// log it operates). Callers MUST ensure `[start, end)` is a valid
+/// subtree per [`Subtree::new`]'s contract; the higher-level
+/// [`SubtreeV1CheckpointSigner::sign_subtree`] and
+/// [`SubtreeV1NoteVerifier::verify_subtree`] entry points take a
+/// [`&Subtree`] and so enforce this at the type level.
+///
+/// # Panics
+///
+/// Panics if `log_origin` is empty or longer than 255 bytes — the
+/// `cosigned_message` struct's `log_origin<1..2^8-1>` field is TLS-style
+/// length-prefixed and cannot encode either case. The `cosigner_name`
+/// length is already enforced at construction time by
+/// [`KeyName::new`][signed_note::KeyName::new], which caps at
+/// [`KeyName::MAX_LEN`][signed_note::KeyName::MAX_LEN] = 255 bytes for
+/// exactly this reason.
+///
+/// The internal `unwrap` calls on `Vec<u8>` writes cannot fail; they
+/// are infallible operations on a growable buffer.
+///
+/// [spec]: https://c2sp.org/tlog-cosignature
+/// [mtc]: https://datatracker.ietf.org/doc/draft-ietf-plants-merkle-tree-certs/
+#[must_use]
+pub fn build_cosigned_message(
+    cosigner_name: &KeyName,
+    timestamp: u64,
+    log_origin: &str,
+    start: u64,
+    end: u64,
+    hash: &Hash,
+) -> Vec<u8> {
+    let name_bytes = cosigner_name.as_str().as_bytes();
+    let origin_bytes = log_origin.as_bytes();
+    debug_assert!(
+        (1..=255).contains(&name_bytes.len()),
+        "cosigner_name violates KeyName length invariant",
+    );
+    assert!(
+        (1..=255).contains(&origin_bytes.len()),
+        "log_origin must be 1..=255 bytes per the spec",
+    );
+
+    let mut buf = Vec::with_capacity(
+        LABEL.len() + 1 + name_bytes.len() + 8 + 1 + origin_bytes.len() + 8 + 8 + HASH_SIZE,
+    );
+    buf.extend_from_slice(LABEL);
+    buf.write_length_prefixed(name_bytes, 1).unwrap();
+    buf.write_u64::<BigEndian>(timestamp).unwrap();
+    buf.write_length_prefixed(origin_bytes, 1).unwrap();
+    buf.write_u64::<BigEndian>(start).unwrap();
+    buf.write_u64::<BigEndian>(end).unwrap();
+    buf.extend_from_slice(&hash.0);
+    buf
+}
+
+/// Build the [`timestamped_signature`][spec] blob for a signed-note line:
+/// a big-endian `u64` timestamp prefix followed by `raw_signature`.
+///
+/// This is the wire format for signed-note lines carrying a `subtree/v1`
+/// cosignature, irrespective of signature algorithm. Consumers that
+/// produce signed-note-line output but use an algorithm other than
+/// ML-DSA-44 (e.g. an MTC log serving its own `sign-subtree` responses)
+/// can call this directly. Consumers embedding raw signatures elsewhere
+/// (e.g. inside an X.509 certificate's `signatureValue`) do not need
+/// this wrapper; the signature is the bare algorithm output, and the
+/// timestamp is conveyed via the [`cosigned_message`][spec] body alone.
+///
+/// `timestamp_unix_secs` MUST match the timestamp embedded in the
+/// signed `cosigned_message` body — verifiers parse this prefix and
+/// re-derive the body to check the signature, so a mismatch fails
+/// verification.
+///
+/// # Panics
+///
+/// Cannot panic. `Vec<u8>::write_u64` and `Vec::extend_from_slice` are
+/// both infallible; the `unwrap` on the former is a syntactic
+/// formality.
+///
+/// [spec]: https://c2sp.org/tlog-cosignature
+#[must_use]
+pub fn timestamped_signature(timestamp_unix_secs: u64, raw_signature: &[u8]) -> Vec<u8> {
+    let mut blob = Vec::with_capacity(8 + raw_signature.len());
+    blob.write_u64::<BigEndian>(timestamp_unix_secs).unwrap();
+    blob.extend_from_slice(raw_signature);
+    blob
+}
+
+// ---------------------------------------------------------------------------
+// Signer
+// ---------------------------------------------------------------------------
+
+/// An ML-DSA-44 [`subtree/v1`][spec] cosigner.
+///
+/// Signs both checkpoint and arbitrary-subtree cosignatures. For the
+/// checkpoint case the [`CheckpointSigner`] impl handles
+/// `start = 0, end = checkpoint_size, hash = checkpoint_hash` from a
+/// [`CheckpointText`]. For arbitrary subtrees, use [`Self::sign_subtree`]
+/// directly.
+///
+/// [spec]: https://c2sp.org/tlog-cosignature
+pub struct SubtreeV1CheckpointSigner {
+    v: SubtreeV1NoteVerifier,
+    k: MlDsaExpandedSigningKey<MlDsa44>,
+}
+
+impl SubtreeV1CheckpointSigner {
+    /// Returns a new `SubtreeV1CheckpointSigner` from a name and signing key.
+    ///
+    /// The name's signed-note and length constraints (non-empty, no
+    /// whitespace, no `+`, ≤ [`KeyName::MAX_LEN`] bytes) are
+    /// guaranteed by [`KeyName::new`].
+    ///
+    /// [`KeyName::MAX_LEN`]: signed_note::KeyName::MAX_LEN
+    #[must_use]
+    pub fn new(name: KeyName, k: MlDsaExpandedSigningKey<MlDsa44>) -> Self {
+        let vk = k.verifying_key();
+        Self {
+            v: SubtreeV1NoteVerifier::new(name, vk),
+            k,
+        }
+    }
+
+    /// Sign an arbitrary subtree, returning a `subtree/v1`
+    /// [`NoteSignature`].
+    ///
+    /// `subtree` carries `(start, end)` as a `tlog_tiles::Subtree`,
+    /// which has been validated at construction time to be a valid
+    /// `[start, end)` subtree per draft-ietf-plants-merkle-tree-certs
+    /// §4.1 (`start < end`, alignment to the next-power-of-two width).
+    ///
+    /// `timestamp_unix_secs` is the POSIX-seconds timestamp embedded in
+    /// the [`cosigned_message`][spec]. Per the spec it MAY be zero, in
+    /// which case no statement is made about the signing time or the
+    /// largest observed tree.
+    ///
+    /// Note that for the checkpoint case (`subtree.lo() == 0`) the
+    /// [c2sp.org/tlog-witness][witness] spec additionally REQUIRES a
+    /// non-zero timestamp; passing zero here for the checkpoint case
+    /// produces a spec-legal cosignature that is operationally useless
+    /// for a witness response. This is not enforced by `sign_subtree`
+    /// because the signer doesn't know the calling context — callers
+    /// producing checkpoint cosignatures for witness use must supply a
+    /// non-zero timestamp themselves. The [`CheckpointSigner`] impl
+    /// forwards a millis timestamp from its caller and trusts that
+    /// caller to set it correctly.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `subtree.lo() != 0` and `timestamp_unix_secs != 0`
+    /// (the spec requires `timestamp == 0` whenever `start != 0`), or
+    /// if `log_origin` does not satisfy the TLS-presentation
+    /// `opaque<1..2^8-1>` length bound.
+    ///
+    /// [spec]: https://c2sp.org/tlog-cosignature
+    /// [witness]: https://c2sp.org/tlog-witness
+    #[must_use]
+    pub fn sign_subtree(
+        &self,
+        timestamp_unix_secs: u64,
+        log_origin: &str,
+        subtree: &Subtree,
+        hash: &Hash,
+    ) -> NoteSignature {
+        assert!(
+            !(subtree.lo() != 0 && timestamp_unix_secs != 0),
+            "timestamp must be zero when start is non-zero",
+        );
+
+        let msg = build_cosigned_message(
+            self.v.name(),
+            timestamp_unix_secs,
+            log_origin,
+            subtree.lo(),
+            subtree.hi(),
+            hash,
+        );
+        let sig: MlDsaSignature<MlDsa44> = self.k.sign(&msg);
+        let blob = timestamped_signature(timestamp_unix_secs, sig.encode().as_slice());
+        NoteSignature::new(self.v.name().clone(), self.v.key_id(), blob)
+    }
+}
+
+impl CheckpointSigner for SubtreeV1CheckpointSigner {
+    fn name(&self) -> &KeyName {
+        self.v.name()
+    }
+
+    fn key_id(&self) -> u32 {
+        self.v.key_id()
+    }
+
+    fn sign(
+        &self,
+        timestamp_unix_millis: UnixTimestamp,
+        checkpoint: &CheckpointText,
+    ) -> Result<NoteSignature, NoteError> {
+        // The checkpoint case fixes start = 0 and end = checkpoint_size.
+        // `[0, n)` for any n > 0 is always a valid subtree (`0` is a
+        // multiple of every power of 2); `Subtree::new(0, size)` only
+        // fails for `size == 0`, where there is no meaningful subtree
+        // to cosign.
+        let subtree = Subtree::new(0, checkpoint.size()).map_err(|_| NoteError::Format)?;
+        // The spec requires the witness to use a non-zero timestamp
+        // for checkpoint cosignatures; we forward the caller-supplied
+        // timestamp unchanged (in seconds), trusting them not to pass
+        // zero in this path.
+        Ok(self.sign_subtree(
+            timestamp_unix_millis / 1000,
+            checkpoint.origin(),
+            &subtree,
+            checkpoint.hash(),
+        ))
+    }
+
+    fn verifier(&self) -> Box<dyn NoteVerifier> {
+        Box::new(self.v.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Verifier
+// ---------------------------------------------------------------------------
+
+/// Verifier for ML-DSA-44 `subtree/v1` cosignatures.
+///
+/// As a [`NoteVerifier`] this verifies the *checkpoint* case (`start = 0`,
+/// `end = checkpoint_size`); the verifier reconstructs the
+/// [`cosigned_message`][spec] from the checkpoint's origin, size, and
+/// root hash. For arbitrary-subtree verification use
+/// [`Self::verify_subtree`] directly with the `(start, end, hash)` the
+/// caller already knows out of band.
+///
+/// [spec]: https://c2sp.org/tlog-cosignature
+#[derive(Clone)]
+pub struct SubtreeV1NoteVerifier {
+    name: KeyName,
+    id: u32,
+    verifying_key: MlDsaVerifyingKey<MlDsa44>,
+}
+
+impl SubtreeV1NoteVerifier {
+    /// Construct a new verifier from a key name and verifying key.
+    #[must_use]
+    pub fn new(name: KeyName, verifying_key: MlDsaVerifyingKey<MlDsa44>) -> Self {
+        let pk_bytes = verifying_key.encode();
+        let id = signed_note::compute_key_id(
+            &name,
+            &[SignatureType::MlDsa44 as u8],
+            pk_bytes.as_slice(),
+        );
+        Self {
+            name,
+            id,
+            verifying_key,
+        }
+    }
+
+    /// Verify a subtree cosignature blob against an arbitrary
+    /// `(subtree, hash)`.
+    ///
+    /// Returns `true` if `sig_blob` is a well-formed
+    /// `timestamped_signature` (8-byte big-endian POSIX-seconds
+    /// timestamp followed by a 2420-byte ML-DSA-44 signature) over
+    /// the [`cosigned_message`][spec] for the given subtree. Returns
+    /// `false` for any malformation, including when the spec's
+    /// timestamp/start invariant is violated.
+    ///
+    /// `subtree` carries `(start, end)` as a `tlog_tiles::Subtree`,
+    /// which has been validated at construction time; the previous
+    /// runtime `start < end` check is now expressed in the type.
+    ///
+    /// [spec]: https://c2sp.org/tlog-cosignature
+    #[must_use]
+    pub fn verify_subtree(
+        &self,
+        log_origin: &str,
+        subtree: &Subtree,
+        hash: &Hash,
+        sig_blob: &[u8],
+    ) -> bool {
+        let Some(timestamp) = parse_timestamped_signature_timestamp(sig_blob) else {
+            return false;
+        };
+        // Spec: `timestamp` MUST be zero when `start` is non-zero.
+        if subtree.lo() != 0 && timestamp != 0 {
+            return false;
+        }
+        let Some(sig) = decode_signature(&sig_blob[8..]) else {
+            return false;
+        };
+        let msg = build_cosigned_message(
+            &self.name,
+            timestamp,
+            log_origin,
+            subtree.lo(),
+            subtree.hi(),
+            hash,
+        );
+        MlDsaVerifier::verify(&self.verifying_key, &msg, &sig).is_ok()
+    }
+}
+
+impl NoteVerifier for SubtreeV1NoteVerifier {
+    fn name(&self) -> &KeyName {
+        &self.name
+    }
+
+    fn key_id(&self) -> u32 {
+        self.id
+    }
+
+    /// Verify a `subtree/v1` cosignature attached to a checkpoint note.
+    ///
+    /// `msg` is the checkpoint note body. The verifier parses it as a
+    /// [`CheckpointText`] and reconstructs the [`cosigned_message`][spec]
+    /// with `start = 0, end = checkpoint.size(), hash = checkpoint.hash()`.
+    ///
+    /// [spec]: https://c2sp.org/tlog-cosignature
+    fn verify(&self, msg: &[u8], sig_blob: &[u8]) -> bool {
+        let Ok(checkpoint) = CheckpointText::from_bytes(msg) else {
+            return false;
+        };
+        // `[0, n)` for n > 0 is always a valid subtree; reject empty
+        // checkpoints (size == 0) at this layer rather than panicking
+        // inside `verify_subtree`.
+        let Ok(subtree) = Subtree::new(0, checkpoint.size()) else {
+            return false;
+        };
+        self.verify_subtree(checkpoint.origin(), &subtree, checkpoint.hash(), sig_blob)
+    }
+
+    /// Parse the timestamp prefix from a `timestamped_signature` blob
+    /// and return it in milliseconds.
+    ///
+    /// This is a **parse-only** helper for callers that need to read a
+    /// note signature's embedded timestamp before verifying the signature
+    /// itself (e.g. for ordering, rate limiting, or coarse pruning).
+    /// Returning `Ok(Some(_))` means the blob has the correct envelope
+    /// shape (exactly [`TIMESTAMPED_SIGNATURE_LEN`] bytes — 8-byte
+    /// timestamp + [`MLDSA_44_SIGNATURE_LEN`]-byte tail) and the prefix
+    /// decodes as a `u64`. It does **not** mean the signature itself is
+    /// valid, or that the timestamp is the one the signer actually
+    /// committed to — the tail bytes are not parsed or verified here.
+    /// Use [`Self::verify_subtree`] (or the [`NoteVerifier::verify`]
+    /// path on this type) for that.
+    ///
+    /// Returns [`NoteError::Timestamp`] if the blob length is wrong, or
+    /// if the seconds-to-millis conversion would overflow `u64`
+    /// (impossible for any timestamp this side of POSIX year 5.85e14).
+    fn extract_timestamp_millis(&self, sig_blob: &[u8]) -> Result<Option<u64>, NoteError> {
+        let ts_secs =
+            parse_timestamped_signature_timestamp(sig_blob).ok_or(NoteError::Timestamp)?;
+        let ts_millis = ts_secs.checked_mul(1000).ok_or(NoteError::Timestamp)?;
+        Ok(Some(ts_millis))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Read the 8-byte big-endian timestamp prefix from a
+/// `timestamped_signature` blob, returning `None` unless the blob is
+/// exactly [`TIMESTAMPED_SIGNATURE_LEN`] bytes (8-byte timestamp prefix
+/// + [`MLDSA_44_SIGNATURE_LEN`]-byte signature tail).
+///
+/// The exact-length check rejects malformed blobs at the parse layer
+/// rather than deferring to the signature decode, so callers using this
+/// helper for pre-verification ordering or rate-limiting can't be fed
+/// an attacker-supplied timestamp inside an over-long envelope.
+///
+/// Hardcoded to the ML-DSA-44 envelope length today; would take an
+/// algorithm descriptor when [`MLDSA_44_SIGNATURE_LEN`] does.
+fn parse_timestamped_signature_timestamp(sig_blob: &[u8]) -> Option<u64> {
+    if sig_blob.len() != TIMESTAMPED_SIGNATURE_LEN {
+        return None;
+    }
+    let mut head = &sig_blob[..8];
+    head.read_u64::<BigEndian>().ok()
+}
+
+/// Decode the [`MLDSA_44_SIGNATURE_LEN`]-byte ML-DSA-44 signature from
+/// the tail of a `timestamped_signature` blob. See
+/// [`MLDSA_44_SIGNATURE_LEN`] for the future-extension note.
+fn decode_signature(bytes: &[u8]) -> Option<MlDsaSignature<MlDsa44>> {
+    let encoded = MlDsaEncodedSignature::<MlDsa44>::try_from(bytes).ok()?;
+    MlDsaSignature::<MlDsa44>::decode(&encoded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ml_dsa::ExpandedSigningKey;
+    use tlog_tiles::HASH_SIZE;
+
+    /// Construct a deterministic ML-DSA-44 expanded signing key from a
+    /// 32-byte seed; the companion verifying key is derived via
+    /// [`ExpandedSigningKey::verifying_key`].
+    fn signing_key(seed_byte: u8) -> ExpandedSigningKey<MlDsa44> {
+        let seed = ml_dsa::B32::from([seed_byte; 32]);
+        ExpandedSigningKey::<MlDsa44>::from_seed(&seed)
+    }
+
+    fn name(s: &str) -> KeyName {
+        KeyName::new(s.to_owned()).unwrap()
+    }
+
+    fn subtree(lo: u64, hi: u64) -> Subtree {
+        Subtree::new(lo, hi).expect("valid test subtree")
+    }
+
+    /// Sign-then-verify roundtrip for a checkpoint cosignature
+    /// (start = 0, end = size, non-zero timestamp).
+    #[test]
+    fn checkpoint_sign_verify_roundtrip() {
+        let sk = signing_key(1);
+        let signer = SubtreeV1CheckpointSigner::new(name("witness.example/w"), sk.clone());
+        let sig = signer.sign_subtree(
+            1_700_000_000,
+            "log.example/origin",
+            &subtree(0, 42),
+            &Hash([0x33u8; HASH_SIZE]),
+        );
+
+        let verifier = SubtreeV1NoteVerifier::new(name("witness.example/w"), sk.verifying_key());
+        assert!(verifier.verify_subtree(
+            "log.example/origin",
+            &subtree(0, 42),
+            &Hash([0x33u8; HASH_SIZE]),
+            sig.signature(),
+        ));
+    }
+
+    /// Sign-then-verify roundtrip for a non-zero-start subtree
+    /// cosignature (timestamp must be zero per the spec).
+    #[test]
+    fn subtree_sign_verify_roundtrip() {
+        let sk = signing_key(2);
+        let signer = SubtreeV1CheckpointSigner::new(name("ca.example/c"), sk.clone());
+        let sig = signer.sign_subtree(
+            0,
+            "log.example/origin",
+            &subtree(8, 16),
+            &Hash([0x77u8; HASH_SIZE]),
+        );
+
+        let verifier = SubtreeV1NoteVerifier::new(name("ca.example/c"), sk.verifying_key());
+        assert!(verifier.verify_subtree(
+            "log.example/origin",
+            &subtree(8, 16),
+            &Hash([0x77u8; HASH_SIZE]),
+            sig.signature(),
+        ));
+    }
+
+    /// `verify_subtree` rejects when the spec invariant
+    /// "timestamp == 0 if start != 0" is violated, even when ML-DSA
+    /// verification of the underlying signature succeeds.
+    #[test]
+    fn verify_rejects_nonzero_timestamp_with_nonzero_start() {
+        let sk = signing_key(3);
+        let name = name("witness/w");
+        let verifier = SubtreeV1NoteVerifier::new(name.clone(), sk.verifying_key());
+
+        // Hand-craft a sig blob with a non-zero timestamp paired with
+        // start=4. `build_cosigned_message` takes `(start, end)`
+        // directly because callers may have already validated
+        // upstream; the test goes through it to forge a
+        // cryptographically-valid blob with the bad timestamp/start
+        // combination.
+        let msg = build_cosigned_message(&name, 12345, "log/origin", 4, 8, &Hash([0u8; HASH_SIZE]));
+        let raw_sig: MlDsaSignature<MlDsa44> = sk.sign(&msg);
+        let mut blob = Vec::new();
+        blob.write_u64::<BigEndian>(12345).unwrap();
+        blob.extend_from_slice(raw_sig.encode().as_slice());
+
+        assert!(!verifier.verify_subtree(
+            "log/origin",
+            &subtree(4, 8),
+            &Hash([0u8; HASH_SIZE]),
+            &blob
+        ));
+    }
+
+    /// `verify_subtree` rejects when the embedded `(subtree, hash)`
+    /// don't match the bytes the signer signed.
+    #[test]
+    fn verify_rejects_mismatched_subtree() {
+        let sk = signing_key(4);
+        let signer = SubtreeV1CheckpointSigner::new(name("w"), sk.clone());
+        let sig = signer.sign_subtree(0, "log", &subtree(0, 100), &Hash([0xAAu8; HASH_SIZE]));
+
+        let verifier = SubtreeV1NoteVerifier::new(name("w"), sk.verifying_key());
+        // Different subtree (and a valid one in its own right per
+        // `Subtree::new`'s alignment rules).
+        assert!(!verifier.verify_subtree(
+            "log",
+            &subtree(64, 128),
+            &Hash([0xAAu8; HASH_SIZE]),
+            sig.signature()
+        ));
+        // Same subtree but different hash.
+        assert!(!verifier.verify_subtree(
+            "log",
+            &subtree(0, 100),
+            &Hash([0xBBu8; HASH_SIZE]),
+            sig.signature()
+        ));
+        // Different log origin.
+        assert!(!verifier.verify_subtree(
+            "other",
+            &subtree(0, 100),
+            &Hash([0xAAu8; HASH_SIZE]),
+            sig.signature()
+        ));
+    }
+
+    /// `NoteVerifier::verify` reconstructs the `cosigned_message` from a
+    /// checkpoint note body and verifies the signature against
+    /// `start = 0, end = size, hash = root`.
+    #[test]
+    fn note_verifier_verifies_checkpoint() {
+        use signed_note::{Note, VerifierList};
+
+        let sk = signing_key(5);
+        let signer = SubtreeV1CheckpointSigner::new(name("witness/w"), sk.clone());
+
+        // Build a checkpoint note body and sign with the CheckpointSigner
+        // path. Timestamp is in millis; signer divides by 1000 internally.
+        let cp_text = tlog_tiles::CheckpointText::new(
+            "log.example/origin",
+            42,
+            Hash([0x55u8; HASH_SIZE]),
+            &[],
+        )
+        .unwrap();
+        let sig = signer.sign(1_700_000_000_000, &cp_text).unwrap();
+
+        // Assemble the note + signature and verify via NoteVerifier.
+        let note = Note::new(&cp_text.to_bytes(), &[sig]).unwrap();
+        let (verified, _unverified) = note
+            .verify(&VerifierList::new(vec![signer.verifier()]))
+            .unwrap();
+        assert_eq!(verified.len(), 1);
+    }
+
+    /// Pin the binary layout of the `cosigned_message` struct against
+    /// known bytes, mirroring the format-fix tests other crates carry.
+    /// Any change here would invalidate every previously-produced
+    /// `subtree/v1` cosignature.
+    #[test]
+    fn cosigned_message_layout_unchanged() {
+        let msg = build_cosigned_message(
+            &name("a"), // 1-byte cosigner_name
+            0x0102_0304_0506_0708,
+            "b", // 1-byte log_origin
+            0x0910_1112_1314_1516,
+            0x1718_191a_1b1c_1d1e,
+            &Hash([0x42u8; HASH_SIZE]),
+        );
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(b"subtree/v1\n\x00");
+        expected.push(1);
+        expected.extend_from_slice(b"a");
+        expected.extend_from_slice(&0x0102_0304_0506_0708u64.to_be_bytes());
+        expected.push(1);
+        expected.extend_from_slice(b"b");
+        expected.extend_from_slice(&0x0910_1112_1314_1516u64.to_be_bytes());
+        expected.extend_from_slice(&0x1718_191a_1b1c_1d1eu64.to_be_bytes());
+        expected.extend_from_slice(&[0x42u8; HASH_SIZE]);
+
+        assert_eq!(msg, expected, "subtree/v1 cosigned_message layout changed");
+    }
+
+    /// Pin the key-ID derivation (algorithm byte `0x06`) against the spec.
+    #[test]
+    fn key_id_uses_signature_type_ml_dsa_44() {
+        let sk = signing_key(6);
+        let v = SubtreeV1NoteVerifier::new(name("witness.example/w"), sk.verifying_key());
+
+        // Recompute manually with explicit 0x06 to confirm we got the
+        // signed-note key-ID algorithm byte right.
+        let pk_bytes = sk.verifying_key().encode();
+        let expected = signed_note::compute_key_id(
+            &name("witness.example/w"),
+            &[0x06], // SignatureType::MlDsa44
+            pk_bytes.as_slice(),
+        );
+        assert_eq!(v.key_id(), expected);
+    }
+
+    /// `extract_timestamp_millis` parses the BE-u64 prefix and returns
+    /// it in milliseconds.
+    #[test]
+    fn extract_timestamp_millis_parses_prefix() {
+        let sk = signing_key(7);
+        let signer = SubtreeV1CheckpointSigner::new(name("w"), sk.clone());
+        let sig = signer.sign_subtree(
+            1_700_000_000,
+            "log",
+            &subtree(0, 1),
+            &Hash([0u8; HASH_SIZE]),
+        );
+        let v = signer.verifier();
+        let ts = v.extract_timestamp_millis(sig.signature()).unwrap();
+        assert_eq!(ts, Some(1_700_000_000_000));
+    }
+
+    /// `extract_timestamp_millis` rejects blobs whose length doesn't match
+    /// the `timestamped_signature` envelope exactly. Both a too-short
+    /// blob and an over-long blob with otherwise-valid 8-byte prefix
+    /// must be rejected at the parse layer so callers using the helper
+    /// for pre-verification ordering can't be fed a timestamp inside
+    /// a malformed envelope.
+    #[test]
+    fn extract_timestamp_millis_rejects_wrong_length() {
+        let sk = signing_key(8);
+        let v = SubtreeV1NoteVerifier::new(name("w"), sk.verifying_key());
+
+        // Too short: 8 bytes — just a u64 prefix, no signature tail.
+        let too_short = [0u8; 8];
+        assert!(v.extract_timestamp_millis(&too_short).is_err());
+
+        // Too long: TIMESTAMPED_SIGNATURE_LEN + 1 — looks like a
+        // well-formed envelope plus one trailing byte. Pre-tightening
+        // this would have decoded the prefix and returned a timestamp.
+        let too_long = vec![0u8; TIMESTAMPED_SIGNATURE_LEN + 1];
+        assert!(v.extract_timestamp_millis(&too_long).is_err());
+
+        // Exact length is accepted (even with garbage tail — the helper
+        // is parse-only).
+        let exact = vec![0u8; TIMESTAMPED_SIGNATURE_LEN];
+        assert_eq!(v.extract_timestamp_millis(&exact).unwrap(), Some(0));
+    }
+
+    /// `Subtree::new` rejects misaligned `(start, end)` per draft-ietf-
+    /// plants-merkle-tree-certs §4.1, so callers of `sign_subtree` /
+    /// `verify_subtree` cannot supply non-subtree inputs at all (the
+    /// type system rules them out before the cosignature layer ever
+    /// sees them). Pin the rejection here as a regression check.
+    #[test]
+    fn subtree_constructor_rejects_misaligned_pairs() {
+        // `[3, 5)`: 3 is not a multiple of BIT_CEIL(2) = 2.
+        assert!(Subtree::new(3, 5).is_err());
+        // `[16, 100)`: 16 is not a multiple of BIT_CEIL(84) = 128.
+        assert!(Subtree::new(16, 100).is_err());
+        // `[5, 5)`: empty subtree (lo >= hi).
+        assert!(Subtree::new(5, 5).is_err());
+        // `[8, 16)`: 8 is a multiple of BIT_CEIL(8) = 8. ✓
+        assert!(Subtree::new(8, 16).is_ok());
+    }
+
+    /// `extract_timestamp_millis` returns an error rather than wrapping
+    /// or panicking when a malformed prefix would overflow seconds-to-
+    /// millis multiplication.
+    #[test]
+    fn extract_timestamp_millis_rejects_overflow() {
+        let sk = signing_key(9);
+        let v = SubtreeV1NoteVerifier::new(name("w"), sk.verifying_key());
+
+        // Build a well-shaped envelope with a u64 timestamp prefix
+        // that overflows when multiplied by 1000.
+        let mut blob = vec![0u8; TIMESTAMPED_SIGNATURE_LEN];
+        blob[..8].copy_from_slice(&u64::MAX.to_be_bytes());
+        assert!(v.extract_timestamp_millis(&blob).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `subtree/v1` cosignature format from [c2sp.org/tlog-cosignature](https://c2sp.org/tlog-cosignature): signed-note algorithm byte `0x06` paired with ML-DSA-44.

## Public API in `tlog_cosignature::subtree_v1`

- `build_cosigned_message`: algorithm-independent body builder for the `cosigned_message` TLS-presentation struct. Takes raw `(start, end)` rather than a typed `&Subtree` because consumers (notably future [draft-ietf-plants-merkle-tree-certs](https://datatracker.ietf.org/doc/draft-ietf-plants-merkle-tree-certs/) CA cosigners) may have already validated their inputs upstream and don't want a redundant construction; callers MUST ensure `[start, end)` is a valid subtree.
- `timestamped_signature`: `BE u64 timestamp || raw signature` blob used inside signed-note lines. Available for callers that produce signed-note-line output with a different signature algorithm.
- `SubtreeV1CheckpointSigner`: ML-DSA-44 signer producing `subtree/v1` cosignatures. Implements `tlog_tiles::CheckpointSigner` for the checkpoint case; `sign_subtree` covers arbitrary subtrees and takes `&tlog_tiles::Subtree` so subtree validity is enforced by the type system rather than at runtime. C2SP `tlog-cosignature` mandates ML-DSA-44 for `subtree/v1` signed-note lines, so this type is spec-faithful rather than generic.
- `SubtreeV1NoteVerifier`: matching ML-DSA-44 verifier. Symmetric shape: `verify_subtree` takes `&Subtree`; the `NoteVerifier::verify` path constructs `Subtree::new(0, checkpoint.size())` and bails on empty checkpoints.

## Spec invariants enforced at the API boundary

- `[start, end)` subtree validity (start < end, alignment to next-power-of-two width per draft-ietf-plants-merkle-tree-certs §4.1) is expressed in the type via `&Subtree`.
- `timestamp != 0` when `start != 0` is rejected on verify; `sign_subtree` panics on the same combination since it indicates caller error.
- `log_origin` is asserted to fit `opaque<1..2^8-1>`. The matching bound on `cosigner_name` is part of `KeyName`'s invariant (see below).
- `extract_timestamp_millis` rejects blobs whose length isn't exactly `TIMESTAMPED_SIGNATURE_LEN`, and uses `checked_mul` to guard seconds-to-millis conversion against overflow.

## `signed_note` changes

- Added `KeyName::MAX_LEN = 255` and enforce it in `KeyName::new`. The signed-note spec itself doesn't constrain length, but every C2SP consumer that embeds a key name in a length-prefixed wire format does so as `opaque<1..2^8-1>` — `cosigner_name` and `log_origin` in tlog-cosignature being the motivating example. Pushing the cap into the type means consumers can rely on the invariant without re-checking, and over-long names fail closed at construction. **Public-API tightening — call out in the next `signed_note` release notes.**
- Added `SignatureType::MlDsa44 = 0x06`.
- New `test_key_name_validation` covers empty / ASCII whitespace / Unicode whitespace / `+` / max-length acceptance / byte-vs-character distinction.

## Workspace plumbing

- `[workspace.dependencies]` adds `ml-dsa = "=0.1.0-rc.8"` (the `=` pin matches the wider RustCrypto pre-release pinning convention already documented in the comment block).
- `pkcs8` is tightened from `"0.11.0-rc.11"` to `"=0.11.0-rc.11"` so transitive resolvers don't pick the released `0.11.0` (whose API is incompatible with the rc.11 ed25519/ml-dsa pre-releases).
- `tlog_cosignature` gains `length_prefixed` (for the TLS-style length-prefixed `cosigner_name` / `log_origin` encoding) and `ml-dsa` dependencies.

## Test coverage

12 unit tests in `tlog_cosignature::subtree_v1`:
- Sign-then-verify roundtrips for both checkpoint (`start = 0`) and arbitrary-subtree (`start != 0`) cases.
- Spec's timestamp/start invariant.
- Mismatched-input rejection (different subtree, different hash, different origin).
- `NoteVerifier::verify` checkpoint reconstruction path through a real `signed_note::Note`.
- `extract_timestamp_millis` envelope-length and overflow handling.
- Key-ID derivation against the explicit `0x06` algorithm byte.
- Byte-pinned regression test on the `cosigned_message` layout (catches any drift in the TLS presentation).
- Pin on `Subtree::new`'s alignment rejection so the type-level validation can't quietly weaken.

## Followup

When the [IETF MTC draft-04](https://github.com/ietf-plants-wg/merkle-tree-certs/pull/215) lands, the MTC CA cosigner implementation (in a future `ietf_mtc_api` crate) will use `build_cosigned_message` directly with PKIX-defined signers (Ed25519, ECDSA, RSA, ML-DSA-44, ML-DSA-65, ML-DSA-87 per the draft). The signed-note-line wrapper isn't needed for cert-embedded cosignatures (the timestamp lives in the body); MTC sign-subtree implementations will use `timestamped_signature` directly with their own algorithm.

## Testing

`cargo clippy --workspace --all-targets -- -Dwarnings -Dclippy::pedantic`, `cargo test`, `cargo fmt --all --check`, `cargo machete` all pass locally.
