### PR TITLE
Extract Merkle math from tlog_tiles into a new tlog_core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "sha2",
  "signed_note",
  "thiserror 2.0.17",
+ "tlog_core",
  "tlog_tiles",
  "x509-cert",
  "x509_util",
@@ -210,6 +211,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "signed_note",
+ "tlog_core",
  "tlog_tiles",
  "url",
  "worker",
@@ -584,6 +586,7 @@ dependencies = [
  "serde_with",
  "signed_note",
  "static_ct_api",
+ "tlog_core",
  "tlog_tiles",
  "url",
  "worker",
@@ -1030,6 +1033,7 @@ dependencies = [
  "signed_note",
  "static_ct_api",
  "thiserror 2.0.17",
+ "tlog_core",
  "tlog_tiles",
  "tokio",
  "worker",
@@ -1478,6 +1482,7 @@ dependencies = [
  "sha2",
  "signed_note",
  "static_ct_api",
+ "tlog_core",
  "tlog_cosignature",
  "tlog_tiles",
  "tlog_witness",
@@ -2809,6 +2814,7 @@ dependencies = [
  "signed_note",
  "spki",
  "thiserror 2.0.17",
+ "tlog_core",
  "tlog_tiles",
  "x509-cert",
  "x509_util",
@@ -2991,6 +2997,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tlog_core"
+version = "0.2.0"
+dependencies = [
+ "base64",
+ "serde",
+ "sha2",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "tlog_cosignature"
 version = "0.2.0"
 dependencies = [
@@ -3000,6 +3016,7 @@ dependencies = [
  "ml-dsa",
  "rand",
  "signed_note",
+ "tlog_core",
  "tlog_tiles",
 ]
 
@@ -3016,6 +3033,7 @@ dependencies = [
  "sha2",
  "signed_note",
  "thiserror 2.0.17",
+ "tlog_core",
  "url",
 ]
 
@@ -3025,6 +3043,7 @@ version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.4.2",
+ "tlog_core",
  "tlog_tiles",
  "wasm-bindgen",
 ]
@@ -3036,7 +3055,7 @@ dependencies = [
  "base64",
  "signed_note",
  "thiserror 2.0.17",
- "tlog_tiles",
+ "tlog_core",
 ]
 
 [[package]]
@@ -3802,6 +3821,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "signed_note",
+ "tlog_core",
  "tlog_cosignature",
  "tlog_tiles",
  "tlog_witness",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/signed_note",
     "crates/signed_note_wasm",
     "crates/static_ct_api",
+    "crates/tlog_core",
     "crates/tlog_cosignature",
     "crates/tlog_tiles",
     "crates/tlog_tiles_wasm",
@@ -42,6 +43,7 @@ default-members = [
     "crates/signed_note",
     "crates/signed_note_wasm",
     "crates/static_ct_api",
+    "crates/tlog_core",
     "crates/tlog_cosignature",
     "crates/tlog_tiles",
     "crates/tlog_tiles_wasm",
@@ -124,6 +126,7 @@ signature = "3.0.0-rc.10"
 signed_note = { path = "crates/signed_note", version = "0.2.0" }
 static_ct_api = { path = "crates/static_ct_api", version = "0.2.0" }
 thiserror = "2.0"
+tlog_core = { path = "crates/tlog_core", version = "0.2.0" }
 tlog_cosignature = { path = "crates/tlog_cosignature", version = "0.2.0" }
 tlog_tiles = { path = "crates/tlog_tiles", version = "0.2.0" }
 tlog_witness = { path = "crates/tlog_witness", version = "0.2.0" }

--- a/crates/bootstrap_mtc_api/Cargo.toml
+++ b/crates/bootstrap_mtc_api/Cargo.toml
@@ -20,6 +20,7 @@ serde_with.workspace = true
 sha2.workspace = true
 signed_note.workspace = true
 thiserror.workspace = true
+tlog_core.workspace = true
 tlog_tiles.workspace = true
 x509-cert.workspace = true
 x509_util.workspace = true

--- a/crates/bootstrap_mtc_api/src/cosigner.rs
+++ b/crates/bootstrap_mtc_api/src/cosigner.rs
@@ -9,7 +9,8 @@ use ed25519_dalek::{
 };
 use length_prefixed::WriteLengthPrefixedBytesExt;
 use signed_note::{KeyName, NoteError, NoteSignature, NoteVerifier};
-use tlog_tiles::{CheckpointSigner, CheckpointText, Hash, LeafIndex, UnixTimestamp};
+use tlog_core::{Hash, LeafIndex};
+use tlog_tiles::{CheckpointSigner, CheckpointText, UnixTimestamp};
 
 use crate::{RelativeOid, ID_RDNA_TRUSTANCHOR_ID};
 
@@ -234,7 +235,8 @@ fn serialize_mtc_subtree_signature_input(
 #[cfg(test)]
 mod tests {
 
-    use tlog_tiles::{open_checkpoint, record_hash, TreeWithTimestamp};
+    use tlog_core::record_hash;
+    use tlog_tiles::{open_checkpoint, TreeWithTimestamp};
 
     use super::*;
     use signed_note::VerifierList;

--- a/crates/bootstrap_mtc_api/src/landmark.rs
+++ b/crates/bootstrap_mtc_api/src/landmark.rs
@@ -34,7 +34,7 @@
 
 use crate::MtcError;
 use std::{collections::VecDeque, fmt::Write};
-use tlog_tiles::Subtree;
+use tlog_core::Subtree;
 
 /// A sequence of landmarks used for constructing landmark certificates.
 ///

--- a/crates/bootstrap_mtc_api/src/lib.rs
+++ b/crates/bootstrap_mtc_api/src/lib.rs
@@ -24,9 +24,9 @@ use std::{
     num::ParseIntError,
 };
 use thiserror::Error;
+use tlog_core::{Hash, LeafIndex, Proof, Subtree, TlogError};
 use tlog_tiles::{
-    Hash, LeafIndex, LogEntry, PathElem, PendingLogEntry, Proof, Subtree, TlogError,
-    TlogTilesLogEntry, TlogTilesPendingLogEntry, UnixTimestamp,
+    LogEntry, PathElem, PendingLogEntry, TlogTilesLogEntry, TlogTilesPendingLogEntry, UnixTimestamp,
 };
 use x509_cert::{
     certificate::Version,
@@ -876,7 +876,8 @@ mod tests {
     #[test]
     fn test_serialize_signatureless_cert() {
         use der::Decode as _;
-        use tlog_tiles::{Proof, Subtree, TlogTilesLogEntry, TlogTilesPendingLogEntry};
+        use tlog_core::{Proof, Subtree};
+        use tlog_tiles::{TlogTilesLogEntry, TlogTilesPendingLogEntry};
 
         let certs =
             Certificate::load_pem_chain(include_bytes!("../../static_ct_api/tests/leaf-cert.pem"))

--- a/crates/bootstrap_mtc_worker/Cargo.toml
+++ b/crates/bootstrap_mtc_worker/Cargo.toml
@@ -58,6 +58,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 signed_note.workspace = true
+tlog_core.workspace = true
 tlog_tiles.workspace = true
 worker.workspace = true
 x509-cert.workspace = true

--- a/crates/bootstrap_mtc_worker/src/frontend_worker.rs
+++ b/crates/bootstrap_mtc_worker/src/frontend_worker.rs
@@ -27,9 +27,9 @@ use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 use signed_note::VerifierList;
 use std::time::Duration;
+use tlog_core::LeafIndex;
 use tlog_tiles::{
-    open_checkpoint, CheckpointSigner, CheckpointText, LeafIndex, PendingLogEntry,
-    PendingLogEntryBlob,
+    open_checkpoint, CheckpointSigner, CheckpointText, PendingLogEntry, PendingLogEntryBlob,
 };
 #[allow(clippy::wildcard_imports)]
 use worker::*;

--- a/crates/bootstrap_mtc_worker/src/sequence_metadata.rs
+++ b/crates/bootstrap_mtc_worker/src/sequence_metadata.rs
@@ -8,7 +8,8 @@ use generic_log_worker::{
     deserialize_sequence_metadata_entries, serialize_sequence_metadata_entries, SequencerMetadata,
 };
 use serde::{Deserialize, Serialize};
-use tlog_tiles::{LeafIndex, LookupKey, UnixTimestamp};
+use tlog_core::LeafIndex;
+use tlog_tiles::{LookupKey, UnixTimestamp};
 
 /// Sequencer metadata for a bootstrap MTC log entry.
 ///

--- a/crates/bootstrap_mtc_worker/src/sequencer_do.rs
+++ b/crates/bootstrap_mtc_worker/src/sequencer_do.rs
@@ -19,7 +19,8 @@ use generic_log_worker::{
 use serde::{Deserialize, Serialize};
 use serde_with::{base64::Base64, serde_as};
 use signed_note::Note;
-use tlog_tiles::{CheckpointText, Hash, UnixTimestamp};
+use tlog_core::Hash;
+use tlog_tiles::{CheckpointText, UnixTimestamp};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 

--- a/crates/ct_worker/Cargo.toml
+++ b/crates/ct_worker/Cargo.toml
@@ -50,6 +50,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 static_ct_api.workspace = true
 signed_note.workspace = true
+tlog_core.workspace = true
 tlog_tiles.workspace = true
 worker.workspace = true
 x509-cert.workspace = true

--- a/crates/ct_worker/src/lib.rs
+++ b/crates/ct_worker/src/lib.rs
@@ -81,9 +81,7 @@ pub(crate) fn load_checkpoint_signers(env: &Env, name: &str) -> Vec<Box<dyn Chec
     let signer = StaticCTCheckpointSigner::new(origin.clone(), signing_key)
         .map_err(|e| format!("could not create static-ct checkpoint signer: {e}"))
         .unwrap();
-    let witness = Ed25519CheckpointSigner::new(origin, witness_key)
-        .map_err(|e| format!("could not create ed25519 checkpoint signer: {e}"))
-        .unwrap();
+    let witness = Ed25519CheckpointSigner::new(origin, witness_key);
 
     vec![Box::new(signer), Box::new(witness)]
 }

--- a/crates/ct_worker/src/sequence_metadata.rs
+++ b/crates/ct_worker/src/sequence_metadata.rs
@@ -8,7 +8,8 @@ use generic_log_worker::{
     deserialize_sequence_metadata_entries, serialize_sequence_metadata_entries, SequencerMetadata,
 };
 use serde::{Deserialize, Serialize};
-use tlog_tiles::{LeafIndex, LookupKey, UnixTimestamp};
+use tlog_core::LeafIndex;
+use tlog_tiles::{LookupKey, UnixTimestamp};
 
 /// Sequencer metadata for a static-ct-api log entry.
 ///

--- a/crates/generic_log_worker/Cargo.toml
+++ b/crates/generic_log_worker/Cargo.toml
@@ -40,6 +40,7 @@ serde_json.workspace = true
 sha2.workspace = true
 signed_note.workspace = true
 thiserror.workspace = true
+tlog_core.workspace = true
 tlog_tiles.workspace = true
 tokio.workspace = true
 worker.workspace = true

--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -27,8 +27,9 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 
 use serde::de::DeserializeOwned;
+use tlog_core::LeafIndex;
 pub use tlog_tiles::LookupKey;
-use tlog_tiles::{LeafIndex, PendingLogEntry, UnixTimestamp};
+use tlog_tiles::{PendingLogEntry, UnixTimestamp};
 use tokio::sync::Mutex;
 use util::now_millis;
 use worker::{

--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -39,10 +39,10 @@ use std::{
     sync::LazyLock,
 };
 use thiserror::Error;
+use tlog_core::{Hash, HashReader, Proof, Subtree, TlogError, HASH_SIZE};
 use tlog_tiles::{
-    Hash, HashReader, LogEntry, PendingLogEntry, PreloadedTlogTileReader, Proof, Subtree,
-    TileHashReader, TileIterator, TlogError, TlogTile, TlogTileRecorder, TreeWithTimestamp,
-    UnixTimestamp, HASH_SIZE,
+    LogEntry, PendingLogEntry, PreloadedTlogTileReader, TileHashReader, TileIterator, TlogTile,
+    TlogTileRecorder, TreeWithTimestamp, UnixTimestamp,
 };
 use tokio::sync::watch::{channel, Receiver, Sender};
 
@@ -276,7 +276,7 @@ pub(crate) async fn create_log(
     }
 
     let timestamp = now_millis();
-    let tree = TreeWithTimestamp::new(0, tlog_tiles::EMPTY_HASH, timestamp);
+    let tree = TreeWithTimestamp::new(0, tlog_core::EMPTY_HASH, timestamp);
 
     // Construct the checkpoint signers
     let dyn_signers = config
@@ -415,7 +415,7 @@ impl SequenceState {
                 let got = entry?.merkle_tree_leaf();
                 let exp = level0_tile.hash_at_index(
                     level0_tile_bytes,
-                    tlog_tiles::stored_hash_index(0, start + i as u64),
+                    tlog_core::stored_hash_index(0, start + i as u64),
                 )?;
                 if got != exp {
                     bail!(
@@ -488,7 +488,7 @@ impl SequenceState {
         };
         // We can unwrap because edge_tiles is guaranteed to contain the tiles
         // necessary to prove this.
-        tlog_tiles::inclusion_proof(tree_size, tree_size - 1, &reader).unwrap()
+        tlog_core::inclusion_proof(tree_size, tree_size - 1, &reader).unwrap()
     }
 
     /// Proves that this tree of size n is compatible with the subtree of size
@@ -504,14 +504,14 @@ impl SequenceState {
             edge_tiles: &self.edge_tiles,
             overlay: &HashMap::default(),
         };
-        tlog_tiles::consistency_proof(tree_size, tree_size - 1, &reader)
+        tlog_core::consistency_proof(tree_size, tree_size - 1, &reader)
     }
 }
 
 #[derive(Error, Debug)]
 pub enum ProofError {
     #[error(transparent)]
-    Tlog(#[from] tlog_tiles::TlogError),
+    Tlog(#[from] tlog_core::TlogError),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -558,12 +558,12 @@ pub async fn prove_subtree_inclusion(
 ) -> Result<Proof, ProofError> {
     // Fetch the tiles needed for the proof.
     let n = &Subtree::new(start, end)?;
-    let indexes = tlog_tiles::subtree_inclusion_proof_indexes(n, leaf_index)?;
+    let indexes = tlog_core::subtree_inclusion_proof_indexes(n, leaf_index)?;
     let tile_reader = tile_reader_for_indexes(cur_tree_size, &indexes, object).await?;
     let hash_reader = TileHashReader::new(cur_tree_size, cur_tree_hash, &tile_reader);
 
     // Construct the proof.
-    Ok(tlog_tiles::subtree_inclusion_proof(
+    Ok(tlog_core::subtree_inclusion_proof(
         n,
         leaf_index,
         &hash_reader,
@@ -605,15 +605,15 @@ pub async fn prove_subtree_consistency(
 ) -> Result<(Proof, Hash), ProofError> {
     let m = &Subtree::new(start, end)?;
     // Fetch the tiles needed for the proof.
-    let indexes = tlog_tiles::subtree_consistency_proof_indexes(cur_tree_size, m)?;
+    let indexes = tlog_core::subtree_consistency_proof_indexes(cur_tree_size, m)?;
     let tile_reader = tile_reader_for_indexes(cur_tree_size, &indexes, object).await?;
     let hash_reader = TileHashReader::new(cur_tree_size, cur_tree_hash, &tile_reader);
 
     // Construct the proof.
-    let proof = tlog_tiles::subtree_consistency_proof(cur_tree_size, m, &hash_reader)?;
+    let proof = tlog_core::subtree_consistency_proof(cur_tree_size, m, &hash_reader)?;
 
     // Compute the subtree hash.
-    let subtree_hash = tlog_tiles::subtree_hash(m, &hash_reader)?;
+    let subtree_hash = tlog_core::subtree_hash(m, &hash_reader)?;
     Ok((proof, subtree_hash))
 }
 
@@ -891,7 +891,7 @@ async fn sequence_entries<L: LogEntry, M: SequencerMetadata>(
         // Compute the new tree hashes and add them to the hashReader overlay
         // (we will use them later to insert more leaves and finally to produce
         // the new tiles).
-        let hashes = tlog_tiles::stored_hashes_for_record_hash(
+        let hashes = tlog_core::stored_hashes_for_record_hash(
             n,
             merkle_tree_leaf,
             &HashReaderWithOverlay {
@@ -905,7 +905,7 @@ async fn sequence_entries<L: LogEntry, M: SequencerMetadata>(
             ))
         })?;
         for (i, h) in hashes.iter().enumerate() {
-            let id = tlog_tiles::stored_hash_index(0, n) + i as u64;
+            let id = tlog_core::stored_hash_index(0, n) + i as u64;
             overlay.insert(id, *h);
         }
 
@@ -1115,7 +1115,7 @@ fn stage_data_tile<L: LogEntry>(
     data_tile: Vec<u8>,
     aux_tile: Vec<u8>,
 ) {
-    let tile = TlogTile::from_index(tlog_tiles::stored_hash_index(0, n - 1))
+    let tile = TlogTile::from_index(tlog_core::stored_hash_index(0, n - 1))
         .with_data_path(L::Pending::DATA_TILE_PATH);
     edge_tiles.insert(
         DATA_TILE_LEVEL_KEY,
@@ -1131,7 +1131,7 @@ fn stage_data_tile<L: LogEntry>(
     });
     if let Some(path_elem) = L::Pending::AUX_TILE_PATH {
         let tile =
-            TlogTile::from_index(tlog_tiles::stored_hash_index(0, n - 1)).with_data_path(path_elem);
+            TlogTile::from_index(tlog_core::stored_hash_index(0, n - 1)).with_data_path(path_elem);
         edge_tiles.insert(
             AUX_TILE_LEVEL_KEY,
             TileWithBytes {
@@ -1179,7 +1179,7 @@ async fn read_edge_tiles(
 ) -> Result<HashMap<u8, TileWithBytes>, anyhow::Error> {
     // Fetch the right-most edge tiles by reading the last leaf. TileHashReader
     // will fetch and verify the right tiles as a side-effect.
-    let indexes = vec![tlog_tiles::stored_hash_index(0, tree_size - 1)];
+    let indexes = vec![tlog_core::stored_hash_index(0, tree_size - 1)];
     let tile_reader = tile_reader_for_indexes(tree_size, &indexes, object).await?;
 
     // Verify the leaf tile against the tree hash.
@@ -1210,7 +1210,7 @@ pub async fn read_leaf<L: LogEntry>(
     tree_size: u64,
     tree_hash: &Hash,
 ) -> Result<L, anyhow::Error> {
-    let leaf_stored_hash_index = tlog_tiles::stored_hash_index(0, leaf_index);
+    let leaf_stored_hash_index = tlog_core::stored_hash_index(0, leaf_index);
     let tile_reader = tile_reader_for_indexes(tree_size, &[leaf_stored_hash_index], object).await?;
 
     // Verify the leaf tile against the tree hash.
@@ -1246,7 +1246,7 @@ pub async fn read_leaf<L: LogEntry>(
         let got = entry.merkle_tree_leaf();
         let exp = level0_tile.hash_at_index(
             &level0_tile_bytes,
-            tlog_tiles::stored_hash_index(0, start + i as u64),
+            tlog_core::stored_hash_index(0, start + i as u64),
         )?;
         if got != exp {
             bail!(
@@ -1385,7 +1385,7 @@ pub async fn upload_issuers(
 mod tests {
     use super::*;
     use crate::{empty_checkpoint_callback, util};
-    use tlog_tiles::LeafIndex;
+    use tlog_core::LeafIndex;
 
     /// Local metadata type used to exercise the sequencer and batcher logic
     /// end-to-end. Kept as a `(LeafIndex, UnixTimestamp)` tuple so existing
@@ -1457,7 +1457,7 @@ mod tests {
                 let leaf_edge = &sequence_state.edge_tiles.get(&0u8).unwrap().b;
                 Hash(leaf_edge[leaf_edge.len() - HASH_SIZE..].try_into().unwrap())
             };
-            tlog_tiles::verify_inclusion_proof(
+            tlog_core::verify_inclusion_proof(
                 &inc_proof,
                 tree_size,
                 new_tree_hash,
@@ -1473,7 +1473,7 @@ mod tests {
             if i > 0 {
                 let proof = sequence_state.prove_consistency_of_single_append().unwrap();
                 // Verify the proof
-                tlog_tiles::verify_consistency_proof(
+                tlog_core::verify_consistency_proof(
                     &proof,
                     tree_size,
                     new_tree_hash,
@@ -1523,7 +1523,7 @@ mod tests {
                 )
             };
             // Verify the inclusion proof
-            tlog_tiles::verify_inclusion_proof(&proof, n, tree_hash, i, leaf_hash).unwrap();
+            tlog_core::verify_inclusion_proof(&proof, n, tree_hash, i, leaf_hash).unwrap();
         }
 
         // Check that we can make a consistency proof for random spans in the tree
@@ -1538,7 +1538,7 @@ mod tests {
                 &log.object,
             ))
             .unwrap();
-            tlog_tiles::verify_consistency_proof(
+            tlog_core::verify_consistency_proof(
                 &consistency_proof,
                 new_tree_size,
                 tree_hashes[usize::try_from(new_tree_size).unwrap()],
@@ -1849,8 +1849,7 @@ mod tests {
         let checkpoint_signer = Ed25519CheckpointSigner::new(
             log.config.origin.clone(),
             Ed25519SigningKey::generate(&mut rand::rng()),
-        )
-        .unwrap();
+        );
         log.config.checkpoint_signers = vec![Box::new(checkpoint_signer)];
         block_on(SequenceState::load::<StaticCTLogEntry>(
             &log.config,
@@ -2451,8 +2450,7 @@ mod tests {
                 let witness = Ed25519CheckpointSigner::new(
                     origin.clone(),
                     Ed25519SigningKey::generate(&mut rng),
-                )
-                .unwrap();
+                );
                 vec![Box::new(signer), Box::new(witness)]
             };
             // Don't use checkpoint extensions
@@ -2621,7 +2619,7 @@ mod tests {
             }
 
             let indexes: Vec<u64> = (0..c.size())
-                .map(|n| tlog_tiles::stored_hash_index(0, n))
+                .map(|n| tlog_core::stored_hash_index(0, n))
                 .collect();
             // [read_tile_hashes] checks the inclusion of every hash in the provided tree,
             // so this checks the validity of the entire Merkle tree.
@@ -2632,7 +2630,7 @@ mod tests {
                 hash_reader.read_hashes(&indexes)?
             };
 
-            let last_tile = TlogTile::from_index(tlog_tiles::stored_hash_count(c.size() - 1))
+            let last_tile = TlogTile::from_index(tlog_core::stored_hash_count(c.size() - 1))
                 .with_data_path(StaticCTPendingLogEntry::DATA_TILE_PATH);
 
             for n in 0..last_tile.level_index() {

--- a/crates/integration_tests/Cargo.toml
+++ b/crates/integration_tests/Cargo.toml
@@ -29,6 +29,7 @@ sha2.workspace = true
 signed_note.workspace = true
 static_ct_api.workspace = true
 bootstrap_mtc_api.workspace = true
+tlog_core.workspace = true
 tlog_cosignature.workspace = true
 tlog_tiles.workspace = true
 tlog_witness.workspace = true

--- a/crates/integration_tests/src/assertions.rs
+++ b/crates/integration_tests/src/assertions.rs
@@ -14,9 +14,10 @@ use sct_validator::{
 use sha2::{Digest, Sha256};
 use signed_note::{Ed25519NoteVerifier, KeyName, VerifierList};
 use static_ct_api::{Extensions, RFC6962NoteVerifier, StaticCTLogEntry};
+use tlog_core::HashReader;
 use tlog_tiles::{
-    open_checkpoint, CheckpointText, HashReader, LogEntry, PathElem, PreloadedTlogTileReader,
-    TileHashReader, TileIterator, TlogTile,
+    open_checkpoint, CheckpointText, LogEntry, PathElem, PreloadedTlogTileReader, TileHashReader,
+    TileIterator, TlogTile,
 };
 use x509_cert::{der::Decode, der::Encode, Certificate};
 
@@ -299,7 +300,7 @@ pub async fn assert_leaf_in_checkpoint(
     }
 
     // Compute the hash storage index for this leaf.
-    let hash_index = tlog_tiles::stored_hash_index(0, leaf_index);
+    let hash_index = tlog_core::stored_hash_index(0, leaf_index);
     let indexes = vec![hash_index];
 
     // Use TlogTileRecorder to discover which hash tiles are needed for the

--- a/crates/integration_tests/tests/tlog_witness.rs
+++ b/crates/integration_tests/tests/tlog_witness.rs
@@ -50,10 +50,11 @@ use serde::Deserialize;
 use serde_with::{base64::Base64, serde_as};
 use signed_note::{KeyName, Note, NoteSignature, VerifierList};
 use std::time::Duration;
-use tlog_tiles::{
-    consistency_proof, record_hash, stored_hashes, tree_hash, CheckpointSigner,
-    Ed25519CheckpointSigner, Hash, HashReader, TlogError, TreeWithTimestamp, HASH_SIZE,
+use tlog_core::{
+    consistency_proof, record_hash, stored_hashes, tree_hash, Hash, HashReader, TlogError,
+    HASH_SIZE,
 };
+use tlog_tiles::{CheckpointSigner, Ed25519CheckpointSigner, TreeWithTimestamp};
 use tlog_witness::{
     parse_add_checkpoint_response, serialize_add_checkpoint_request, CONTENT_TYPE_TLOG_SIZE,
 };
@@ -77,7 +78,7 @@ const LOG_SIGNING_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----\n\
 fn log_signer() -> Ed25519CheckpointSigner {
     let sk = Ed25519SigningKey::from_pkcs8_pem(LOG_SIGNING_KEY_PEM).expect("parse dev log key");
     let name = KeyName::new(LOG_ORIGIN.to_owned()).expect("KeyName for origin");
-    Ed25519CheckpointSigner::new(name, sk).expect("build Ed25519CheckpointSigner")
+    Ed25519CheckpointSigner::new(name, sk)
 }
 
 /// Generate a fresh Ed25519 log signer that the witness does *not* trust —
@@ -85,7 +86,7 @@ fn log_signer() -> Ed25519CheckpointSigner {
 fn untrusted_log_signer() -> Ed25519CheckpointSigner {
     let sk = Ed25519SigningKey::generate(&mut rng());
     let name = KeyName::new(LOG_ORIGIN.to_owned()).unwrap();
-    Ed25519CheckpointSigner::new(name, sk).unwrap()
+    Ed25519CheckpointSigner::new(name, sk)
 }
 
 // ---------------------------------------------------------------------------
@@ -145,7 +146,7 @@ impl ToyLog {
     }
 
     /// `consistency_proof(old_size → current)`. Wraps
-    /// `tlog_tiles::consistency_proof`, whose argument order is reversed from
+    /// `tlog_core::consistency_proof`, whose argument order is reversed from
     /// RFC 6962 convention (larger size first).
     fn consistency_proof(&self, old_size: u64) -> Vec<Hash> {
         let size = self.size();
@@ -364,7 +365,7 @@ async fn tlog_witness_end_to_end() {
         let sk = Ed25519SigningKey::generate(&mut rng());
         let origin = "not.configured.example/log";
         let name = KeyName::new(origin.to_owned()).unwrap();
-        let other_signer = Ed25519CheckpointSigner::new(name, sk).unwrap();
+        let other_signer = Ed25519CheckpointSigner::new(name, sk);
         let tree = TreeWithTimestamp::new(1, record_hash(b"x"), now_millis());
         let cp = tree
             .sign(origin, &[], &[&other_signer], &mut rng())

--- a/crates/static_ct_api/Cargo.toml
+++ b/crates/static_ct_api/Cargo.toml
@@ -37,6 +37,7 @@ sha2.workspace = true
 signature.workspace = true
 signed_note.workspace = true
 thiserror.workspace = true
+tlog_core.workspace = true
 tlog_tiles.workspace = true
 spki.workspace = true
 x509-cert.workspace = true

--- a/crates/static_ct_api/src/lib.rs
+++ b/crates/static_ct_api/src/lib.rs
@@ -10,7 +10,7 @@ pub use static_ct::*;
 #[derive(thiserror::Error, Debug)]
 pub enum StaticCTError {
     #[error(transparent)]
-    Tlog(#[from] tlog_tiles::TlogError),
+    Tlog(#[from] tlog_core::TlogError),
     #[error(transparent)]
     Signature(#[from] signature::Error),
     #[error(transparent)]

--- a/crates/static_ct_api/src/static_ct.rs
+++ b/crates/static_ct_api/src/static_ct.rs
@@ -119,9 +119,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use signed_note::{KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
 use std::io::Read;
+use tlog_core::{Hash, LeafIndex};
 use tlog_tiles::{
-    CheckpointSigner, CheckpointText, Hash, LeafIndex, LogEntry, LookupKey, PathElem,
-    PendingLogEntry, UnixTimestamp,
+    CheckpointSigner, CheckpointText, LogEntry, LookupKey, PathElem, PendingLogEntry, UnixTimestamp,
 };
 
 #[repr(u16)]
@@ -303,7 +303,7 @@ impl LogEntry for StaticCTLogEntry {
     ///
     /// Panics if writing to the internal buffer fails, which should never happen.
     fn merkle_tree_leaf(&self) -> Hash {
-        tlog_tiles::record_hash(
+        tlog_core::record_hash(
             &[
                 &[
                     0, // version = v1 (0)

--- a/crates/tlog_core/Cargo.toml
+++ b/crates/tlog_core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tlog_tiles"
+name = "tlog_core"
 readme = "README.md"
 version.workspace = true
 authors.workspace = true
@@ -7,9 +7,9 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "An implementation of c2sp.org/tlog-tiles and c2sp.org/tlog-checkpoint"
+description = "RFC 6962 Merkle tree math + draft-ietf-plants-merkle-tree-certs subtree proofs"
 categories = ["cryptography"]
-keywords = ["ct", "certificate", "transparency", "crypto", "pki"]
+keywords = ["transparency", "merkle", "rfc6962", "crypto", "pki"]
 
 [package.metadata.release]
 release = false
@@ -21,17 +21,8 @@ wasm-opt = false
 [lib]
 crate-type = ["rlib"]
 
-[dev-dependencies]
-serde_json.workspace = true
-
 [dependencies]
 base64.workspace = true
-ed25519-dalek.workspace = true
-length_prefixed.workspace = true
-rand.workspace = true
 serde.workspace = true
 sha2.workspace = true
-signed_note.workspace = true
 thiserror.workspace = true
-tlog_core.workspace = true
-url.workspace = true

--- a/crates/tlog_core/LICENSE
+++ b/crates/tlog_core/LICENSE
@@ -1,0 +1,73 @@
+Copyright 2025 Cloudflare, Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+========================================================================
+
+Copyright 2023 The Sunlight Authors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+========================================================================
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+ * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/crates/tlog_core/README.md
+++ b/crates/tlog_core/README.md
@@ -1,0 +1,40 @@
+# tlog_core
+
+Merkle Tree primitives for transparency logs: the algorithm-only core
+shared by every transparency-log spec in this workspace.
+
+This crate provides the [`Hash`] type, the RFC 6962 hash builders, and
+inclusion / consistency proof builders and verifiers (with the subtree
+variants from [draft-ietf-plants-merkle-tree-certs][mtc]). It is
+transport-agnostic: no HTTP, no tile encoding, no checkpoint signing.
+
+Higher-level crates that build on top of `tlog_core`:
+
+- [`tlog_tiles`](../tlog_tiles): the [C2SP tlog-tiles][tt] HTTP wire format.
+- [`tlog_checkpoint`](../tlog_tiles): the [C2SP tlog-checkpoint][tc] signed-note
+  format. (Currently still inside `tlog_tiles`; planned move tracked in
+  [issue #230](https://github.com/cloudflare/azul/issues/230).)
+- [`tlog_witness`](../tlog_witness): the [C2SP tlog-witness][tw] HTTP witness
+  protocol.
+- [`tlog_cosignature`](../tlog_cosignature): the [C2SP tlog-cosignature][cs]
+  cosignature formats.
+
+## Test
+
+    cargo test
+
+## Acknowledgements
+
+Ported from the Go [tlog package][go-tlog]; see per-function references
+in the source back to the upstream commit.
+
+## License
+
+[BSD-3-Clause](./LICENSE).
+
+[mtc]: https://datatracker.ietf.org/doc/draft-ietf-plants-merkle-tree-certs/
+[tt]: https://c2sp.org/tlog-tiles
+[tc]: https://c2sp.org/tlog-checkpoint
+[tw]: https://c2sp.org/tlog-witness
+[cs]: https://c2sp.org/tlog-cosignature
+[go-tlog]: https://pkg.go.dev/golang.org/x/mod/sumdb/tlog

--- a/crates/tlog_core/src/lib.rs
+++ b/crates/tlog_core/src/lib.rs
@@ -7,13 +7,28 @@
 // Modifications and Rust implementation Copyright (c) 2025 Cloudflare, Inc.
 // Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
-//! Provides Merkle Tree functionality required for a basic transparency log.
+//! Merkle Tree primitives for transparency logs.
 //!
-//! This file contains code ported from the original project [tlog](https://pkg.go.dev/golang.org/x/mod/sumdb/tlog).
+//! This crate provides the algorithm-only Merkle math used by every
+//! transparency-log spec in this workspace: the [`Hash`] type and the
+//! `record_hash` / `node_hash` / `tree_hash` / `*_hash_index` builders
+//! per [RFC 6962][rfc6962] §2.1, the inclusion-proof and consistency-
+//! proof builders/verifiers per RFC 6962 §2.1.1–§2.1.4, and the subtree
+//! variants from [draft-ietf-plants-merkle-tree-certs §4][mtc-§4].
 //!
-//! References:
-//! - [tlog.go](https://cs.opensource.google/go/x/mod/+/refs/tags/v0.21.0:sumdb/tlog/tlog.go)
-//! - [tlog_test.go](https://cs.opensource.google/go/x/mod/+/refs/tags/v0.21.0:sumdb/tlog/tlog_test.go)
+//! It is transport-agnostic: there is no HTTP, no tile encoding, no
+//! checkpoint signing. Higher-level crates (`tlog_tiles` for the C2SP
+//! tiled wire format, `tlog_witness` for the witness HTTP protocol,
+//! `tlog_cosignature` for cosignatures, MTC-related crates for the
+//! IETF Merkle Tree Certificates work) build on top of these
+//! primitives.
+//!
+//! Ported from the Go [tlog package][go-tlog]; see the source for
+//! per-function references back to the upstream commit.
+//!
+//! [rfc6962]: https://www.rfc-editor.org/rfc/rfc6962
+//! [mtc-§4]: https://datatracker.ietf.org/doc/html/draft-ietf-plants-merkle-tree-certs#section-4
+//! [go-tlog]: https://pkg.go.dev/golang.org/x/mod/sumdb/tlog
 
 use base64::prelude::*;
 use serde::{
@@ -44,21 +59,12 @@ pub enum TlogError {
     IndexesOutOfOrder,
     #[error("unmet input condition: {0}")]
     ConditionNotMet(String),
-    #[error("missing verifier signature")]
-    MissingVerifierSignature,
-    #[error("timestamp is after current time")]
-    InvalidTimestamp,
-    #[error("checkpoint origin does not match")]
-    OriginMismatch,
-    #[error(transparent)]
-    Note(#[from] signed_note::NoteError),
-    #[error(transparent)]
-    MalformedCheckpoint(#[from] crate::MalformedCheckpointTextError),
     #[error(transparent)]
     InvalidBase64(#[from] base64::DecodeError),
-    #[error(transparent)]
-    IO(#[from] std::io::Error),
 }
+
+/// Index of a leaf in the Merkle tree (0-based).
+pub type LeafIndex = u64;
 
 /// `HashSize` is the size of a Hash in bytes.
 pub const HASH_SIZE: usize = 32;
@@ -1101,10 +1107,12 @@ impl Subtree {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tile::{Tile, TileHashReader, TileReader};
-    use std::cell::Cell;
-    use std::collections::HashMap;
 
+    /// In-memory `HashReader` backing every test in this module.
+    ///
+    /// Tests that exercise the tile-encoding layer (the integration test
+    /// that pairs this with `TileHashReader`) live in `tlog_tiles`, since
+    /// `Tile` and friends belong to that crate.
     type TestHashStorage = Vec<Hash>;
 
     impl HashReader for TestHashStorage {
@@ -1125,224 +1133,6 @@ mod tests {
                 out.push(self[usize::try_from(index).unwrap()]);
             }
             Ok(out)
-        }
-    }
-
-    #[derive(Default, Debug)]
-    struct TestTilesStorage {
-        // Make use of interior mutability here to avoid needing to make struct mutable for tests:
-        // https://ricardomartins.cc/2016/06/08/interior-mutability
-        unsaved: Cell<usize>,
-        m: HashMap<Tile, Vec<u8>>,
-    }
-
-    impl TileReader for TestTilesStorage {
-        fn height(&self) -> u8 {
-            2
-        }
-
-        fn save_tiles(&self, tiles: &[Tile], _data: &[Vec<u8>]) {
-            let new_size = self.unsaved.get() - tiles.len();
-            self.unsaved.set(new_size);
-        }
-
-        fn read_tiles(&self, tiles: &[Tile]) -> Result<Vec<Vec<u8>>, TlogError> {
-            let mut out = Vec::with_capacity(tiles.len());
-            for tile in tiles {
-                if let Some(data) = self.m.get(tile) {
-                    out.push(data.clone());
-                } else {
-                    panic!("tile {tile:?} not found in map");
-                }
-            }
-            let new_size = self.unsaved.get() + tiles.len();
-            self.unsaved.set(new_size);
-            Ok(out)
-        }
-    }
-
-    #[allow(clippy::too_many_lines)]
-    #[test]
-    fn test_tree() {
-        const TEST_H: u8 = 2;
-
-        let mut trees = Vec::new();
-        let mut leafhashes = Vec::new();
-        let mut storage = TestHashStorage::new();
-        let mut tiles = HashMap::<Tile, Vec<u8>>::new();
-
-        for i in 0..100 {
-            let data = format!("leaf {i}");
-            let hashes = stored_hashes(i, data.as_bytes(), &storage).unwrap();
-
-            leafhashes.push(record_hash(data.as_bytes()));
-            let old_storage_len = storage.len();
-            storage.extend(hashes);
-
-            assert_eq!(stored_hash_count(i + 1), storage.len() as u64);
-
-            let th = tree_hash(i + 1, &storage).unwrap();
-
-            for tile in Tile::new_tiles(TEST_H, i, i + 1) {
-                let data = tile.read_data(&storage).unwrap();
-                let default = Vec::new();
-                let old_data = if tile.width() > 1 {
-                    let old = Tile::new(
-                        tile.height(),
-                        tile.level(),
-                        tile.level_index(),
-                        tile.width() - 1,
-                        None,
-                    );
-                    tiles.get(&old).unwrap_or(&default)
-                } else {
-                    &default
-                };
-                assert!(
-                    old_data.len() == data.len() - HASH_SIZE && *old_data == data[..old_data.len()],
-                    "tile {tile:?} not extending old tile"
-                );
-                tiles.insert(tile, data);
-            }
-
-            for tile in Tile::new_tiles(TEST_H, 0, i + 1) {
-                let data = tile.read_data(&storage).unwrap();
-                assert_eq!(tiles[&tile], data, "mismatch at {tile:?}");
-            }
-
-            for tile in Tile::new_tiles(TEST_H, i / 2, i + 1) {
-                let data = tile.read_data(&storage).unwrap();
-                assert_eq!(tiles[&tile], data, "mismatch at {tile:?}");
-            }
-
-            // Check that all the new hashes are readable from their tiles.
-            for (j, stored_hash) in storage.iter().enumerate().skip(old_storage_len) {
-                let tile = Tile::from_index(TEST_H, j as u64);
-                let data = tiles.get(&tile).cloned().unwrap();
-                let h = tile.hash_at_index(&data, j as u64).unwrap();
-                assert_eq!(h, *stored_hash);
-            }
-
-            trees.push(th);
-
-            // Check that inclusion proofs work, for all trees and leaves so far.
-            for j in 0..=i {
-                let mut p = inclusion_proof(i + 1, j, &storage).unwrap();
-                verify_inclusion_proof(&p, i + 1, th, j, leafhashes[usize::try_from(j).unwrap()])
-                    .unwrap();
-
-                for k in 0..p.len() {
-                    p[k].0[0] ^= 1;
-                    assert!(
-                        verify_inclusion_proof(
-                            &p,
-                            i + 1,
-                            th,
-                            j,
-                            leafhashes[usize::try_from(j).unwrap()]
-                        )
-                        .is_err(),
-                        "verify_inclusion_proof({}, {j}) succeeded with corrupt proof hash #{k}!",
-                        i + 1
-                    );
-                    p[k].0[0] ^= 1;
-                }
-            }
-
-            // Check that inclusion proofs work using TileReader.
-            let tile_storage = TestTilesStorage {
-                m: tiles.clone(),
-                unsaved: Cell::new(0),
-            };
-            let thr = TileHashReader::new(i + 1, th, &tile_storage);
-            for j in 0..=i {
-                let h = thr.read_hashes(&[stored_hash_index(0, j)]).unwrap();
-                assert_eq!(h.len(), 1, "bad read_hashes implementation");
-                assert_eq!(h[0], leafhashes[usize::try_from(j).unwrap()], "wrong hash");
-
-                // Even though reading the hash suffices, check we can generate the proof too.
-                let p = inclusion_proof(i + 1, j, &thr).unwrap();
-                verify_inclusion_proof(&p, i + 1, th, j, leafhashes[usize::try_from(j).unwrap()])
-                    .unwrap();
-            }
-            assert_eq!(tile_storage.unsaved.get(), 0, "did not save tiles");
-
-            // Check that ReadHashes will give an error if the index is not in the tree.
-            assert!(
-                thr.read_hashes(&[(i + 1) * 2]).is_err(),
-                "read_hashes returned non-err for index not in tree, want err"
-            );
-
-            assert_eq!(tile_storage.unsaved.get(), 0, "did not save tiles");
-
-            // Check that consistency proofs work, for all trees so far, using TileReader.
-            for j in 0..=i {
-                let h = tree_hash(j + 1, &thr).unwrap();
-                assert_eq!(h, trees[usize::try_from(j).unwrap()]);
-
-                // Even though computing the subtree hash suffices, check that we can generate the proof too.
-                let mut p = consistency_proof(i + 1, j + 1, &thr).unwrap();
-                verify_consistency_proof(&p, i + 1, th, j + 1, trees[usize::try_from(j).unwrap()])
-                    .unwrap();
-                for k in 0..p.len() {
-                    p[k].0[0] ^= 1;
-                    assert!(
-                        verify_consistency_proof(
-                            &p,
-                            i + 1,
-                            th,
-                            j + 1,
-                            trees[usize::try_from(j).unwrap()]
-                        )
-                        .is_err(),
-                        "verify_consistency_proof({}, {j}) succeeded with corrupt proof hash #{k}!",
-                        i + 1
-                    );
-                    p[k].0[0] ^= 1;
-                }
-            }
-            assert_eq!(tile_storage.unsaved.get(), 0, "did not save tiles");
-
-            // Check that subtree consistency proofs work, for all valid subtrees up to the current tree size.
-            for lo in 0..i {
-                let max_hi = if lo == 0 {
-                    u64::MAX
-                } else {
-                    // If `lo` is non-zero, find the maximum power of 2 that divides `lo`.
-                    // This is a bitwise trick that isolates the lowest set bit.
-                    let max_size = lo & lo.wrapping_neg();
-                    lo + max_size
-                };
-                for hi in lo + 1..=i.min(max_hi) {
-                    let m = Subtree::new(lo, hi).unwrap();
-                    let m_hash = subtree_hash(&m, &storage).unwrap();
-                    // Prove that the subtree is consistent with the tree of size `n`.
-                    verify_subtree_consistency_proof(
-                        &subtree_consistency_proof(i + 1, &m, &storage).unwrap(),
-                        i + 1,
-                        th,
-                        &m,
-                        m_hash,
-                    )
-                    .unwrap();
-                    for leaf_index in lo..hi {
-                        let proof = subtree_inclusion_proof(&m, leaf_index, &storage).unwrap();
-                        let leaf_hash = leafhashes[usize::try_from(leaf_index).unwrap()];
-                        // Prove that each leaf in the subtree is included in the subtree.
-                        verify_subtree_inclusion_proof(&proof, &m, m_hash, leaf_index, leaf_hash)
-                            .unwrap();
-                        // The evaluator returns the subtree hash, which must
-                        // match the committed `m_hash`. This is the
-                        // counterpart used by cosignature verifiers that
-                        // reconstruct the subtree hash from an inclusion
-                        // proof instead of being handed it directly.
-                        let evaluated =
-                            evaluate_subtree_inclusion_proof(&proof, &m, leaf_index, leaf_hash)
-                                .unwrap();
-                        assert_eq!(evaluated, m_hash);
-                    }
-                }
-            }
         }
     }
 

--- a/crates/tlog_cosignature/Cargo.toml
+++ b/crates/tlog_cosignature/Cargo.toml
@@ -20,6 +20,7 @@ ed25519-dalek.workspace = true
 length_prefixed.workspace = true
 ml-dsa.workspace = true
 signed_note.workspace = true
+tlog_core.workspace = true
 tlog_tiles.workspace = true
 
 [dev-dependencies]

--- a/crates/tlog_cosignature/src/cosignature_v1.rs
+++ b/crates/tlog_cosignature/src/cosignature_v1.rs
@@ -140,7 +140,8 @@ impl NoteVerifier for CosignatureV1NoteVerifier {
 #[cfg(test)]
 mod tests {
 
-    use tlog_tiles::{open_checkpoint, record_hash, TreeWithTimestamp};
+    use tlog_core::record_hash;
+    use tlog_tiles::{open_checkpoint, TreeWithTimestamp};
 
     use super::*;
     use signed_note::VerifierList;

--- a/crates/tlog_cosignature/src/subtree_v1.rs
+++ b/crates/tlog_cosignature/src/subtree_v1.rs
@@ -89,7 +89,8 @@ use ml_dsa::{
     MlDsa44, Signature as MlDsaSignature, VerifyingKey as MlDsaVerifyingKey,
 };
 use signed_note::{KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
-use tlog_tiles::{CheckpointSigner, CheckpointText, Hash, Subtree, UnixTimestamp, HASH_SIZE};
+use tlog_core::{Hash, Subtree, HASH_SIZE};
+use tlog_tiles::{CheckpointSigner, CheckpointText, UnixTimestamp};
 
 /// The fixed 12-byte label prefix domain-separating `subtree/v1` from
 /// other cosignature formats.
@@ -259,7 +260,7 @@ impl SubtreeV1CheckpointSigner {
     /// Sign an arbitrary subtree, returning a `subtree/v1`
     /// [`NoteSignature`].
     ///
-    /// `subtree` carries `(start, end)` as a `tlog_tiles::Subtree`,
+    /// `subtree` carries `(start, end)` as a `tlog_core::Subtree`,
     /// which has been validated at construction time to be a valid
     /// `[start, end)` subtree per draft-ietf-plants-merkle-tree-certs
     /// §4.1 (`start < end`, alignment to the next-power-of-two width).
@@ -401,7 +402,7 @@ impl SubtreeV1NoteVerifier {
     /// `false` for any malformation, including when the spec's
     /// timestamp/start invariant is violated.
     ///
-    /// `subtree` carries `(start, end)` as a `tlog_tiles::Subtree`,
+    /// `subtree` carries `(start, end)` as a `tlog_core::Subtree`,
     /// which has been validated at construction time; the previous
     /// runtime `start < end` check is now expressed in the type.
     ///
@@ -527,7 +528,7 @@ fn decode_signature(bytes: &[u8]) -> Option<MlDsaSignature<MlDsa44>> {
 mod tests {
     use super::*;
     use ml_dsa::ExpandedSigningKey;
-    use tlog_tiles::HASH_SIZE;
+    use tlog_core::HASH_SIZE;
 
     /// Construct a deterministic ML-DSA-44 expanded signing key from a
     /// 32-byte seed; the companion verifying key is derived via

--- a/crates/tlog_tiles/src/checkpoint.rs
+++ b/crates/tlog_tiles/src/checkpoint.rs
@@ -34,7 +34,7 @@
 //! - [note_test.go](https://cs.opensource.google/go/x/mod/+/refs/tags/v0.21.0:sumdb/tlog/note_test.go)
 //! - [checkpoint.go](https://github.com/FiloSottile/sunlight/blob/36be227ff4599ac11afe3cec37a5febcd61da16a/checkpoint.go)
 
-use crate::{tlog::Hash, HashReader, TlogError, UnixTimestamp};
+use crate::UnixTimestamp;
 use base64::{prelude::BASE64_STANDARD, Engine};
 use ed25519_dalek::{Signer, SigningKey as Ed25519SigningKey};
 use rand::{seq::SliceRandom, Rng, RngExt};
@@ -47,6 +47,44 @@ use std::{
     fmt,
     io::{BufRead, Read},
 };
+use thiserror::Error;
+use tlog_core::{Hash, HashReader, TlogError};
+
+/// Errors returned by the checkpoint-signing and -verification entry
+/// points in this module ([`open_checkpoint`], [`TreeWithTimestamp::sign`],
+/// [`TreeWithTimestamp::from_hash_reader`]).
+///
+/// Compared to the math-only [`tlog_core::TlogError`] this also covers
+/// signature-verification failure modes and parser failures specific to
+/// the [c2sp.org/tlog-checkpoint][spec] signed-note format.
+///
+/// [spec]: https://c2sp.org/tlog-checkpoint
+#[derive(Debug, Error)]
+pub enum CheckpointError {
+    /// A required verifier did not produce a valid signature on the
+    /// note. Surfaces as `403 Forbidden` in HTTP frontends.
+    #[error("missing verifier signature")]
+    MissingVerifierSignature,
+    /// One of the embedded note signature timestamps is in the future
+    /// relative to the caller-supplied `current_time`.
+    #[error("timestamp is after current time")]
+    InvalidTimestamp,
+    /// The checkpoint origin does not match the caller-supplied origin.
+    #[error("checkpoint origin does not match")]
+    OriginMismatch,
+    /// The embedded signed note is malformed or its signatures fail to
+    /// verify.
+    #[error(transparent)]
+    Note(#[from] NoteError),
+    /// The checkpoint text section is not parseable as a
+    /// [`CheckpointText`].
+    #[error(transparent)]
+    MalformedCheckpoint(#[from] MalformedCheckpointTextError),
+    /// A pure-math error from the underlying `tlog` layer (e.g. failing
+    /// to compute a tree hash from the supplied [`HashReader`]).
+    #[error(transparent)]
+    Tlog(#[from] TlogError),
+}
 
 /// This works like `BufRead::lines`, except it reports a final newline as a
 /// length-0 line
@@ -325,16 +363,14 @@ pub struct Ed25519CheckpointSigner {
 }
 
 impl Ed25519CheckpointSigner {
-    /// Returns a new `Ed25519Signer`.
-    ///
-    /// # Errors
-    ///
-    /// Errors if a verifier cannot be created from the provided signing key.
-    pub fn new(name: KeyName, k: Ed25519SigningKey) -> Result<Self, TlogError> {
-        Ok(Self {
+    /// Returns a new `Ed25519CheckpointSigner` from a key name and
+    /// signing key. Infallible.
+    #[must_use]
+    pub fn new(name: KeyName, k: Ed25519SigningKey) -> Self {
+        Self {
             v: Ed25519NoteVerifier::new(name, k.verifying_key()),
             k,
-        })
+        }
     }
 }
 
@@ -390,7 +426,7 @@ pub fn open_checkpoint(
     verifiers: &VerifierList,
     current_time: UnixTimestamp,
     checkpoint_bytes: &[u8],
-) -> Result<(CheckpointText, Option<UnixTimestamp>), TlogError> {
+) -> Result<(CheckpointText, Option<UnixTimestamp>), CheckpointError> {
     // A checkpoint is a signed note whose text is a CheckpointText
     let n = Note::from_bytes(checkpoint_bytes)?;
     let (verified_sigs, _) = n.verify(verifiers)?;
@@ -419,15 +455,15 @@ pub fn open_checkpoint(
 
     // If we didn't see all the verifiers we wanted to see, error
     if !key_ids_to_observe.is_empty() {
-        return Err(TlogError::MissingVerifierSignature);
+        return Err(CheckpointError::MissingVerifierSignature);
     }
 
     let checkpoint_text = CheckpointText::from_bytes(n.text())?;
     if current_time < latest_timestamp.unwrap_or(0) {
-        return Err(TlogError::InvalidTimestamp);
+        return Err(CheckpointError::InvalidTimestamp);
     }
     if checkpoint_text.origin() != origin {
-        return Err(TlogError::OriginMismatch);
+        return Err(CheckpointError::OriginMismatch);
     }
 
     Ok((checkpoint_text, latest_timestamp))
@@ -459,7 +495,7 @@ impl TreeWithTimestamp {
         r: &R,
         time: UnixTimestamp,
     ) -> Result<TreeWithTimestamp, TlogError> {
-        let hash = crate::tree_hash(size, r)?;
+        let hash = tlog_core::tree_hash(size, r)?;
         Ok(Self { size, hash, time })
     }
 
@@ -493,7 +529,7 @@ impl TreeWithTimestamp {
         extensions: &[&str],
         signers: &[&dyn CheckpointSigner],
         rng: &mut impl Rng,
-    ) -> Result<Vec<u8>, TlogError> {
+    ) -> Result<Vec<u8>, CheckpointError> {
         // Shuffle the signer order
         let mut signers = signers.to_vec();
         signers.shuffle(rng);
@@ -559,7 +595,7 @@ fn gen_grease_signatures(origin: &str, rng: &mut impl Rng) -> Vec<NoteSignature>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tlog::record_hash;
+    use tlog_core::record_hash;
 
     #[test]
     fn test_parse_checkpoint() {
@@ -660,7 +696,7 @@ mod tests {
         let tree = TreeWithTimestamp::new(tree_size, record_hash(b"hello world"), timestamp);
         let signer = {
             let sk = Ed25519SigningKey::generate(&mut rand::rng());
-            Ed25519CheckpointSigner::new(KeyName::new("my-signer".into()).unwrap(), sk).unwrap()
+            Ed25519CheckpointSigner::new(KeyName::new("my-signer".into()).unwrap(), sk)
         };
         let checkpoint = tree
             .sign(origin, &[], &[&signer], &mut rand::rng())

--- a/crates/tlog_tiles/src/entries.rs
+++ b/crates/tlog_tiles/src/entries.rs
@@ -3,16 +3,14 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::{io::Read, marker::PhantomData};
 
-use crate::{Hash, PathElem, TlogError};
+use crate::PathElem;
+use tlog_core::{Hash, LeafIndex};
 
 pub const LOOKUP_KEY_LEN: usize = 16;
 pub type LookupKey = [u8; LOOKUP_KEY_LEN];
 
 /// Unix timestamp.
 pub type UnixTimestamp = u64;
-
-/// Index of a leaf in the Merkle tree.
-pub type LeafIndex = u64;
 
 /// An opaque `PendingLogEntry` that can be passed around without requiring full
 /// deserialization.
@@ -153,7 +151,7 @@ impl PendingLogEntry for TlogTilesPendingLogEntry {
 impl LogEntry for TlogTilesLogEntry {
     const REQUIRE_CHECKPOINT_TIMESTAMP: bool = false;
     type Pending = TlogTilesPendingLogEntry;
-    type ParseError = TlogError;
+    type ParseError = std::io::Error;
 
     fn initial_entry() -> Option<Self::Pending> {
         None
@@ -164,7 +162,7 @@ impl LogEntry for TlogTilesLogEntry {
     }
 
     fn merkle_tree_leaf(&self) -> Hash {
-        crate::tlog::record_hash(&self.inner.data)
+        tlog_core::record_hash(&self.inner.data)
     }
 
     fn to_data_tile_entry(&self) -> Vec<u8> {

--- a/crates/tlog_tiles/src/lib.rs
+++ b/crates/tlog_tiles/src/lib.rs
@@ -1,39 +1,37 @@
-// Ported from "mod" (https://pkg.go.dev/golang.org/x/mod)
-// Copyright 2009 The Go Authors
-// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
-//
-// This ports code from the original Go project "mod" and adapts it to Rust idioms.
-//
-// Modifications and Rust implementation Copyright (c) 2025 Cloudflare, Inc.
+// Copyright (c) 2025 Cloudflare, Inc.
 // Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
-//! # tlog tiles
+//! # `tlog_tiles`
 //!
-//! Implementation of the [C2SP tlog-tiles](https://c2sp.org/tlog-tiles) and [C2SP checkpoint](https://c2sp.org/tlog-checkpoint) specifications.
+//! Implementation of the [C2SP tlog-tiles](https://c2sp.org/tlog-tiles) and
+//! [C2SP tlog-checkpoint](https://c2sp.org/tlog-checkpoint) specifications.
 //!
-//! This file contains code ported from the original project [tlog](https://pkg.go.dev/golang.org/x/mod/sumdb/tlog).
+//! The underlying RFC 6962 Merkle math (the [`Hash`] type, the proof
+//! builders/verifiers, the `Subtree` type) lives in the [`tlog_core`]
+//! crate; this crate adds the tile-encoding wire format and the
+//! checkpoint note shape on top.
 //!
-//! References:
-//! - [ct_test.go](https://cs.opensource.google/go/x/mod/+/refs/tags/v0.21.0:sumdb/tlog/ct_test.go)
+//! [`Hash`]: tlog_core::Hash
+//! [`tlog_core`]: https://docs.rs/tlog_core
 
 pub mod checkpoint;
 pub mod entries;
 pub mod tile;
-pub mod tlog;
 
 pub use checkpoint::*;
 pub use entries::*;
 pub use tile::*;
-pub use tlog::*;
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use base64::prelude::*;
     use serde::{Deserialize, Deserializer};
     use std::fs::File;
     use std::io::Read;
     use std::path::PathBuf;
+    use tlog_core::{
+        record_hash, verify_consistency_proof, verify_inclusion_proof, Hash, TlogError,
+    };
     use url::form_urlencoded;
 
     #[derive(Deserialize)]

--- a/crates/tlog_tiles/src/tile.rs
+++ b/crates/tlog_tiles/src/tile.rs
@@ -15,15 +15,15 @@
 //! - [tile.go](https://cs.opensource.google/go/x/mod/+/refs/tags/v0.21.0:sumdb/tlog/tile.go)
 //! - [tile_test.go](https://cs.opensource.google/go/x/mod/+/refs/tags/v0.21.0:sumdb/tlog/tile_test.go)
 
-use crate::tlog::{
-    node_hash, split_stored_hash_index, stored_hash_index, tree_hash_indexes, Hash, HashReader,
-    TlogError, HASH_SIZE,
-};
 use std::cell::RefCell;
 use std::cmp::max;
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
+use tlog_core::{
+    node_hash, split_stored_hash_index, stored_hash_index, tree_hash_indexes, Hash, HashReader,
+    TlogError, HASH_SIZE,
+};
 
 // To limit the size of any particular directory listing, we encode the (possibly very large)
 // number N by encoding three digits at a time.  For example, 123456789 encodes as x123/x456/789.
@@ -791,6 +791,284 @@ impl TileReader for PreloadedTlogTileReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+    use std::collections::HashMap;
+    use tlog_core::{
+        consistency_proof, evaluate_subtree_inclusion_proof, inclusion_proof, record_hash,
+        stored_hash_count, stored_hash_index, stored_hashes, subtree_consistency_proof,
+        subtree_hash, subtree_inclusion_proof, tree_hash, verify_consistency_proof,
+        verify_inclusion_proof, verify_subtree_consistency_proof, verify_subtree_inclusion_proof,
+        Subtree,
+    };
+
+    /// In-memory `HashReader` paired with [`TestTilesStorage`] in the
+    /// `test_tree` integration test below. Newtype wrapper around
+    /// `Vec<Hash>` so the orphan rules let us implement the foreign
+    /// `HashReader` trait on it.
+    #[derive(Default)]
+    struct TestHashStorage(Vec<Hash>);
+
+    impl TestHashStorage {
+        fn new() -> Self {
+            Self::default()
+        }
+        fn extend<I: IntoIterator<Item = Hash>>(&mut self, iter: I) {
+            self.0.extend(iter);
+        }
+        fn iter(&self) -> std::slice::Iter<'_, Hash> {
+            self.0.iter()
+        }
+        fn len(&self) -> usize {
+            self.0.len()
+        }
+    }
+
+    impl HashReader for TestHashStorage {
+        fn read_hashes(&self, indexes: &[u64]) -> Result<Vec<Hash>, TlogError> {
+            // It's not required by HashReader that indexes be in increasing order,
+            // but check that the functions we are testing only ever ask for
+            // indexes in increasing order.
+            let mut prev_index = 0;
+            for (i, &index) in indexes.iter().enumerate() {
+                if i != 0 && index <= prev_index {
+                    return Err(TlogError::IndexesOutOfOrder);
+                }
+                prev_index = index;
+            }
+
+            let mut out = Vec::with_capacity(indexes.len());
+            for &index in indexes {
+                out.push(self.0[usize::try_from(index).unwrap()]);
+            }
+            Ok(out)
+        }
+    }
+
+    /// `TileReader` impl backed by an in-memory `HashMap<Tile, Vec<u8>>`.
+    /// Counts how many tiles are read but not saved so the integration
+    /// test below can pin the "must save tiles" invariant.
+    #[derive(Default, Debug)]
+    struct TestTilesStorage {
+        // Make use of interior mutability here to avoid needing to make struct mutable for tests:
+        // https://ricardomartins.cc/2016/06/08/interior-mutability
+        unsaved: Cell<usize>,
+        m: HashMap<Tile, Vec<u8>>,
+    }
+
+    impl TileReader for TestTilesStorage {
+        fn height(&self) -> u8 {
+            2
+        }
+
+        fn save_tiles(&self, tiles: &[Tile], _data: &[Vec<u8>]) {
+            let new_size = self.unsaved.get() - tiles.len();
+            self.unsaved.set(new_size);
+        }
+
+        fn read_tiles(&self, tiles: &[Tile]) -> Result<Vec<Vec<u8>>, TlogError> {
+            let mut out = Vec::with_capacity(tiles.len());
+            for tile in tiles {
+                if let Some(data) = self.m.get(tile) {
+                    out.push(data.clone());
+                } else {
+                    panic!("tile {tile:?} not found in map");
+                }
+            }
+            let new_size = self.unsaved.get() + tiles.len();
+            self.unsaved.set(new_size);
+            Ok(out)
+        }
+    }
+
+    /// Cross-crate integration test: exercises the [`tlog`] math layer
+    /// (`stored_hashes`, `tree_hash`, `inclusion_proof`,
+    /// `consistency_proof`, the `subtree_*` variants) against the
+    /// tile-encoded storage layer (`Tile`, `TileReader`,
+    /// `TileHashReader`) for trees of size 0..100.
+    #[allow(clippy::too_many_lines)]
+    #[test]
+    fn test_tree() {
+        const TEST_H: u8 = 2;
+
+        let mut trees = Vec::new();
+        let mut leafhashes = Vec::new();
+        let mut storage = TestHashStorage::new();
+        let mut tiles = HashMap::<Tile, Vec<u8>>::new();
+
+        for i in 0..100 {
+            let data = format!("leaf {i}");
+            let hashes = stored_hashes(i, data.as_bytes(), &storage).unwrap();
+
+            leafhashes.push(record_hash(data.as_bytes()));
+            let old_storage_len = storage.len();
+            storage.extend(hashes);
+
+            assert_eq!(stored_hash_count(i + 1), storage.len() as u64);
+
+            let th = tree_hash(i + 1, &storage).unwrap();
+
+            for tile in Tile::new_tiles(TEST_H, i, i + 1) {
+                let data = tile.read_data(&storage).unwrap();
+                let default = Vec::new();
+                let old_data = if tile.width() > 1 {
+                    let old = Tile::new(
+                        tile.height(),
+                        tile.level(),
+                        tile.level_index(),
+                        tile.width() - 1,
+                        None,
+                    );
+                    tiles.get(&old).unwrap_or(&default)
+                } else {
+                    &default
+                };
+                assert!(
+                    old_data.len() == data.len() - HASH_SIZE && *old_data == data[..old_data.len()],
+                    "tile {tile:?} not extending old tile"
+                );
+                tiles.insert(tile, data);
+            }
+
+            for tile in Tile::new_tiles(TEST_H, 0, i + 1) {
+                let data = tile.read_data(&storage).unwrap();
+                assert_eq!(tiles[&tile], data, "mismatch at {tile:?}");
+            }
+
+            for tile in Tile::new_tiles(TEST_H, i / 2, i + 1) {
+                let data = tile.read_data(&storage).unwrap();
+                assert_eq!(tiles[&tile], data, "mismatch at {tile:?}");
+            }
+
+            // Check that all the new hashes are readable from their tiles.
+            for (j, stored_hash) in storage.iter().enumerate().skip(old_storage_len) {
+                let tile = Tile::from_index(TEST_H, j as u64);
+                let data = tiles.get(&tile).cloned().unwrap();
+                let h = tile.hash_at_index(&data, j as u64).unwrap();
+                assert_eq!(h, *stored_hash);
+            }
+
+            trees.push(th);
+
+            // Check that inclusion proofs work, for all trees and leaves so far.
+            for j in 0..=i {
+                let mut p = inclusion_proof(i + 1, j, &storage).unwrap();
+                verify_inclusion_proof(&p, i + 1, th, j, leafhashes[usize::try_from(j).unwrap()])
+                    .unwrap();
+
+                for k in 0..p.len() {
+                    p[k].0[0] ^= 1;
+                    assert!(
+                        verify_inclusion_proof(
+                            &p,
+                            i + 1,
+                            th,
+                            j,
+                            leafhashes[usize::try_from(j).unwrap()]
+                        )
+                        .is_err(),
+                        "verify_inclusion_proof({}, {j}) succeeded with corrupt proof hash #{k}!",
+                        i + 1
+                    );
+                    p[k].0[0] ^= 1;
+                }
+            }
+
+            // Check that inclusion proofs work using TileReader.
+            let tile_storage = TestTilesStorage {
+                m: tiles.clone(),
+                unsaved: Cell::new(0),
+            };
+            let thr = TileHashReader::new(i + 1, th, &tile_storage);
+            for j in 0..=i {
+                let h = thr.read_hashes(&[stored_hash_index(0, j)]).unwrap();
+                assert_eq!(h.len(), 1, "bad read_hashes implementation");
+                assert_eq!(h[0], leafhashes[usize::try_from(j).unwrap()], "wrong hash");
+
+                // Even though reading the hash suffices, check we can generate the proof too.
+                let p = inclusion_proof(i + 1, j, &thr).unwrap();
+                verify_inclusion_proof(&p, i + 1, th, j, leafhashes[usize::try_from(j).unwrap()])
+                    .unwrap();
+            }
+            assert_eq!(tile_storage.unsaved.get(), 0, "did not save tiles");
+
+            // Check that ReadHashes will give an error if the index is not in the tree.
+            assert!(
+                thr.read_hashes(&[(i + 1) * 2]).is_err(),
+                "read_hashes returned non-err for index not in tree, want err"
+            );
+
+            assert_eq!(tile_storage.unsaved.get(), 0, "did not save tiles");
+
+            // Check that consistency proofs work, for all trees so far, using TileReader.
+            for j in 0..=i {
+                let h = tree_hash(j + 1, &thr).unwrap();
+                assert_eq!(h, trees[usize::try_from(j).unwrap()]);
+
+                // Even though computing the subtree hash suffices, check that we can generate the proof too.
+                let mut p = consistency_proof(i + 1, j + 1, &thr).unwrap();
+                verify_consistency_proof(&p, i + 1, th, j + 1, trees[usize::try_from(j).unwrap()])
+                    .unwrap();
+                for k in 0..p.len() {
+                    p[k].0[0] ^= 1;
+                    assert!(
+                        verify_consistency_proof(
+                            &p,
+                            i + 1,
+                            th,
+                            j + 1,
+                            trees[usize::try_from(j).unwrap()]
+                        )
+                        .is_err(),
+                        "verify_consistency_proof({}, {j}) succeeded with corrupt proof hash #{k}!",
+                        i + 1
+                    );
+                    p[k].0[0] ^= 1;
+                }
+            }
+            assert_eq!(tile_storage.unsaved.get(), 0, "did not save tiles");
+
+            // Check that subtree consistency proofs work, for all valid subtrees up to the current tree size.
+            for lo in 0..i {
+                let max_hi = if lo == 0 {
+                    u64::MAX
+                } else {
+                    // If `lo` is non-zero, find the maximum power of 2 that divides `lo`.
+                    // This is a bitwise trick that isolates the lowest set bit.
+                    let max_size = lo & lo.wrapping_neg();
+                    lo + max_size
+                };
+                for hi in lo + 1..=i.min(max_hi) {
+                    let m = Subtree::new(lo, hi).unwrap();
+                    let m_hash = subtree_hash(&m, &storage).unwrap();
+                    // Prove that the subtree is consistent with the tree of size `n`.
+                    verify_subtree_consistency_proof(
+                        &subtree_consistency_proof(i + 1, &m, &storage).unwrap(),
+                        i + 1,
+                        th,
+                        &m,
+                        m_hash,
+                    )
+                    .unwrap();
+                    for leaf_index in lo..hi {
+                        let proof = subtree_inclusion_proof(&m, leaf_index, &storage).unwrap();
+                        let leaf_hash = leafhashes[usize::try_from(leaf_index).unwrap()];
+                        // Prove that each leaf in the subtree is included in the subtree.
+                        verify_subtree_inclusion_proof(&proof, &m, m_hash, leaf_index, leaf_hash)
+                            .unwrap();
+                        // The evaluator returns the subtree hash, which must
+                        // match the committed `m_hash`. This is the
+                        // counterpart used by cosignature verifiers that
+                        // reconstruct the subtree hash from an inclusion
+                        // proof instead of being handed it directly.
+                        let evaluated =
+                            evaluate_subtree_inclusion_proof(&proof, &m, leaf_index, leaf_hash)
+                                .unwrap();
+                        assert_eq!(evaluated, m_hash);
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_new_tiles_for_size() {

--- a/crates/tlog_tiles_wasm/Cargo.toml
+++ b/crates/tlog_tiles_wasm/Cargo.toml
@@ -18,6 +18,7 @@ ignored = ["getrandom"]
 crate-type = ["cdylib"]
 
 [dependencies]
+tlog_core = { workspace = true }
 tlog_tiles = { workspace = true }
 wasm-bindgen = { workspace = true }
 console_error_panic_hook = { workspace = true }

--- a/crates/tlog_tiles_wasm/src/lib.rs
+++ b/crates/tlog_tiles_wasm/src/lib.rs
@@ -118,18 +118,18 @@ pub fn verify_consistency_proof(
         )));
     }
 
-    let proof: Vec<tlog_tiles::Hash> = proof_hashes
+    let proof: Vec<tlog_core::Hash> = proof_hashes
         .chunks_exact(32)
-        .map(|chunk| tlog_tiles::Hash(chunk.try_into().unwrap()))
+        .map(|chunk| tlog_core::Hash(chunk.try_into().unwrap()))
         .collect();
 
     // Underlying API: (proof, n=new_size, root_hash=new_root, m=old_size, m_hash=old_root)
-    tlog_tiles::verify_consistency_proof(
+    tlog_core::verify_consistency_proof(
         &proof,
         new_size,
-        tlog_tiles::Hash(new_root.try_into().unwrap()),
+        tlog_core::Hash(new_root.try_into().unwrap()),
         old_size,
-        tlog_tiles::Hash(old_root.try_into().unwrap()),
+        tlog_core::Hash(old_root.try_into().unwrap()),
     )
     .map_err(|e| JsValue::from_str(&e.to_string()))
 }

--- a/crates/tlog_witness/Cargo.toml
+++ b/crates/tlog_witness/Cargo.toml
@@ -18,4 +18,4 @@ crate-type = ["rlib"]
 base64.workspace = true
 signed_note.workspace = true
 thiserror.workspace = true
-tlog_tiles.workspace = true
+tlog_core.workspace = true

--- a/crates/tlog_witness/src/add_checkpoint.rs
+++ b/crates/tlog_witness/src/add_checkpoint.rs
@@ -28,7 +28,7 @@
 
 use base64::prelude::*;
 use signed_note::{Note, NoteSignature};
-use tlog_tiles::{Hash, HASH_SIZE};
+use tlog_core::{Hash, HASH_SIZE};
 
 /// Maximum number of consistency-proof lines a client may send, per
 /// [c2sp.org/tlog-witness#add-checkpoint](https://c2sp.org/tlog-witness#add-checkpoint).

--- a/crates/tlog_witness/src/lib.rs
+++ b/crates/tlog_witness/src/lib.rs
@@ -31,7 +31,7 @@
 //!   handled by [`tlog_cosignature::CosignatureV1CheckpointSigner`] (or any
 //!   other [`tlog_tiles::CheckpointSigner`] impl).
 //! - Consistency-proof verification: use
-//!   [`tlog_tiles::verify_consistency_proof`] directly.
+//!   [`tlog_core::verify_consistency_proof`] directly.
 //! - Persistent state for the "latest cosigned checkpoint per origin" check
 //!   that [`add-checkpoint`][add] mandates — that is a deployment concern,
 //!   not a wire-format concern.

--- a/crates/witness_worker/Cargo.toml
+++ b/crates/witness_worker/Cargo.toml
@@ -40,6 +40,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 signed_note.workspace = true
+tlog_core.workspace = true
 tlog_cosignature.workspace = true
 tlog_tiles.workspace = true
 tlog_witness.workspace = true

--- a/crates/witness_worker/src/frontend_worker.rs
+++ b/crates/witness_worker/src/frontend_worker.rs
@@ -203,7 +203,8 @@ async fn add_checkpoint(mut req: Request, env: Env) -> Result<Response> {
     // `NoteError` variants indicate a syntactically malformed signature
     // line and are surfaced as `400 Bad Request`.
     //
-    // `tlog_tiles::open_checkpoint` is deliberately not used here because
+    // `tlog_tiles::open_checkpoint` (in the c2sp.org/tlog-checkpoint slice
+    // of `tlog_tiles`) is deliberately not used here because
     // it additionally requires *every* configured verifier to sign — the
     // full-coverage semantics an issuer or monitor wants, but not a
     // witness: a log rotating keys may have multiple trusted public keys

--- a/crates/witness_worker/src/witness_state_do.rs
+++ b/crates/witness_worker/src/witness_state_do.rs
@@ -41,7 +41,7 @@
 //! [add]: https://c2sp.org/tlog-witness#add-checkpoint
 
 use serde::{Deserialize, Serialize};
-use tlog_tiles::{verify_consistency_proof, Hash};
+use tlog_core::{verify_consistency_proof, Hash};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
@@ -199,7 +199,7 @@ pub(crate) fn state_stub(env: &Env, origin: &str) -> Result<Stub> {
 // ---------------------------------------------------------------------------
 mod hash_hex {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use tlog_tiles::{Hash, HASH_SIZE};
+    use tlog_core::{Hash, HASH_SIZE};
 
     pub fn serialize<S>(h: &Hash, ser: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -233,7 +233,7 @@ mod hash_hex {
 mod hash_vec_hex {
     use super::hash_hex::from_hex;
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use tlog_tiles::Hash;
+    use tlog_core::Hash;
 
     pub fn serialize<S>(v: &[Hash], ser: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -259,7 +259,7 @@ mod hash_vec_hex {
 #[cfg(test)]
 mod tests {
     use super::{CheckAndUpdateRequest, LatestCheckpoint};
-    use tlog_tiles::{Hash, HASH_SIZE};
+    use tlog_core::{Hash, HASH_SIZE};
 
     /// Pin the on-disk JSON layout of `LatestCheckpoint`. Changing this
     /// format would make already-deployed witnesses unable to read their


### PR DESCRIPTION
First slice of #230. Extract the RFC 6962 Merkle math from `tlog_tiles` into a new `tlog_core` crate so `tlog_tiles` is closer to the [c2sp.org/tlog-tiles](https://c2sp.org/tlog-tiles) HTTP wire format only.

Closes neither slice 2 (`checkpoint.rs` → `tlog_checkpoint`) nor slice 3 (`entries.rs` → `generic_log_worker`); those land in follow-ups.

## What moves

| Symbol | Old home | New home |
| --- | --- | --- |
| `Hash`, `HASH_SIZE`, `EMPTY_HASH`, `Proof`, `HashReader`, `Subtree` | `tlog_tiles::tlog` | `tlog_core` |
| `LeafIndex` | `tlog_tiles::entries` | `tlog_core` |
| `record_hash`, `node_hash`, `stored_hash_*` | `tlog_tiles::tlog` | `tlog_core` |
| `tree_hash` + `_indexes`, `subtree_hash` + `_indexes` | `tlog_tiles::tlog` | `tlog_core` |
| `inclusion_proof` + `_indexes`, `subtree_inclusion_proof` + `_indexes`, `evaluate_subtree_inclusion_proof` | `tlog_tiles::tlog` | `tlog_core` |
| `consistency_proof` + `_indexes`, `subtree_consistency_proof` + `_indexes` | `tlog_tiles::tlog` | `tlog_core` |
| `verify_inclusion_proof`, `verify_subtree_inclusion_proof`, `verify_consistency_proof`, `verify_subtree_consistency_proof` | `tlog_tiles::tlog` | `tlog_core` |
| `TlogError` (math-only variants) | `tlog_tiles::tlog` | `tlog_core` |

## What stays in `tlog_tiles` for now

- `tile.rs` — the c2sp.org/tlog-tiles wire format itself.
- `checkpoint.rs` — c2sp.org/tlog-checkpoint (slice 2 will move it).
- `entries.rs` — `LogEntry`/`PendingLogEntry` traits + `UnixTimestamp`/`LookupKey` aliases (slice 3 will move worker abstractions).

## Cleanups in `tlog_tiles`

- New `CheckpointError` type for `open_checkpoint` and `TreeWithTimestamp::sign`. Variants: `MissingVerifierSignature`, `InvalidTimestamp`, `OriginMismatch`, `Note(NoteError)`, `MalformedCheckpoint`, `Tlog(TlogError)`. These were previously variants on `tlog_tiles::TlogError` even though they're not math errors.
- `Ed25519CheckpointSigner::new` is now infallible (`-> Self` instead of `-> Result<Self, TlogError>`); it never actually errored.
- `TlogTilesPendingLogEntry::ParseError` is `std::io::Error` directly (was `TlogError`); the io error was the only failure path.

## Crate-name choice

`tlog` is taken on crates.io by an unmaintained logging crate. `tlog_core` follows the local workspace convention (snake_case) and conveys the role accurately ("core primitives below the spec crates"). Other candidates considered: `merkle_tlog`, `cf_tlog`, `tlog_proofs`.

## Migration

Every internal consumer (`tlog_witness`, `tlog_cosignature`, `static_ct_api`, `bootstrap_mtc_api`, `bootstrap_mtc_worker`, `ct_worker`, `generic_log_worker`, `witness_worker`, `tlog_tiles_wasm`, `integration_tests`) imports moved symbols from `tlog_core` directly. `tlog_witness` no longer depends on `tlog_tiles` at all.

The `fuzz` crate is unchanged — it already used deep-path imports (`tlog_tiles::tile::Tile`, `tlog_tiles::checkpoint::CheckpointText`).

## Test relocations

- `test_tree` integration test (math + tile encoding) moved from `tlog_tiles/src/tlog.rs` to `tlog_tiles/src/tile.rs` together with the `TestTilesStorage` helper, since it depends on `Tile`/`TileReader`/`TileHashReader`.
- Pure-math unit tests (`test_split_stored_hash_index`, `test_new_subtree`, `test_evaluate_subtree_inclusion_proof_rejects_out_of_range`, `test_verify_inclusion_proof_rejects_zero_tree_size`, `test_empty_tree`, `test_subtrees_split_interval`) stayed in `tlog_core`.

## Stats

42 files changed, +641 / −359. The bulk:
- New `tlog_core` crate scaffolding (`Cargo.toml`, `LICENSE`, `README`).
- The moved `tlog.rs` → `tlog_core/src/lib.rs` (file rename, ~80% similarity preserved per `git mv`).
- Moved `test_tree` test (~286 lines now in `tlog_tiles/src/tile.rs`).
- The `LeafIndex` relocation + the `CheckpointError` refactor.
- Mechanical import-path updates across 10 consumer crates.

## Pre-push checks

All four pass:

- `cargo clippy --workspace --all-targets -- -Dwarnings -Dclippy::pedantic`
- `cargo test` (29 test result blocks ok, including all 6 pure-math tests in `tlog_core` and the relocated `test_tree`)
- `cargo fmt --all --check`
- `cargo machete`

WASM build also clean (`cargo check -p witness_worker --target wasm32-unknown-unknown`).

## Stacking

Independent of the in-flight witness PRs (#228, #229), based directly on `main`. Those branches will need rebasing onto this one's eventual merge to pick up the import path changes.

Refs #230.
