### PR TITLE
Migrate to axum::Router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +236,7 @@ dependencies = [
 name = "bootstrap_mtc_worker"
 version = "0.2.0"
 dependencies = [
+ "axum",
  "base64",
  "base64ct",
  "bootstrap_mtc_api",
@@ -216,6 +262,7 @@ dependencies = [
  "tlog_checkpoint",
  "tlog_core",
  "tlog_entry",
+ "tower-service",
  "url",
  "worker",
  "x509-cert",
@@ -569,6 +616,7 @@ dependencies = [
 name = "ct_worker"
 version = "0.2.0"
 dependencies = [
+ "axum",
  "base64",
  "base64ct",
  "chrono",
@@ -592,6 +640,7 @@ dependencies = [
  "tlog_checkpoint",
  "tlog_core",
  "tlog_entry",
+ "tower-service",
  "url",
  "worker",
  "x509-cert",
@@ -1684,6 +1733,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +2683,17 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
  "serde",
  "serde_core",
 ]
@@ -3838,6 +3904,7 @@ dependencies = [
 name = "witness_worker"
 version = "0.2.0"
 dependencies = [
+ "axum",
  "base64",
  "console_error_panic_hook",
  "console_log",
@@ -3858,6 +3925,7 @@ dependencies = [
  "tlog_core",
  "tlog_cosignature",
  "tlog_witness",
+ "tower-service",
  "witness_worker_config",
  "worker",
 ]
@@ -3879,6 +3947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "244647fd7673893058f91f22a0eabd0f45bb50298e995688cb0c4b9837081b19"
 dependencies = [
  "async-trait",
+ "axum",
  "bytes",
  "chrono",
  "futures-channel",
@@ -3886,7 +3955,7 @@ dependencies = [
  "http",
  "http-body",
  "js-sys",
- "matchit",
+ "matchit 0.7.3",
  "pin-project",
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ debug = 1
 
 [workspace.dependencies]
 anyhow = "1.0"
+axum = { version = "0.8", default-features = false, features = ["json"] }
 base64 = "0.22"
 base64ct = "1.8.0"
 bitcode = { version = "0.6.6", features = ["serde"] }
@@ -137,6 +138,7 @@ tlog_entry = { path = "crates/tlog_entry", version = "0.2.0" }
 tlog_tiles = { path = "crates/tlog_tiles", version = "0.2.0" }
 tlog_witness = { path = "crates/tlog_witness", version = "0.2.0" }
 tokio = { version = "1", features = ["sync"] }
+tower-service = "0.3.3"
 reqwest = { version = "0.12", features = ["json"] }
 url = "2.2"
 wasm-bindgen = "0.2"

--- a/crates/bootstrap_mtc_worker/Cargo.toml
+++ b/crates/bootstrap_mtc_worker/Cargo.toml
@@ -43,6 +43,7 @@ parking_lot.workspace = true
 futures-executor.workspace = true
 
 [dependencies]
+axum.workspace = true
 base64.workspace = true
 base64ct.workspace = true
 chrono.workspace = true
@@ -61,7 +62,8 @@ signed_note.workspace = true
 tlog_core.workspace = true
 tlog_entry.workspace = true
 tlog_checkpoint.workspace = true
-worker.workspace = true
+tower-service.workspace = true
+worker = { workspace = true, features = ["http", "axum"] }
 x509-cert.workspace = true
 x509_util.workspace = true
 bootstrap_mtc_api.workspace = true

--- a/crates/bootstrap_mtc_worker/src/frontend_worker.rs
+++ b/crates/bootstrap_mtc_worker/src/frontend_worker.rs
@@ -107,156 +107,25 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
             // handle the request.
             Router::with_data(name)
                 .get_async("/logs/:log/get-roots", |_req, ctx| async move {
-                    Response::from_json(&GetRootsResponse {
-                        certificates: x509_util::certs_to_bytes(
-                            &load_roots(&ctx.env, ctx.data).await?.certs,
-                        )
-                        .unwrap(),
-                    })
+                    get_roots(&ctx.env, ctx.data).await
                 })
                 .post_async("/logs/:log/add-entry", |req, ctx| async move {
                     add_entry(req, &ctx.env, ctx.data).await
                 })
-                .post_async("/logs/:log/get-certificate", |mut req, ctx| async move {
-                    let name = ctx.data;
-                    let params = &CONFIG.logs[name];
-                    let Ok(GetCertificateRequest {
-                        leaf_index,
-                        spki_der,
-                    }) = req.json().await
-                    else {
-                        return Response::error("Unexpected input", 400);
-                    };
-                    let object_backend = ObjectBucket::new(load_public_bucket(&ctx.env, name)?);
-                    // Fetch the current checkpoint to know which tiles to fetch
-                    // (full or partials).
-                    let (checkpoint, _checkpoint_bytes) =
-                        get_current_checkpoint(&ctx.env, name, &object_backend).await?;
-                    if leaf_index >= checkpoint.size() {
-                        return Response::error("Leaf index is not in log", 422);
-                    }
-
-                    let seq = get_landmark_sequence(name, &object_backend).await?;
-                    if leaf_index < seq.first_index() {
-                        return Response::error("Leaf index is before first active landmark", 422);
-                    }
-                    let Some((landmark_id, landmark_subtree)) = seq.subtree_for_index(leaf_index)
-                    else {
-                        // The leaf index might be between the latest landmark
-                        // and the current tree size. Set Retry-After to the
-                        // expected time for the next landmark so the client can
-                        // try again later.
-                        let headers = Headers::new();
-                        let i = params.landmark_interval_secs as u64;
-                        headers
-                            .set("Retry-After", &format!("{}", i - (now_millis() / 1000) % i))?;
-                        return Response::error("Leaf index will be covered by next landmark", 503)
-                            .map(|r| r.with_headers(headers));
-                    };
-
-                    // Fetch the log entry for the leaf index.
-                    let log_entry = read_leaf::<BootstrapMtcLogEntry>(
-                        &object_backend,
-                        leaf_index,
-                        checkpoint.size(),
-                        checkpoint.hash(),
-                    )
-                    .await
-                    .map_err(|e| e.to_string())?;
-
-                    // Get the inclusion proof.
-                    let proof = match prove_subtree_inclusion(
-                        checkpoint.size(),
-                        *checkpoint.hash(),
-                        landmark_subtree.lo(),
-                        landmark_subtree.hi(),
-                        leaf_index,
-                        &object_backend,
-                    )
-                    .await
-                    {
-                        Ok(p) => p,
-                        Err(ProofError::Tlog(s)) => return Response::error(s.to_string(), 422),
-                        Err(ProofError::Other(e)) => return Err(e.to_string().into()),
-                    };
-
-                    // Construct the signatureless certificate.
-                    let data = match serialize_signatureless_cert(
-                        &log_entry,
-                        leaf_index,
-                        &spki_der,
-                        &landmark_subtree,
-                        proof,
-                    ) {
-                        Ok(data) => data,
-                        Err(e) => {
-                            return Response::error(
-                                format!("Failed to serialize signatureless cert: {e}"),
-                                422,
-                            )
-                        }
-                    };
-
-                    Response::from_json(&GetCertificateResponse { data, landmark_id })
+                .post_async("/logs/:log/get-certificate", |req, ctx| async move {
+                    get_certificate(req, &ctx.env, ctx.data).await
                 })
                 .get_async("/logs/:log/get-landmark-bundle", |_req, ctx| async move {
                     get_landmark_bundle(&ctx.env, ctx.data).await
                 })
                 .get("/logs/:log/metadata", |_req, ctx| {
-                    let name = ctx.data;
-                    let params = &CONFIG.logs[name];
-                    let cosigner = load_checkpoint_cosigner(&ctx.env, name);
-                    Response::from_json(&MetadataResponse {
-                        description: &params.description,
-                        log_id: cosigner.log_id().to_string(),
-                        cosigner_id: cosigner.cosigner_id().to_string(),
-                        cosigner_public_key: cosigner.verifying_key(),
-                        submission_url: &params.submission_url,
-                        monitoring_url: if params.monitoring_url.is_empty() {
-                            &params.submission_url
-                        } else {
-                            &params.monitoring_url
-                        },
-                    })
+                    metadata(&ctx.env, ctx.data)
                 })
                 .get("/logs/:log/sequencer_id", |_req, ctx| {
-                    // Print out the Durable Object ID of the sequencer to allow
-                    // looking it up in internal Cloudflare dashboards. This
-                    // value does not need to be kept secret.
-                    let name = ctx.data;
-                    let namespace = ctx.env.durable_object("SEQUENCER")?;
-                    let object_id = namespace.id_from_name(name)?;
-                    Response::ok(object_id.to_string())
+                    sequencer_id(&ctx.env, ctx.data)
                 })
                 .get_async("/logs/:log/*key", |_req, ctx| async move {
-                    let name = ctx.data;
-                    let key = ctx.param("key").unwrap();
-
-                    // Enable direct access to the bucket via the Worker if
-                    // monitoring_url is unspecified.
-                    if CONFIG.logs[name].monitoring_url.is_empty() {
-                        let bucket = load_public_bucket(&ctx.env, name)?;
-                        if let Some(obj) = bucket.get(key).execute().await? {
-                            Response::from_body(
-                                obj.body()
-                                    .ok_or("R2 object missing body")?
-                                    .response_body()?,
-                            )
-                            .map(|r| {
-                                r.with_headers(headers_from_http_metadata(obj.http_metadata()))
-                            })
-                        } else {
-                            Response::error("Not found", 404)
-                        }
-                    } else {
-                        Response::error(
-                            format!(
-                                "Use {} for monitoring API",
-                                CONFIG.logs[name].monitoring_url
-                            ),
-                            404,
-                        )
-                    }
+                    get_object(&ctx.env, ctx.data, ctx.param("key").unwrap()).await
                 })
                 .run(req, ctx.env)
                 .await
@@ -276,6 +145,145 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
         ctx.wait_until(async move { wshim.flush(&generic_log_worker::obs::logs::LOGGER).await });
     }
     response
+}
+
+/// `GET /logs/:log/get-roots`
+async fn get_roots(env: &Env, name: &str) -> Result<Response> {
+    Response::from_json(&GetRootsResponse {
+        certificates: x509_util::certs_to_bytes(&load_roots(env, name).await?.certs).unwrap(),
+    })
+}
+
+/// `POST /logs/:log/get-certificate`
+async fn get_certificate(mut req: Request, env: &Env, name: &str) -> Result<Response> {
+    let params = &CONFIG.logs[name];
+    let Ok(GetCertificateRequest {
+        leaf_index,
+        spki_der,
+    }) = req.json().await
+    else {
+        return Response::error("Unexpected input", 400);
+    };
+    let object_backend = ObjectBucket::new(load_public_bucket(env, name)?);
+    // Fetch the current checkpoint to know which tiles to fetch
+    // (full or partials).
+    let (checkpoint, _checkpoint_bytes) =
+        get_current_checkpoint(env, name, &object_backend).await?;
+    if leaf_index >= checkpoint.size() {
+        return Response::error("Leaf index is not in log", 422);
+    }
+
+    let seq = get_landmark_sequence(name, &object_backend).await?;
+    if leaf_index < seq.first_index() {
+        return Response::error("Leaf index is before first active landmark", 422);
+    }
+    let Some((landmark_id, landmark_subtree)) = seq.subtree_for_index(leaf_index) else {
+        // The leaf index might be between the latest landmark and the current
+        // tree size. Set Retry-After to the expected time for the next landmark
+        // so the client can try again later.
+        let headers = Headers::new();
+        let i = params.landmark_interval_secs as u64;
+        headers.set("Retry-After", &format!("{}", i - (now_millis() / 1000) % i))?;
+        return Response::error("Leaf index will be covered by next landmark", 503)
+            .map(|r| r.with_headers(headers));
+    };
+
+    // Fetch the log entry for the leaf index.
+    let log_entry = read_leaf::<BootstrapMtcLogEntry>(
+        &object_backend,
+        leaf_index,
+        checkpoint.size(),
+        checkpoint.hash(),
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+
+    // Get the inclusion proof.
+    let proof = match prove_subtree_inclusion(
+        checkpoint.size(),
+        *checkpoint.hash(),
+        landmark_subtree.lo(),
+        landmark_subtree.hi(),
+        leaf_index,
+        &object_backend,
+    )
+    .await
+    {
+        Ok(p) => p,
+        Err(ProofError::Tlog(s)) => return Response::error(s.to_string(), 422),
+        Err(ProofError::Other(e)) => return Err(e.to_string().into()),
+    };
+
+    // Construct the signatureless certificate.
+    let data = match serialize_signatureless_cert(
+        &log_entry,
+        leaf_index,
+        &spki_der,
+        &landmark_subtree,
+        proof,
+    ) {
+        Ok(data) => data,
+        Err(e) => {
+            return Response::error(format!("Failed to serialize signatureless cert: {e}"), 422)
+        }
+    };
+
+    Response::from_json(&GetCertificateResponse { data, landmark_id })
+}
+
+/// `GET /logs/:log/metadata`
+fn metadata(env: &Env, name: &str) -> Result<Response> {
+    let params = &CONFIG.logs[name];
+    let cosigner = load_checkpoint_cosigner(env, name);
+    Response::from_json(&MetadataResponse {
+        description: &params.description,
+        log_id: cosigner.log_id().to_string(),
+        cosigner_id: cosigner.cosigner_id().to_string(),
+        cosigner_public_key: cosigner.verifying_key(),
+        submission_url: &params.submission_url,
+        monitoring_url: if params.monitoring_url.is_empty() {
+            &params.submission_url
+        } else {
+            &params.monitoring_url
+        },
+    })
+}
+
+/// `GET /logs/:log/sequencer_id`
+fn sequencer_id(env: &Env, name: &str) -> Result<Response> {
+    // Print out the Durable Object ID of the sequencer to allow looking it up
+    // in internal Cloudflare dashboards. This value does not need to be secret.
+    let namespace = env.durable_object("SEQUENCER")?;
+    let object_id = namespace.id_from_name(name)?;
+    Response::ok(object_id.to_string())
+}
+
+/// `GET /logs/:log/*key` -- direct read-through to the public R2 bucket when
+/// the log's `monitoring_url` is unspecified.
+async fn get_object(env: &Env, name: &str, key: &str) -> Result<Response> {
+    // Enable direct access to the bucket via the Worker if monitoring_url is
+    // unspecified.
+    if CONFIG.logs[name].monitoring_url.is_empty() {
+        let bucket = load_public_bucket(env, name)?;
+        if let Some(obj) = bucket.get(key).execute().await? {
+            Response::from_body(
+                obj.body()
+                    .ok_or("R2 object missing body")?
+                    .response_body()?,
+            )
+            .map(|r| r.with_headers(headers_from_http_metadata(obj.http_metadata())))
+        } else {
+            Response::error("Not found", 404)
+        }
+    } else {
+        Response::error(
+            format!(
+                "Use {} for monitoring API",
+                CONFIG.logs[name].monitoring_url
+            ),
+            404,
+        )
+    }
 }
 
 /// Builds the issuer RDN with the trust anchor ID.

--- a/crates/bootstrap_mtc_worker/src/frontend_worker.rs
+++ b/crates/bootstrap_mtc_worker/src/frontend_worker.rs
@@ -20,7 +20,7 @@ use generic_log_worker::{
     log_ops::{prove_subtree_inclusion, read_leaf, ProofError, CHECKPOINT_KEY},
     obs::Wshim,
     serialize,
-    util::now_millis,
+    util::{now_millis, WorkerByteStream},
     ObjectBackend, ObjectBucket, ENTRY_ENDPOINT,
 };
 use serde::{Deserialize, Serialize};
@@ -32,13 +32,21 @@ use tlog_core::LeafIndex;
 use tlog_entry::{PendingLogEntry, PendingLogEntryBlob};
 #[allow(clippy::wildcard_imports)]
 use worker::*;
+
+use axum::{
+    body::Bytes,
+    extract::{Path, State},
+    http::{header, HeaderMap, StatusCode},
+    response::{AppendHeaders, IntoResponse},
+    routing::{get, post},
+    Json, Router,
+};
+use tower_service::Service;
 use x509_cert::{
     attr::AttributeTypeAndValue,
     name::{RdnSequence, RelativeDistinguishedName},
     time::{Time, Validity},
 };
-
-const UNKNOWN_LOG_MSG: &str = "unknown log";
 
 #[serde_as]
 #[derive(Serialize)]
@@ -82,110 +90,330 @@ fn start() {
 ///
 /// # Errors
 ///
-/// Returns an error if any unhandled internal errors occur while processing the request.
-///
-/// # Panics
-///
-/// Panics if there are issues parsing route parameters, which should never happen.
+/// Returns an error if any unhandled internal error occurs while processing the
+/// request.
 #[event(fetch, respond_with_errors)]
-async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
+async fn main(
+    req: HttpRequest,
+    env: Env,
+    ctx: Context,
+) -> Result<axum::http::Response<axum::body::Body>> {
     let wshim = Wshim::from_env(&env);
-    // Use an outer router as middleware to check that the log name is valid.
     let response = Router::new()
-        .or_else_any_method_async("/logs/:log/*route", |req, ctx| async move {
-            let name = if let Some(name) = ctx.param("log") {
-                if CONFIG.logs.contains_key(name) {
-                    &name.clone()
-                } else {
-                    return Err(UNKNOWN_LOG_MSG.into());
-                }
-            } else {
-                return Err("missing 'log' route param".into());
-            };
-
-            // Now that we've validated the log name, use an inner router to
-            // handle the request.
-            Router::with_data(name)
-                .get_async("/logs/:log/get-roots", |_req, ctx| async move {
-                    get_roots(&ctx.env, ctx.data).await
-                })
-                .post_async("/logs/:log/add-entry", |req, ctx| async move {
-                    add_entry(req, &ctx.env, ctx.data).await
-                })
-                .post_async("/logs/:log/get-certificate", |req, ctx| async move {
-                    get_certificate(req, &ctx.env, ctx.data).await
-                })
-                .get_async("/logs/:log/get-landmark-bundle", |_req, ctx| async move {
-                    get_landmark_bundle(&ctx.env, ctx.data).await
-                })
-                .get("/logs/:log/metadata", |_req, ctx| {
-                    metadata(&ctx.env, ctx.data)
-                })
-                .get("/logs/:log/sequencer_id", |_req, ctx| {
-                    sequencer_id(&ctx.env, ctx.data)
-                })
-                .get_async("/logs/:log/*key", |_req, ctx| async move {
-                    get_object(&ctx.env, ctx.data, ctx.param("key").unwrap()).await
-                })
-                .run(req, ctx.env)
-                .await
-        })
-        .run(req, env)
-        .await
-        .or_else(|e| match e {
-            Error::RustError(ref msg) if msg == UNKNOWN_LOG_MSG => {
-                Response::error("Unknown log", 400)
-            }
-            _ => {
-                log::warn!("Internal error: {e}");
-                Response::error("Internal error", 500)
-            }
-        });
+        .route("/logs/{log}/get-roots", get(get_roots))
+        .route("/logs/{log}/add-entry", post(add_entry))
+        .route("/logs/{log}/get-certificate", post(get_certificate))
+        .route("/logs/{log}/get-landmark-bundle", get(get_landmark_bundle))
+        .route("/logs/{log}/metadata", get(metadata))
+        .route("/logs/{log}/sequencer_id", get(sequencer_id))
+        .route("/logs/{log}/{*key}", get(get_object))
+        .with_state(env)
+        .call(req)
+        .await?;
     if let Ok(wshim) = wshim {
         ctx.wait_until(async move { wshim.flush(&generic_log_worker::obs::logs::LOGGER).await });
     }
-    response
+    Ok(response)
 }
 
-/// `GET /logs/:log/get-roots`
-async fn get_roots(env: &Env, name: &str) -> Result<Response> {
-    Response::from_json(&GetRootsResponse {
-        certificates: x509_util::certs_to_bytes(&load_roots(env, name).await?.certs).unwrap(),
-    })
+#[derive(serde::Deserialize)]
+struct PathParams<Rest> {
+    log: String,
+    #[serde(flatten)]
+    rest: Rest,
 }
 
-/// `POST /logs/:log/get-certificate`
-async fn get_certificate(mut req: Request, env: &Env, name: &str) -> Result<Response> {
-    let params = &CONFIG.logs[name];
+#[derive(serde::Deserialize)]
+struct Key {
+    key: String,
+}
+
+impl<T> axum::extract::FromRequestParts<Env> for PathParams<T>
+where
+    T: serde::de::DeserializeOwned + Send,
+{
+    type Rejection = AppError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &Env,
+    ) -> Result<Self, Self::Rejection> {
+        let Path(params) = Path::<PathParams<T>>::from_request_parts(parts, state)
+            .await
+            .map_err(|_| {
+                AppError::InternalServerError("path param does not have log field".into())
+            })?;
+        if CONFIG.logs.contains_key(&params.log) {
+            Ok(params)
+        } else {
+            Err(AppError::UnknownLog)
+        }
+    }
+}
+
+/// Result type for the route handlers: each builds a [`worker::Response`] which
+/// is converted into an axum response at the boundary via the worker crate's
+/// `axum` feature.
+type ApiResult<T> = std::result::Result<T, AppError>;
+
+enum AppError {
+    InternalServerError(String),
+    NotFound,
+    BadRequest(String),
+    UnknownLog,
+    FailedToSerializeSignaturelessCert(bootstrap_mtc_api::MtcError),
+    SubtreeInclusionProofFailed(tlog_core::TlogError),
+    LeafIndexBeforeFirstActiveLandmark,
+    LeafIndexNotInLog,
+    RedirectToMonitorApi(&'static str),
+    LeafIndexPendingLandmark { retry_after: u64 },
+}
+
+impl From<Error> for AppError {
+    fn from(err: Error) -> Self {
+        Self::InternalServerError(err.to_string())
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::InternalServerError(msg) => {
+                log::error!("Internal error: {msg}");
+                (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal error",
+                )
+                    .into_response()
+            }
+            AppError::NotFound => (StatusCode::NOT_FOUND, "Not Found").into_response(),
+            Self::BadRequest(e) => (
+                StatusCode::BAD_REQUEST,
+                format!("Bad request{}{e}", if e.is_empty() { "" } else { ": " }),
+            )
+                .into_response(),
+            Self::UnknownLog => {
+                (axum::http::StatusCode::BAD_REQUEST, "Unknown log").into_response()
+            }
+            Self::FailedToSerializeSignaturelessCert(e) => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                format!("Failed to serialize signatureless cert: {e}"),
+            )
+                .into_response(),
+            Self::SubtreeInclusionProofFailed(e) => {
+                (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response()
+            }
+            Self::LeafIndexBeforeFirstActiveLandmark => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "Leaf index is before first active landmark",
+            )
+                .into_response(),
+            Self::LeafIndexNotInLog => {
+                (StatusCode::UNPROCESSABLE_ENTITY, "Leaf index is not in log").into_response()
+            }
+            Self::LeafIndexPendingLandmark { retry_after } => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                AppendHeaders([(header::RETRY_AFTER, retry_after.to_string())]),
+                "Leaf index will be covered by next landmark",
+            )
+                .into_response(),
+            Self::RedirectToMonitorApi(url) => (
+                StatusCode::NOT_FOUND,
+                format!("Use {url} for monitoring API"),
+            )
+                .into_response(),
+        }
+    }
+}
+
+/// `GET /logs/{log}/get-roots`
+#[worker::send]
+async fn get_roots(
+    State(env): State<Env>,
+    PathParams { log, .. }: PathParams<()>,
+) -> ApiResult<impl IntoResponse> {
+    Ok((
+        StatusCode::OK,
+        Json(GetRootsResponse {
+            certificates: x509_util::certs_to_bytes(&load_roots(&env, &log).await?.certs).unwrap(),
+        }),
+    ))
+}
+
+/// `POST /logs/{log}/add-entry`
+#[worker::send]
+async fn add_entry(
+    State(env): State<Env>,
+    PathParams { log, .. }: PathParams<()>,
+    body: Bytes,
+) -> ApiResult<impl IntoResponse> {
+    let params = &CONFIG.logs[&log];
+    let req: AddEntryRequest =
+        serde_json::from_slice(&body).map_err(|e| AppError::BadRequest(e.to_string()))?;
+
+    let issuer = build_issuer_rdn(&params.log_id).map_err(AppError::BadRequest)?;
+    let mut validity = build_validity(now_millis(), params.max_certificate_lifetime_secs as u64)
+        .map_err(AppError::BadRequest)?;
+
+    let roots = load_roots(&env, &log).await?;
+    let (pending_entry, found_root_idx) =
+        match bootstrap_mtc_api::validate_chain(&req.chain, roots, &issuer, &mut validity) {
+            Ok(v) => v,
+            Err(e) => {
+                log::warn!("{log}: Bad request: {e}");
+                return Err(AppError::BadRequest(String::new()));
+            }
+        };
+
+    // SCT validation (if enabled for this log shard)
+    if params.enable_sct_validation {
+        use crate::ct_logs_cron::load_ct_logs;
+        use sct_validator::{SctValidationResult, SctValidator};
+
+        // Load the CT log list from KV
+        let ct_logs = load_ct_logs(&env).await?;
+        let validator = SctValidator::new(ct_logs);
+
+        // Get leaf and issuer DER for SCT validation
+        let leaf_der = req
+            .chain
+            .first()
+            .ok_or_else(|| AppError::BadRequest("Chain is empty".into()))?;
+        let issuer_der = resolve_issuer_for_sct(&req.chain, roots).map_err(AppError::BadRequest)?;
+
+        let validation_time_secs = now_millis() / 1000;
+
+        match validator.validate_embedded_scts(leaf_der, &issuer_der, validation_time_secs) {
+            Ok(SctValidationResult::Valid) => {
+                log::info!("{log}: SCT validation passed");
+            }
+            Ok(SctValidationResult::ValidWithWarnings(warnings)) => {
+                log::info!(
+                    "{log}: SCT validation passed with {} warnings",
+                    warnings.len()
+                );
+                for warning in &warnings {
+                    log::debug!("{log}: SCT warning: {warning:?}");
+                }
+            }
+            Ok(SctValidationResult::StaleLogList) => {
+                log::warn!("{log}: SCT validation skipped (stale log list)");
+            }
+            Err(e) => {
+                log::warn!("{log}: SCT validation failed: {e}");
+                return Err(AppError::BadRequest(format!("SCT validation failed: {e}")));
+            }
+        }
+    }
+
+    // Retrieve the sequenced entry for this pending log entry by sending a request to the DO to
+    // sequence the entry.
+    let lookup_key = pending_entry.lookup_key();
+
+    // First persist issuers. Use a block so memory is deallocated sooner.
+    {
+        let public_bucket = ObjectBucket::new(load_public_bucket(&env, &log)?);
+        let mut issuers = req.chain[1..]
+            .iter()
+            .map(Vec::as_slice)
+            .collect::<Vec<&[u8]>>();
+
+        // Make sure the found root is persisted as well, if the add-chain
+        // request did not include the root.
+        let root_bytes;
+        if let Some(idx) = found_root_idx {
+            root_bytes = roots.certs[idx]
+                .to_der()
+                .map_err(|e| AppError::BadRequest(e.to_string()))?;
+            issuers.push(&root_bytes);
+        }
+
+        generic_log_worker::upload_issuers(&public_bucket, &issuers, &log).await?;
+    }
+
+    // Submit entry to be sequenced, either via a batcher or directly to the
+    // sequencer.
+    let stub = {
+        let shard_id = batcher_id_from_lookup_key(&lookup_key, params.num_batchers);
+        get_durable_object_stub(
+            &env,
+            &log,
+            shard_id,
+            if shard_id.is_some() {
+                "BATCHER"
+            } else {
+                "SEQUENCER"
+            },
+            params.location_hint.as_deref(),
+        )?
+    };
+    let serialized = serialize(&PendingLogEntryBlob {
+        lookup_key,
+        data: serialize(&pending_entry)?,
+    })?;
+    let mut response = stub
+        .fetch_with_request(Request::new_with_init(
+            &format!("http://fake_url.com{ENTRY_ENDPOINT}"),
+            &RequestInit {
+                method: Method::Post,
+                body: Some(serialized.into()),
+                ..Default::default()
+            },
+        )?)
+        .await?;
+    if response.status_code() != 200 {
+        // Return the response from the sequencing directly to the client.
+        return Ok(response.into());
+    }
+    let metadata = deserialize::<BootstrapMtcSequenceMetadata>(&response.bytes().await?)?;
+    Ok((
+        StatusCode::OK,
+        Json(AddEntryResponse {
+            leaf_index: metadata.leaf_index(),
+            timestamp: metadata.timestamp(),
+            not_before: validity.not_before.to_unix_duration().as_secs(),
+            not_after: validity.not_after.to_unix_duration().as_secs(),
+        }),
+    )
+        .into_response())
+}
+
+/// `POST /logs/{log}/get-certificate`
+#[worker::send]
+async fn get_certificate(
+    State(env): State<Env>,
+    PathParams { log, .. }: PathParams<()>,
+    body: Bytes,
+) -> ApiResult<impl IntoResponse> {
+    let params = &CONFIG.logs[&log];
     let Ok(GetCertificateRequest {
         leaf_index,
         spki_der,
-    }) = req.json().await
+    }) = serde_json::from_slice(&body)
     else {
-        return Response::error("Unexpected input", 400);
+        return Err(AppError::BadRequest("Unexpected input".into()));
     };
-    let object_backend = ObjectBucket::new(load_public_bucket(env, name)?);
+    let object_backend = ObjectBucket::new(load_public_bucket(&env, &log)?);
     // Fetch the current checkpoint to know which tiles to fetch
     // (full or partials).
     let (checkpoint, _checkpoint_bytes) =
-        get_current_checkpoint(env, name, &object_backend).await?;
+        get_current_checkpoint(&env, &log, &object_backend).await?;
     if leaf_index >= checkpoint.size() {
-        return Response::error("Leaf index is not in log", 422);
+        return Err(AppError::LeafIndexNotInLog);
     }
 
-    let seq = get_landmark_sequence(name, &object_backend).await?;
+    let seq = get_landmark_sequence(&log, &object_backend).await?;
     if leaf_index < seq.first_index() {
-        return Response::error("Leaf index is before first active landmark", 422);
+        return Err(AppError::LeafIndexBeforeFirstActiveLandmark);
     }
     let Some((landmark_id, landmark_subtree)) = seq.subtree_for_index(leaf_index) else {
         // The leaf index might be between the latest landmark and the current
         // tree size. Set Retry-After to the expected time for the next landmark
         // so the client can try again later.
-        let headers = Headers::new();
         let i = params.landmark_interval_secs as u64;
-        headers.set("Retry-After", &format!("{}", i - (now_millis() / 1000) % i))?;
-        return Response::error("Leaf index will be covered by next landmark", 503)
-            .map(|r| r.with_headers(headers));
+        return Err(AppError::LeafIndexPendingLandmark {
+            retry_after: i - (now_millis() / 1000) % i,
+        });
     };
 
     // Fetch the log entry for the leaf index.
@@ -196,7 +424,7 @@ async fn get_certificate(mut req: Request, env: &Env, name: &str) -> Result<Resp
         checkpoint.hash(),
     )
     .await
-    .map_err(|e| e.to_string())?;
+    .map_err(|e| AppError::BadRequest(e.to_string()))?;
 
     // Get the inclusion proof.
     let proof = match prove_subtree_inclusion(
@@ -210,8 +438,8 @@ async fn get_certificate(mut req: Request, env: &Env, name: &str) -> Result<Resp
     .await
     {
         Ok(p) => p,
-        Err(ProofError::Tlog(s)) => return Response::error(s.to_string(), 422),
-        Err(ProofError::Other(e)) => return Err(e.to_string().into()),
+        Err(ProofError::Tlog(s)) => return Err(AppError::SubtreeInclusionProofFailed(s)),
+        Err(ProofError::Other(e)) => return Err(AppError::BadRequest(e.to_string())),
     };
 
     // Construct the signatureless certificate.
@@ -223,66 +451,109 @@ async fn get_certificate(mut req: Request, env: &Env, name: &str) -> Result<Resp
         proof,
     ) {
         Ok(data) => data,
-        Err(e) => {
-            return Response::error(format!("Failed to serialize signatureless cert: {e}"), 422)
-        }
+        Err(e) => return Err(AppError::FailedToSerializeSignaturelessCert(e)),
     };
 
-    Response::from_json(&GetCertificateResponse { data, landmark_id })
+    Ok((
+        StatusCode::OK,
+        Json(GetCertificateResponse { data, landmark_id }),
+    ))
 }
 
-/// `GET /logs/:log/metadata`
-fn metadata(env: &Env, name: &str) -> Result<Response> {
-    let params = &CONFIG.logs[name];
-    let cosigner = load_checkpoint_cosigner(env, name);
-    Response::from_json(&MetadataResponse {
-        description: &params.description,
-        log_id: cosigner.log_id().to_string(),
-        cosigner_id: cosigner.cosigner_id().to_string(),
-        cosigner_public_key: cosigner.verifying_key(),
-        submission_url: &params.submission_url,
-        monitoring_url: if params.monitoring_url.is_empty() {
-            &params.submission_url
-        } else {
-            &params.monitoring_url
-        },
-    })
+/// `GET /logs/{log}/get-landmark-bundle`
+#[worker::send]
+async fn get_landmark_bundle(
+    State(env): State<Env>,
+    PathParams { log, .. }: PathParams<()>,
+) -> ApiResult<impl IntoResponse> {
+    let object_backend = ObjectBucket::new(load_public_bucket(&env, &log)?);
+
+    // Fetch the current landmark bundle from R2 (already encoded in JSON) and return it
+    let Some(landmark_bundle_bytes) = object_backend.fetch(LANDMARK_BUNDLE_KEY).await? else {
+        return Err(AppError::InternalServerError(
+            "failed to get landmark bundle".into(),
+        ));
+    };
+
+    Ok((
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        landmark_bundle_bytes,
+    ))
 }
 
-/// `GET /logs/:log/sequencer_id`
-fn sequencer_id(env: &Env, name: &str) -> Result<Response> {
+/// `GET /logs/{log}/metadata`
+#[worker::send]
+async fn metadata(
+    State(env): State<Env>,
+    PathParams { log, .. }: PathParams<()>,
+) -> ApiResult<impl IntoResponse> {
+    let params = &CONFIG.logs[&log];
+    let cosigner = load_checkpoint_cosigner(&env, &log);
+    Ok((
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        serde_json::to_vec(&MetadataResponse {
+            description: &params.description,
+            log_id: cosigner.log_id().to_string(),
+            cosigner_id: cosigner.cosigner_id().to_string(),
+            cosigner_public_key: cosigner.verifying_key(),
+            submission_url: &params.submission_url,
+            monitoring_url: if params.monitoring_url.is_empty() {
+                &params.submission_url
+            } else {
+                &params.monitoring_url
+            },
+        })
+        .unwrap(),
+    ))
+}
+
+/// `GET /logs/{log}/sequencer_id`
+#[worker::send]
+async fn sequencer_id(
+    State(env): State<Env>,
+    PathParams { log, .. }: PathParams<()>,
+) -> ApiResult<impl IntoResponse> {
     // Print out the Durable Object ID of the sequencer to allow looking it up
     // in internal Cloudflare dashboards. This value does not need to be secret.
     let namespace = env.durable_object("SEQUENCER")?;
-    let object_id = namespace.id_from_name(name)?;
-    Response::ok(object_id.to_string())
+    let object_id = namespace.id_from_name(&log)?;
+    Ok((StatusCode::OK, object_id.to_string()))
 }
 
-/// `GET /logs/:log/*key` -- direct read-through to the public R2 bucket when
+/// `GET /logs/{log}/{*key}` — direct read-through to the public R2 bucket when
 /// the log's `monitoring_url` is unspecified.
-async fn get_object(env: &Env, name: &str, key: &str) -> Result<Response> {
+#[worker::send]
+async fn get_object(
+    State(env): State<Env>,
+    PathParams {
+        log,
+        rest: Key { key },
+    }: PathParams<Key>,
+) -> ApiResult<impl IntoResponse> {
     // Enable direct access to the bucket via the Worker if monitoring_url is
     // unspecified.
-    if CONFIG.logs[name].monitoring_url.is_empty() {
-        let bucket = load_public_bucket(env, name)?;
+    if CONFIG.logs[&log].monitoring_url.is_empty() {
+        let bucket = load_public_bucket(&env, &log)?;
         if let Some(obj) = bucket.get(key).execute().await? {
-            Response::from_body(
-                obj.body()
-                    .ok_or("R2 object missing body")?
-                    .response_body()?,
-            )
-            .map(|r| r.with_headers(headers_from_http_metadata(obj.http_metadata())))
+            let body = obj
+                .body()
+                .ok_or_else(|| AppError::InternalServerError("R2 object missing body".into()))?
+                .stream()?;
+            Ok((
+                StatusCode::OK,
+                headers_from_http_metadata(obj.http_metadata()),
+                axum::body::Body::from_stream(WorkerByteStream::new(body)),
+            ))
         } else {
-            Response::error("Not found", 404)
+            Err(AppError::NotFound)
         }
     } else {
-        Response::error(
-            format!(
-                "Use {} for monitoring API",
-                CONFIG.logs[name].monitoring_url
-            ),
-            404,
-        )
+        // TODO: should this be an HTTP redirect instead of a 404?
+        Err(AppError::RedirectToMonitorApi(
+            &CONFIG.logs[&log].monitoring_url,
+        ))
     }
 }
 
@@ -346,141 +617,6 @@ fn resolve_issuer_for_sct(
         .map_err(|e| format!("failed to encode issuer: {e}"))
 }
 
-#[allow(clippy::too_many_lines)]
-async fn add_entry(mut req: Request, env: &Env, name: &str) -> Result<Response> {
-    let params = &CONFIG.logs[name];
-    let req: AddEntryRequest = req.json().await?;
-
-    let issuer = build_issuer_rdn(&params.log_id)?;
-    let mut validity = build_validity(now_millis(), params.max_certificate_lifetime_secs as u64)?;
-
-    let roots = load_roots(env, name).await?;
-    let (pending_entry, found_root_idx) =
-        match bootstrap_mtc_api::validate_chain(&req.chain, roots, &issuer, &mut validity) {
-            Ok(v) => v,
-            Err(e) => {
-                log::warn!("{name}: Bad request: {e}");
-                return Response::error("Bad request", 400);
-            }
-        };
-
-    // SCT validation (if enabled for this log shard)
-    if params.enable_sct_validation {
-        use crate::ct_logs_cron::load_ct_logs;
-        use sct_validator::{SctValidationResult, SctValidator};
-
-        // Load the CT log list from KV
-        let ct_logs = load_ct_logs(env).await?;
-        let validator = SctValidator::new(ct_logs);
-
-        // Get leaf and issuer DER for SCT validation
-        let leaf_der = req.chain.first().ok_or("Chain is empty")?;
-        let issuer_der = resolve_issuer_for_sct(&req.chain, roots)?;
-
-        let validation_time_secs = now_millis() / 1000;
-
-        match validator.validate_embedded_scts(leaf_der, &issuer_der, validation_time_secs) {
-            Ok(SctValidationResult::Valid) => {
-                log::info!("{name}: SCT validation passed");
-            }
-            Ok(SctValidationResult::ValidWithWarnings(warnings)) => {
-                log::info!(
-                    "{name}: SCT validation passed with {} warnings",
-                    warnings.len()
-                );
-                for warning in &warnings {
-                    log::debug!("{name}: SCT warning: {warning:?}");
-                }
-            }
-            Ok(SctValidationResult::StaleLogList) => {
-                log::warn!("{name}: SCT validation skipped (stale log list)");
-            }
-            Err(e) => {
-                log::warn!("{name}: SCT validation failed: {e}");
-                return Response::error(format!("SCT validation failed: {e}"), 400);
-            }
-        }
-    }
-
-    // Retrieve the sequenced entry for this pending log entry by sending a request to the DO to
-    // sequence the entry.
-    let lookup_key = pending_entry.lookup_key();
-
-    // First persist issuers. Use a block so memory is deallocated sooner.
-    {
-        let public_bucket = ObjectBucket::new(load_public_bucket(env, name)?);
-        let mut issuers = req.chain[1..]
-            .iter()
-            .map(Vec::as_slice)
-            .collect::<Vec<&[u8]>>();
-
-        // Make sure the found root is persisted as well, if the add-chain
-        // request did not include the root.
-        let root_bytes;
-        if let Some(idx) = found_root_idx {
-            root_bytes = roots.certs[idx].to_der().map_err(|e| e.to_string())?;
-            issuers.push(&root_bytes);
-        }
-
-        generic_log_worker::upload_issuers(&public_bucket, &issuers, name).await?;
-    }
-
-    // Submit entry to be sequenced, either via a batcher or directly to the
-    // sequencer.
-    let stub = {
-        let shard_id = batcher_id_from_lookup_key(&lookup_key, params.num_batchers);
-        get_durable_object_stub(
-            env,
-            name,
-            shard_id,
-            if shard_id.is_some() {
-                "BATCHER"
-            } else {
-                "SEQUENCER"
-            },
-            params.location_hint.as_deref(),
-        )?
-    };
-    let serialized = serialize(&PendingLogEntryBlob {
-        lookup_key,
-        data: serialize(&pending_entry)?,
-    })?;
-    let mut response = stub
-        .fetch_with_request(Request::new_with_init(
-            &format!("http://fake_url.com{ENTRY_ENDPOINT}"),
-            &RequestInit {
-                method: Method::Post,
-                body: Some(serialized.into()),
-                ..Default::default()
-            },
-        )?)
-        .await?;
-    if response.status_code() != 200 {
-        // Return the response from the sequencing directly to the client.
-        return Ok(response);
-    }
-    let metadata = deserialize::<BootstrapMtcSequenceMetadata>(&response.bytes().await?)?;
-    Response::from_json(&AddEntryResponse {
-        leaf_index: metadata.leaf_index(),
-        timestamp: metadata.timestamp(),
-        not_before: validity.not_before.to_unix_duration().as_secs(),
-        not_after: validity.not_after.to_unix_duration().as_secs(),
-    })
-}
-
-async fn get_landmark_bundle(env: &Env, name: &str) -> Result<Response> {
-    let object_backend = ObjectBucket::new(load_public_bucket(env, name)?);
-
-    // Fetch the current landmark bundle from R2 (already encoded in JSON) and return it
-    let Some(landmark_bundle_bytes) = object_backend.fetch(LANDMARK_BUNDLE_KEY).await? else {
-        return Err("failed to get landmark bundle".into());
-    };
-
-    Ok(ResponseBuilder::new()
-        .with_header("content-type", "application/json")?
-        .body(ResponseBody::Body(landmark_bundle_bytes)))
-}
-
 async fn get_current_checkpoint(
     env: &Env,
     name: &str,
@@ -516,16 +652,16 @@ async fn get_landmark_sequence(
     Ok(landmark_sequence)
 }
 
-fn headers_from_http_metadata(meta: HttpMetadata) -> Headers {
-    let h = Headers::new();
+fn headers_from_http_metadata(meta: HttpMetadata) -> HeaderMap {
+    let mut h = HeaderMap::new();
     if let Some(hdr) = meta.cache_control {
-        h.append("Cache-Control", &hdr).unwrap();
+        h.append("Cache-Control", hdr.try_into().unwrap());
     }
     if let Some(hdr) = meta.content_encoding {
-        h.append("Content-Encoding", &hdr).unwrap();
+        h.append("Content-Encoding", hdr.try_into().unwrap());
     }
     if let Some(hdr) = meta.content_type {
-        h.append("Content-Type", &hdr).unwrap();
+        h.append("Content-Type", hdr.try_into().unwrap());
     }
     h
 }

--- a/crates/ct_worker/Cargo.toml
+++ b/crates/ct_worker/Cargo.toml
@@ -38,6 +38,7 @@ parking_lot.workspace = true
 futures-executor.workspace = true
 
 [dependencies]
+axum.workspace = true
 base64.workspace = true
 config = { path = "./config", package = "ct_worker_config" }
 generic_log_worker.workspace = true
@@ -53,7 +54,8 @@ signed_note.workspace = true
 tlog_core.workspace = true
 tlog_entry.workspace = true
 tlog_checkpoint.workspace = true
-worker.workspace = true
+tower-service.workspace = true
+worker = { workspace = true, features = ["http", "axum"] }
 x509-cert.workspace = true
 x509_util.workspace = true
 chrono.workspace = true

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -8,7 +8,7 @@ use config::TemporalInterval;
 use generic_log_worker::{
     batcher_id_from_lookup_key, deserialize, get_cached_metadata, get_durable_object_stub,
     init_logging, load_cache_kv, load_public_bucket, obs::Wshim, put_cache_entry_metadata,
-    serialize, ObjectBucket, ENTRY_ENDPOINT,
+    serialize, util::WorkerByteStream, ObjectBucket, ENTRY_ENDPOINT,
 };
 use p256::pkcs8::EncodePublicKey;
 use serde::Serialize;
@@ -19,6 +19,16 @@ use tlog_entry::{LogEntry, PendingLogEntry, PendingLogEntryBlob};
 use worker::*;
 use x509_cert::der::Encode;
 
+use axum::{
+    body::Bytes,
+    extract::{Path, State},
+    http::{header, HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use tower_service::Service;
+
 // The Maximum Merge Delay (MMD) of a log indicates the maximum period of time
 // between when a SCT is issued and the corresponding entry is sequenced in the
 // log. For Azul-based logs, this is effectively zero since SCT issuance happens
@@ -26,8 +36,6 @@ use x509_cert::der::Encode;
 // maximum allowed in Chrome's policy, 60 seconds, to allow future flexibility.
 // For details, see https://github.com/C2SP/C2SP/issues/79.
 const MAX_MERGE_DELAY_SECS: usize = 60;
-
-const UNKNOWN_LOG_MSG: &str = "unknown log";
 
 #[serde_as]
 #[derive(Serialize)]
@@ -56,165 +64,272 @@ fn start() {
 ///
 /// # Errors
 ///
-/// Returns an error if any unhandled internal errors occur while processing the request.
-///
-/// # Panics
-///
-/// Panics if there are issues parsing route parameters, which should never happen.
+/// Returns an error if any unhandled internal error occurs while processing the
+/// request.
 #[event(fetch, respond_with_errors)]
-async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
+async fn main(
+    req: HttpRequest,
+    env: Env,
+    ctx: Context,
+) -> Result<axum::http::Response<axum::body::Body>> {
     let wshim = Wshim::from_env(&env);
-    // Use an outer router as middleware to check that the log name is valid.
     let response = Router::new()
-        .or_else_any_method_async("/logs/:log/*route", |req, ctx| async move {
-            let name = if let Some(name) = ctx.param("log") {
-                if CONFIG.logs.contains_key(name) {
-                    &name.clone()
-                } else {
-                    return Err(UNKNOWN_LOG_MSG.into());
-                }
-            } else {
-                return Err("missing 'log' route param".into());
-            };
-
-            // Now that we've validated the log name, use an inner router to
-            // handle the request.
-            Router::with_data(name)
-                .get_async("/logs/:log/ct/v1/get-roots", |_req, ctx| async move {
-                    get_roots(&ctx.env, ctx.data).await
-                })
-                .post_async("/logs/:log/ct/v1/add-chain", |req, ctx| async move {
-                    add_chain_or_pre_chain(req, &ctx.env, ctx.data, false).await
-                })
-                .post_async("/logs/:log/ct/v1/add-pre-chain", |req, ctx| async move {
-                    add_chain_or_pre_chain(req, &ctx.env, ctx.data, true).await
-                })
-                .get("/logs/:log/log.v3.json", |_req, ctx| {
-                    log_v3_json(&ctx.env, ctx.data)
-                })
-                .get("/logs/:log/sequencer_id", |_req, ctx| {
-                    sequencer_id(&ctx.env, ctx.data)
-                })
-                .get_async("/logs/:log/*key", |_req, ctx| async move {
-                    get_object(&ctx.env, ctx.data, ctx.param("key").unwrap()).await
-                })
-                .run(req, ctx.env)
-                .await
-        })
-        .run(req, env)
-        .await
-        .or_else(|e| match e {
-            Error::RustError(ref msg) if msg == UNKNOWN_LOG_MSG => {
-                Response::error("Unknown log", 400)
-            }
-            _ => {
-                log::warn!("Internal error: {e}");
-                Response::error("Internal error", 500)
-            }
-        });
+        .route("/logs/{log}/ct/v1/get-roots", get(get_roots))
+        .route("/logs/{log}/ct/v1/add-chain", post(add_chain))
+        .route("/logs/{log}/ct/v1/add-pre-chain", post(add_pre_chain))
+        .route("/logs/{log}/log.v3.json", get(log_v3_json))
+        .route("/logs/{log}/sequencer_id", get(sequencer_id))
+        .route("/logs/{log}/{*key}", get(get_object))
+        .with_state(env)
+        .call(req)
+        .await?;
     if let Ok(wshim) = wshim {
         ctx.wait_until(async move { wshim.flush(&generic_log_worker::obs::logs::LOGGER).await });
     }
-    response
+    Ok(response)
 }
 
-/// `GET /logs/:log/ct/v1/get-roots`
-async fn get_roots(env: &Env, name: &str) -> Result<Response> {
-    Response::from_json(&GetRootsResponse {
-        certificates: x509_util::certs_to_bytes(&load_roots(env, name).await?.certs).unwrap(),
-    })
+#[derive(serde::Deserialize)]
+struct PathParams<Rest> {
+    log: String,
+    #[serde(flatten)]
+    rest: Rest,
 }
 
-/// `GET /logs/:log/log.v3.json`
-fn log_v3_json(env: &Env, name: &str) -> Result<Response> {
-    let params = &CONFIG.logs[name];
-    let verifying_key = load_signing_key(env, name)?.verifying_key();
+#[derive(serde::Deserialize)]
+struct Key {
+    key: String,
+}
+
+impl<T> axum::extract::FromRequestParts<Env> for PathParams<T>
+where
+    T: serde::de::DeserializeOwned + Send,
+{
+    type Rejection = AppError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &Env,
+    ) -> Result<Self, Self::Rejection> {
+        let Path(params) = Path::<PathParams<T>>::from_request_parts(parts, state)
+            .await
+            .map_err(|_| {
+                AppError::InternalServerError("path param does not have log field".into())
+            })?;
+        if CONFIG.logs.contains_key(&params.log) {
+            Ok(params)
+        } else {
+            Err(AppError::UnknownLog)
+        }
+    }
+}
+
+/// Result type for the route handlers: each builds a [`worker::Response`] which
+/// is converted into an axum response at the boundary via the worker crate's
+/// `axum` feature.
+type ApiResult<T> = std::result::Result<T, AppError>;
+
+enum AppError {
+    InternalServerError(String),
+    NotFound,
+    BadRequest(String),
+    UnknownLog,
+    ReadonlyLog,
+    RedirectToMonitorApi(&'static str),
+}
+
+impl From<Error> for AppError {
+    fn from(err: Error) -> Self {
+        Self::InternalServerError(err.to_string())
+    }
+}
+
+impl From<String> for AppError {
+    fn from(msg: String) -> Self {
+        Self::InternalServerError(msg)
+    }
+}
+
+impl From<&str> for AppError {
+    fn from(msg: &str) -> Self {
+        Self::InternalServerError(msg.to_owned())
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::InternalServerError(msg) => {
+                log::error!("Internal error: {msg}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal error",
+                )
+                    .into_response()
+            }
+            AppError::NotFound => (StatusCode::NOT_FOUND, "Not Found").into_response(),
+            Self::BadRequest(e) => {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Bad request{}{e}", if e.is_empty() { "" } else { ": " })
+                ).into_response()
+            }
+            Self::UnknownLog => {
+                (StatusCode::BAD_REQUEST, "Unknown log").into_response()
+            }
+            Self::ReadonlyLog => {
+                (StatusCode::SERVICE_UNAVAILABLE,
+                 [(header::RETRY_AFTER, "300")],
+                 "The log is temporarily in read-only mode during maintenance. Please try again after 5 minutes.",).into_response()
+            }
+            Self::RedirectToMonitorApi(url) => (
+                StatusCode::NOT_FOUND,
+                format!("Use {url} for monitoring API"),
+            )
+                .into_response(),
+        }
+    }
+}
+
+/// `GET /logs/{log}/ct/v1/get-roots`
+#[worker::send]
+async fn get_roots(
+    State(env): State<Env>,
+    PathParams { log, .. }: PathParams<()>,
+) -> ApiResult<impl IntoResponse> {
+    Ok((
+        StatusCode::OK,
+        Json(GetRootsResponse {
+            certificates: x509_util::certs_to_bytes(&load_roots(&env, &log).await?.certs).unwrap(),
+        }),
+    ))
+}
+
+/// `POST /logs/{log}/ct/v1/add-chain`
+#[worker::send]
+async fn add_chain(
+    State(env): State<Env>,
+    PathParams { log, .. }: PathParams<()>,
+    body: Bytes,
+) -> ApiResult<impl IntoResponse> {
+    add_chain_or_pre_chain(body, &env, &log, false).await
+}
+
+/// `POST /logs/{log}/ct/v1/add-pre-chain`
+#[worker::send]
+async fn add_pre_chain(
+    State(env): State<Env>,
+    PathParams { log, .. }: PathParams<()>,
+    body: Bytes,
+) -> ApiResult<impl IntoResponse> {
+    add_chain_or_pre_chain(body, &env, &log, true).await
+}
+
+/// `GET /logs/{log}/log.v3.json`
+#[worker::send]
+async fn log_v3_json(
+    State(env): State<Env>,
+    PathParams { log, .. }: PathParams<()>,
+) -> ApiResult<impl IntoResponse> {
+    let params = &CONFIG.logs[&log];
+    let verifying_key = load_signing_key(&env, &log)?.verifying_key();
     let log_id = &static_ct_api::log_id_from_key(verifying_key).map_err(|e| e.to_string())?;
     let key = verifying_key
         .to_public_key_der()
         .map_err(|e| e.to_string())?;
-    Response::from_json(&LogV3JsonResponse {
-        description: &params.description,
-        log_type: &params.log_type,
-        log_id,
-        key: key.as_bytes(),
-        submission_url: &params.submission_url,
-        monitoring_url: if params.monitoring_url.is_empty() {
-            &params.submission_url
-        } else {
-            &params.monitoring_url
-        },
-        mmd: MAX_MERGE_DELAY_SECS,
-        temporal_interval: &params.temporal_interval,
-    })
+    Ok((
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        serde_json::to_string(&LogV3JsonResponse {
+            description: &params.description,
+            log_type: &params.log_type,
+            log_id,
+            key: key.as_bytes(),
+            submission_url: &params.submission_url,
+            monitoring_url: if params.monitoring_url.is_empty() {
+                &params.submission_url
+            } else {
+                &params.monitoring_url
+            },
+            mmd: MAX_MERGE_DELAY_SECS,
+            temporal_interval: &params.temporal_interval,
+        })
+        .unwrap(),
+    )
+        .into_response())
 }
 
-/// `GET /logs/:log/sequencer_id`
-fn sequencer_id(env: &Env, name: &str) -> Result<Response> {
+/// `GET /logs/{log}/sequencer_id`
+#[worker::send]
+async fn sequencer_id(
+    State(env): State<Env>,
+    PathParams { log, .. }: PathParams<()>,
+) -> ApiResult<impl IntoResponse> {
     // Print out the Durable Object ID of the sequencer to allow looking it up
     // in internal Cloudflare dashboards. This value does not need to be secret.
     let namespace = env.durable_object("SEQUENCER")?;
-    let object_id = namespace.id_from_name(name)?;
-    Response::ok(object_id.to_string())
+    let object_id = namespace.id_from_name(&log)?;
+    Ok((StatusCode::OK, object_id.to_string()))
 }
 
-/// `GET /logs/:log/*key` -- direct read-through to the public R2 bucket when
+/// `GET /logs/{log}/{*key}` — direct read-through to the public R2 bucket when
 /// the log's `monitoring_url` is unspecified.
-async fn get_object(env: &Env, name: &str, key: &str) -> Result<Response> {
+#[worker::send]
+async fn get_object(
+    State(env): State<Env>,
+    PathParams {
+        log,
+        rest: Key { key },
+    }: PathParams<Key>,
+) -> ApiResult<impl IntoResponse> {
     // Enable direct access to the bucket via the Worker if monitoring_url is
     // unspecified.
-    if CONFIG.logs[name].monitoring_url.is_empty() {
-        let bucket = load_public_bucket(env, name)?;
+    if CONFIG.logs[&log].monitoring_url.is_empty() {
+        let bucket = load_public_bucket(&env, &log)?;
         if let Some(obj) = bucket.get(key).execute().await? {
-            Response::from_body(
-                obj.body()
-                    .ok_or("R2 object missing body")?
-                    .response_body()?,
-            )
-            .map(|r| r.with_headers(headers_from_http_metadata(obj.http_metadata())))
+            let body = obj
+                .body()
+                .ok_or_else(|| AppError::InternalServerError("R2 object missing body".into()))?
+                .stream()?;
+            Ok((
+                StatusCode::OK,
+                headers_from_http_metadata(obj.http_metadata()),
+                axum::body::Body::from_stream(WorkerByteStream::new(body)),
+            ))
         } else {
-            Response::error("Not found", 404)
+            Err(AppError::NotFound)
         }
     } else {
-        Response::error(
-            format!(
-                "Use {} for monitoring API",
-                CONFIG.logs[name].monitoring_url
-            ),
-            404,
-        )
+        // TODO: should this be an HTTP redirect instead of a 404?
+        Err(AppError::RedirectToMonitorApi(
+            &CONFIG.logs[&log].monitoring_url,
+        ))
     }
 }
 
 #[allow(clippy::too_many_lines)]
 async fn add_chain_or_pre_chain(
-    mut req: Request,
+    body: Bytes,
     env: &Env,
-    name: &str,
+    log: &str,
     expect_precert: bool,
-) -> Result<Response> {
-    let params = &CONFIG.logs[name];
+) -> ApiResult<impl IntoResponse> {
+    let params = &CONFIG.logs[log];
     if params.read_only {
-        return Response::error(
-            "The log is temporarily in read-only mode during maintenance. Please try again after 5 minutes.",
-            503,
-        )
-        .map(|r| {
-            let h = Headers::new();
-            h.set("Retry-After", "300").unwrap();
-            r.with_headers(h)
-        });
+        return Err(AppError::ReadonlyLog);
     }
-    let req: AddChainRequest = match req.json().await {
+    let req: AddChainRequest = match serde_json::from_slice(&body) {
         Ok(req) => req,
         Err(e) => {
-            log::debug!("{name}: Invalid add-(pre)chain request: {e}");
-            return Response::error("Invalid add-[pre-]chain request", 400);
+            log::debug!("{log}: Invalid add-(pre)chain request: {e}");
+            return Err(AppError::BadRequest(
+                "Invalid add-[pre-]chain request".into(),
+            ));
         }
     };
 
     // Temporal interval dates prior to the Unix epoch are treated as the Unix epoch.
-    let roots = load_roots(env, name).await?;
+    let roots = load_roots(env, log).await?;
     let (pending_entry, found_root_idx) = match static_ct_api::partially_validate_chain(
         &req.chain,
         roots,
@@ -231,28 +346,28 @@ async fn add_chain_or_pre_chain(
     ) {
         Ok(v) => v,
         Err(e) => {
-            log::debug!("{name}: Bad request: {e}");
-            return Response::error("Bad request", 400);
+            log::debug!("{log}: Bad request: {e}");
+            return Err(AppError::BadRequest(String::new()));
         }
     };
 
     // Retrieve the sequenced entry for this pending log entry by first checking the
     // deduplication cache and then sending a request to the DO to sequence the entry.
     let lookup_key = pending_entry.lookup_key();
-    let signing_key = load_signing_key(env, name)?;
+    let signing_key = load_signing_key(env, log)?;
 
     // Check if entry is cached and return right away if so.
     if params.enable_dedup {
         if let Some(metadata) =
-            get_cached_metadata::<StaticCTSequenceMetadata>(&load_cache_kv(env, name)?, &lookup_key)
+            get_cached_metadata::<StaticCTSequenceMetadata>(&load_cache_kv(env, log)?, &lookup_key)
                 .await?
         {
-            log::debug!("{name}: Entry is cached");
+            log::debug!("{log}: Entry is cached");
             let entry =
                 StaticCTLogEntry::new(pending_entry, metadata.leaf_index(), metadata.timestamp());
             let sct = static_ct_api::signed_certificate_timestamp(signing_key, &entry)
                 .map_err(|e| e.to_string())?;
-            return Response::from_json(&sct);
+            return Ok((StatusCode::OK, Json(sct)).into_response());
         }
     }
 
@@ -260,7 +375,7 @@ async fn add_chain_or_pre_chain(
 
     // First persist issuers. Use a block so memory is deallocated sooner.
     {
-        let public_bucket = ObjectBucket::new(load_public_bucket(env, name)?);
+        let public_bucket = ObjectBucket::new(load_public_bucket(env, log)?);
         let mut issuers = req.chain[1..]
             .iter()
             .map(Vec::as_slice)
@@ -274,7 +389,7 @@ async fn add_chain_or_pre_chain(
             issuers.push(&root_bytes);
         }
 
-        generic_log_worker::upload_issuers(&public_bucket, &issuers, name).await?;
+        generic_log_worker::upload_issuers(&public_bucket, &issuers, log).await?;
     }
 
     // Submit entry to be sequenced, either via a batcher or directly to the
@@ -283,7 +398,7 @@ async fn add_chain_or_pre_chain(
         let shard_id = batcher_id_from_lookup_key(&lookup_key, params.num_batchers);
         get_durable_object_stub(
             env,
-            name,
+            log,
             shard_id,
             if shard_id.is_some() {
                 "BATCHER"
@@ -310,17 +425,17 @@ async fn add_chain_or_pre_chain(
         .await?;
     if response.status_code() != 200 {
         // Return the response from the sequencing directly to the client.
-        return Ok(response);
+        return Ok(response.into());
     }
     let metadata = deserialize::<StaticCTSequenceMetadata>(&response.bytes().await?)?;
     if params.num_batchers == 0 && params.enable_dedup {
         // Write sequenced entry to the long-term deduplication cache in Workers
         // KV as there are no batchers configured to do it for us.
-        if put_cache_entry_metadata(&load_cache_kv(env, name)?, &pending_entry, metadata)
+        if put_cache_entry_metadata(&load_cache_kv(env, log)?, &pending_entry, metadata)
             .await
             .is_err()
         {
-            log::warn!("{name}: Failed to write entry to deduplication cache");
+            log::warn!("{log}: Failed to write entry to deduplication cache");
         }
     }
     let entry = StaticCTLogEntry {
@@ -330,19 +445,19 @@ async fn add_chain_or_pre_chain(
     };
     let sct = static_ct_api::signed_certificate_timestamp(signing_key, &entry)
         .map_err(|e| e.to_string())?;
-    Response::from_json(&sct)
+    Ok((StatusCode::OK, Json(sct)).into_response())
 }
 
-fn headers_from_http_metadata(meta: HttpMetadata) -> Headers {
-    let h = Headers::new();
+fn headers_from_http_metadata(meta: HttpMetadata) -> HeaderMap {
+    let mut h = HeaderMap::new();
     if let Some(hdr) = meta.cache_control {
-        h.append("Cache-Control", &hdr).unwrap();
+        h.append("Cache-Control", hdr.try_into().unwrap());
     }
     if let Some(hdr) = meta.content_encoding {
-        h.append("Content-Encoding", &hdr).unwrap();
+        h.append("Content-Encoding", hdr.try_into().unwrap());
     }
     if let Some(hdr) = meta.content_type {
-        h.append("Content-Type", &hdr).unwrap();
+        h.append("Content-Type", hdr.try_into().unwrap());
     }
     h
 }

--- a/crates/ct_worker/src/frontend_worker.rs
+++ b/crates/ct_worker/src/frontend_worker.rs
@@ -81,12 +81,7 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
             // handle the request.
             Router::with_data(name)
                 .get_async("/logs/:log/ct/v1/get-roots", |_req, ctx| async move {
-                    Response::from_json(&GetRootsResponse {
-                        certificates: x509_util::certs_to_bytes(
-                            &load_roots(&ctx.env, ctx.data).await?.certs,
-                        )
-                        .unwrap(),
-                    })
+                    get_roots(&ctx.env, ctx.data).await
                 })
                 .post_async("/logs/:log/ct/v1/add-chain", |req, ctx| async move {
                     add_chain_or_pre_chain(req, &ctx.env, ctx.data, false).await
@@ -95,67 +90,13 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                     add_chain_or_pre_chain(req, &ctx.env, ctx.data, true).await
                 })
                 .get("/logs/:log/log.v3.json", |_req, ctx| {
-                    let name = ctx.data;
-                    let params = &CONFIG.logs[name];
-                    let verifying_key = load_signing_key(&ctx.env, name)?.verifying_key();
-                    let log_id = &static_ct_api::log_id_from_key(verifying_key)
-                        .map_err(|e| e.to_string())?;
-                    let key = verifying_key
-                        .to_public_key_der()
-                        .map_err(|e| e.to_string())?;
-                    Response::from_json(&LogV3JsonResponse {
-                        description: &params.description,
-                        log_type: &params.log_type,
-                        log_id,
-                        key: key.as_bytes(),
-                        submission_url: &params.submission_url,
-                        monitoring_url: if params.monitoring_url.is_empty() {
-                            &params.submission_url
-                        } else {
-                            &params.monitoring_url
-                        },
-                        mmd: MAX_MERGE_DELAY_SECS,
-                        temporal_interval: &params.temporal_interval,
-                    })
+                    log_v3_json(&ctx.env, ctx.data)
                 })
                 .get("/logs/:log/sequencer_id", |_req, ctx| {
-                    // Print out the Durable Object ID of the sequencer to allow
-                    // looking it up in internal Cloudflare dashboards. This
-                    // value does not need to be kept secret.
-                    let name = ctx.data;
-                    let namespace = ctx.env.durable_object("SEQUENCER")?;
-                    let object_id = namespace.id_from_name(name)?;
-                    Response::ok(object_id.to_string())
+                    sequencer_id(&ctx.env, ctx.data)
                 })
                 .get_async("/logs/:log/*key", |_req, ctx| async move {
-                    let name = ctx.data;
-                    let key = ctx.param("key").unwrap();
-
-                    // Enable direct access to the bucket via the Worker if
-                    // monitoring_url is unspecified.
-                    if CONFIG.logs[name].monitoring_url.is_empty() {
-                        let bucket = load_public_bucket(&ctx.env, name)?;
-                        if let Some(obj) = bucket.get(key).execute().await? {
-                            Response::from_body(
-                                obj.body()
-                                    .ok_or("R2 object missing body")?
-                                    .response_body()?,
-                            )
-                            .map(|r| {
-                                r.with_headers(headers_from_http_metadata(obj.http_metadata()))
-                            })
-                        } else {
-                            Response::error("Not found", 404)
-                        }
-                    } else {
-                        Response::error(
-                            format!(
-                                "Use {} for monitoring API",
-                                CONFIG.logs[name].monitoring_url
-                            ),
-                            404,
-                        )
-                    }
+                    get_object(&ctx.env, ctx.data, ctx.param("key").unwrap()).await
                 })
                 .run(req, ctx.env)
                 .await
@@ -175,6 +116,74 @@ async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
         ctx.wait_until(async move { wshim.flush(&generic_log_worker::obs::logs::LOGGER).await });
     }
     response
+}
+
+/// `GET /logs/:log/ct/v1/get-roots`
+async fn get_roots(env: &Env, name: &str) -> Result<Response> {
+    Response::from_json(&GetRootsResponse {
+        certificates: x509_util::certs_to_bytes(&load_roots(env, name).await?.certs).unwrap(),
+    })
+}
+
+/// `GET /logs/:log/log.v3.json`
+fn log_v3_json(env: &Env, name: &str) -> Result<Response> {
+    let params = &CONFIG.logs[name];
+    let verifying_key = load_signing_key(env, name)?.verifying_key();
+    let log_id = &static_ct_api::log_id_from_key(verifying_key).map_err(|e| e.to_string())?;
+    let key = verifying_key
+        .to_public_key_der()
+        .map_err(|e| e.to_string())?;
+    Response::from_json(&LogV3JsonResponse {
+        description: &params.description,
+        log_type: &params.log_type,
+        log_id,
+        key: key.as_bytes(),
+        submission_url: &params.submission_url,
+        monitoring_url: if params.monitoring_url.is_empty() {
+            &params.submission_url
+        } else {
+            &params.monitoring_url
+        },
+        mmd: MAX_MERGE_DELAY_SECS,
+        temporal_interval: &params.temporal_interval,
+    })
+}
+
+/// `GET /logs/:log/sequencer_id`
+fn sequencer_id(env: &Env, name: &str) -> Result<Response> {
+    // Print out the Durable Object ID of the sequencer to allow looking it up
+    // in internal Cloudflare dashboards. This value does not need to be secret.
+    let namespace = env.durable_object("SEQUENCER")?;
+    let object_id = namespace.id_from_name(name)?;
+    Response::ok(object_id.to_string())
+}
+
+/// `GET /logs/:log/*key` -- direct read-through to the public R2 bucket when
+/// the log's `monitoring_url` is unspecified.
+async fn get_object(env: &Env, name: &str, key: &str) -> Result<Response> {
+    // Enable direct access to the bucket via the Worker if monitoring_url is
+    // unspecified.
+    if CONFIG.logs[name].monitoring_url.is_empty() {
+        let bucket = load_public_bucket(env, name)?;
+        if let Some(obj) = bucket.get(key).execute().await? {
+            Response::from_body(
+                obj.body()
+                    .ok_or("R2 object missing body")?
+                    .response_body()?,
+            )
+            .map(|r| r.with_headers(headers_from_http_metadata(obj.http_metadata())))
+        } else {
+            Response::error("Not found", 404)
+        }
+    } else {
+        Response::error(
+            format!(
+                "Use {} for monitoring API",
+                CONFIG.logs[name].monitoring_url
+            ),
+            404,
+        )
+    }
 }
 
 #[allow(clippy::too_many_lines)]

--- a/crates/generic_log_worker/Cargo.toml
+++ b/crates/generic_log_worker/Cargo.toml
@@ -45,4 +45,4 @@ tlog_entry.workspace = true
 tlog_checkpoint.workspace = true
 tlog_tiles.workspace = true
 tokio.workspace = true
-worker.workspace = true
+worker = { workspace = true, features = ["http"] }

--- a/crates/generic_log_worker/src/obs/mod.rs
+++ b/crates/generic_log_worker/src/obs/mod.rs
@@ -49,11 +49,11 @@ impl Wshim {
                 return;
             }
         };
-        if response.status_code() != 200 {
+        if !response.status().is_success() {
             worker::console_error!(
                 "post to wshim /{} failed with status code: {}",
                 E::endpoint(),
-                response.status_code()
+                response.status().as_u16()
             );
         }
     }

--- a/crates/generic_log_worker/src/util.rs
+++ b/crates/generic_log_worker/src/util.rs
@@ -3,6 +3,7 @@
 
 //! Utility functions.
 
+use futures_util::StreamExt as _;
 #[cfg(test)]
 use parking_lot::ReentrantMutex;
 #[cfg(test)]
@@ -42,4 +43,25 @@ pub(crate) fn set_freeze_time(b: bool) {
 #[cfg(test)]
 pub(crate) fn set_global_time(time: u64) {
     GLOBAL_TIME.store(time, Ordering::Relaxed);
+}
+
+pub struct WorkerByteStream(worker::send::SendWrapper<worker::ByteStream>);
+impl WorkerByteStream {
+    #[must_use]
+    pub fn new(stream: worker::ByteStream) -> Self {
+        Self(worker::send::SendWrapper::new(stream))
+    }
+}
+
+impl futures_util::Stream for WorkerByteStream {
+    type Item = Result<Vec<u8>, worker::Error>;
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.as_mut().0 .0.poll_next_unpin(cx)
+    }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0 .0.size_hint()
+    }
 }

--- a/crates/witness_worker/Cargo.toml
+++ b/crates/witness_worker/Cargo.toml
@@ -27,6 +27,7 @@ jsonschema.workspace = true
 serde_json.workspace = true
 
 [dependencies]
+axum.workspace = true
 config = { path = "./config", package = "witness_worker_config" }
 console_error_panic_hook.workspace = true
 console_log.workspace = true
@@ -41,11 +42,12 @@ serde.workspace = true
 serde_json.workspace = true
 serde_with.workspace = true
 signed_note.workspace = true
-tlog_core.workspace = true
 tlog_checkpoint.workspace = true
+tlog_core.workspace = true
 tlog_cosignature.workspace = true
 tlog_witness.workspace = true
-worker.workspace = true
+tower-service.workspace = true
+worker = { workspace = true, features = ["http", "axum"] }
 
 [dev-dependencies]
 base64.workspace = true

--- a/crates/witness_worker/src/frontend_worker.rs
+++ b/crates/witness_worker/src/frontend_worker.rs
@@ -41,8 +41,17 @@ use crate::{
     witness_state_do::{state_stub, CheckAndUpdateRequest, LatestCheckpoint},
     WitnessSigner, CONFIG,
 };
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::{header, StatusCode},
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
 use serde::Serialize;
 use serde_with::{base64::Base64 as Base64As, serde_as};
+use tower_service::Service;
 
 /// Entry point: initialize logging and dispatch to the router.
 #[event(start)]
@@ -58,33 +67,85 @@ fn start() {
     let _ = console_log::init_with_level(level);
 }
 
-/// Top-level `#[event(fetch)]` handler.
+/// Top-level `#[event(fetch)]` handler. Delegates to the axum [`router`].
 #[event(fetch, respond_with_errors)]
-async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
-    // /sign-subtree is OPTIONAL per c2sp.org/tlog-witness; we register
-    // the route unconditionally and the handler returns 404 when the
-    // configured signing key isn't ML-DSA-44. This keeps the routing
-    // table static (no need to touch the witness signer at startup just
-    // to decide whether to register a route).
-    Router::new()
-        .post_async("/add-checkpoint", |req, ctx| async move {
-            add_checkpoint(req, ctx.env).await
-        })
-        .post_async("/sign-subtree", |req, ctx| async move {
-            sign_subtree(req, ctx.env).await
-        })
-        .get("/metadata", |_req, ctx| metadata(&ctx.env))
-        .get("/", |_req, _ctx| root())
-        .run(req, env)
-        .await
+async fn fetch(
+    req: HttpRequest,
+    env: Env,
+    _ctx: Context,
+) -> Result<axum::http::Response<axum::body::Body>> {
+    Ok(Router::new()
+        .route("/add-checkpoint", post(add_checkpoint))
+        .route("/sign-subtree", post(sign_subtree))
+        .route("/metadata", get(metadata))
+        .route("/", get(root))
+        .with_state(env)
+        .call(req)
+        .await?)
 }
 
 /// `GET /` -- witness identity string.
-fn root() -> Result<Response> {
-    Response::ok(format!(
-        "{} — c2sp.org/tlog-witness witness\n",
-        CONFIG.witness_name
-    ))
+async fn root() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+        format!("{} — c2sp.org/tlog-witness witness\n", CONFIG.witness_name),
+    )
+}
+
+/// Result type for axum handlers in this module: each handler builds a
+/// [`worker::Response`] which is converted to an axum response at the
+/// boundary via the `From<worker::Response>` impl from the worker crate's
+/// `axum` feature.
+type ApiResult<T> = std::result::Result<T, AppError>;
+
+enum AppError {
+    InternalServerError(String),
+    BadRequest(String),
+    NotFound,
+    UnknownLogOrigin,
+    NoValidSignatures,
+    ReferenceCheckpointNotCosignedByThisWitness,
+    SubtreeConsistencyProofFailed,
+}
+
+impl From<worker::Error> for AppError {
+    fn from(err: worker::Error) -> Self {
+        Self::InternalServerError(err.to_string())
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            AppError::InternalServerError(error) => {
+                log::error!("unhandled error: {error}");
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
+            AppError::BadRequest(e) => {
+                (StatusCode::BAD_REQUEST, format!("Bad request: {e}")).into_response()
+            }
+            AppError::NotFound => (StatusCode::NOT_FOUND, "Not Found").into_response(),
+            AppError::UnknownLogOrigin => {
+                (StatusCode::NOT_FOUND, "Unknown log origin").into_response()
+            }
+            AppError::NoValidSignatures => (
+                StatusCode::FORBIDDEN,
+                "No valid signatures from trusted log keys",
+            )
+                .into_response(),
+            AppError::ReferenceCheckpointNotCosignedByThisWitness => (
+                StatusCode::FORBIDDEN,
+                "Reference checkpoint is not cosigned by this witness",
+            )
+                .into_response(),
+            AppError::SubtreeConsistencyProofFailed => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "Subtree consistency proof failed",
+            )
+                .into_response(),
+        }
+    }
 }
 
 /// Response body for the `/metadata` endpoint.
@@ -121,9 +182,10 @@ struct LogMetadata<'a> {
     log_public_keys: Vec<&'a [u8]>,
 }
 
-/// `GET /metadata` handler.
-fn metadata(env: &Env) -> Result<Response> {
-    let witness_public_key = load_witness_public_key_der(env)?;
+/// `GET /metadata` route handler.
+#[worker::send]
+async fn metadata(State(env): State<Env>) -> ApiResult<impl IntoResponse> {
+    let witness_public_key = load_witness_public_key_der(&env)?;
     let logs: Vec<LogMetadata> = CONFIG
         .logs
         .iter()
@@ -144,10 +206,10 @@ fn metadata(env: &Env) -> Result<Response> {
             .unwrap_or(&CONFIG.submission_prefix),
         logs,
     };
-    Response::from_json(&body)
+    Ok((StatusCode::OK, Json(body)))
 }
 
-/// Handle `POST /add-checkpoint`.
+/// `POST /add-checkpoint` route handler.
 ///
 /// The flow mirrors the MUSTs listed in the spec, in order:
 ///
@@ -169,7 +231,8 @@ fn metadata(env: &Env) -> Result<Response> {
 /// "check then write" pair is atomic per origin.
 ///
 /// [`WitnessState`]: crate::witness_state_do
-async fn add_checkpoint(mut req: Request, env: Env) -> Result<Response> {
+#[worker::send]
+async fn add_checkpoint(State(env): State<Env>, body: Bytes) -> ApiResult<impl IntoResponse> {
     // (1) Parse.
     //
     // Cap the request body at `MAX_ADD_CHECKPOINT_BODY_SIZE` so a
@@ -179,12 +242,10 @@ async fn add_checkpoint(mut req: Request, env: Env) -> Result<Response> {
     // note (capped at `signed_note::MAX_NOTE_SIZE = 1 MiB`); anything
     // larger is guaranteed to be rejected downstream and we avoid the
     // allocation by rejecting it here.
-    let body = req.bytes().await?;
     if body.len() > MAX_ADD_CHECKPOINT_BODY_SIZE {
-        return Response::error(
-            format!("Bad request: body exceeds {MAX_ADD_CHECKPOINT_BODY_SIZE} bytes"),
-            400,
-        );
+        return Err(AppError::BadRequest(format!(
+            "body exceeds {MAX_ADD_CHECKPOINT_BODY_SIZE} bytes"
+        )));
     }
     let AddCheckpointRequest {
         old_size,
@@ -194,10 +255,9 @@ async fn add_checkpoint(mut req: Request, env: Env) -> Result<Response> {
         Ok(r) => r,
         Err(e) => {
             log::warn!("add-checkpoint: malformed request: {e}");
-            return Response::error(format!("Bad request: {e}"), 400);
+            return Err(AppError::BadRequest(e.to_string()));
         }
     };
-
     // (2) Parse the checkpoint body and look up the log by its origin.
     //
     // `CheckpointText::from_bytes` validates the full checkpoint shape
@@ -209,14 +269,13 @@ async fn add_checkpoint(mut req: Request, env: Env) -> Result<Response> {
         Ok(t) => t,
         Err(e) => {
             log::warn!("add-checkpoint: malformed checkpoint text: {e:?}");
-            return Response::error(format!("Bad request: {e}"), 400);
+            return Err(AppError::BadRequest(e.to_string()));
         }
     };
     let origin = cp_text.origin();
     let Some(verifiers) = log_verifiers(origin) else {
-        return Response::error("Unknown log origin", 404);
+        return Err(AppError::UnknownLogOrigin);
     };
-
     // (3) Verify the checkpoint signature against trusted log keys.
     //
     // Per c2sp.org/tlog-witness, the witness accepts the checkpoint as
@@ -240,26 +299,21 @@ async fn add_checkpoint(mut req: Request, env: Env) -> Result<Response> {
         match e {
             NoteError::UnverifiedNote | NoteError::InvalidSignature { .. } => {
                 log::info!("add-checkpoint: rejecting note: {e:?}");
-                return Response::error("No valid signatures from trusted log keys", 403);
+                return Err(AppError::NoValidSignatures);
             }
             _ => {
                 log::warn!("add-checkpoint: verify failed: {e:?}");
-                return Response::error(format!("Bad request: {e}"), 400);
+                return Err(AppError::BadRequest(e.to_string()));
             }
         }
     }
-
     // (4) Range check.
     if old_size > cp_text.size() {
-        return Response::error(
-            format!(
-                "Bad request: old_size {old_size} > checkpoint size {}",
-                cp_text.size()
-            ),
-            400,
-        );
+        return Err(AppError::BadRequest(format!(
+            "old_size {old_size} > checkpoint size {}",
+            cp_text.size()
+        )));
     }
-
     // (5, 6, 7) Atomic check-proof-and-update against the per-origin DO.
     // See [`dispatch_check_and_update`] for the status-code mapping.
     let update = CheckAndUpdateRequest {
@@ -271,7 +325,6 @@ async fn add_checkpoint(mut req: Request, env: Env) -> Result<Response> {
     if let Some(resp) = dispatch_check_and_update(&env, origin, &update).await? {
         return Ok(resp);
     }
-
     // (8) Produce and return the cosignature.
     //
     // The witness's algorithm (Ed25519 or ML-DSA-44) is determined at
@@ -287,12 +340,10 @@ async fn add_checkpoint(mut req: Request, env: Env) -> Result<Response> {
         .sign(now, &cp_text)
         .map_err(|e| Error::from(format!("signing: {e:?}")))?;
     let body = serialize_add_checkpoint_response(std::slice::from_ref(&note_sig));
-    let headers = Headers::new();
-    headers.set("content-type", "text/plain; charset=utf-8")?;
-    Ok(Response::from_body(ResponseBody::Body(body))?.with_headers(headers))
+    Ok(([(header::CONTENT_TYPE, "text/plain; charset=utf-8")], body).into_response())
 }
 
-/// Handle `POST /sign-subtree`.
+/// `POST /sign-subtree` handler.
 ///
 /// OPTIONAL endpoint per [c2sp.org/tlog-witness#sign-subtree][spec].
 /// Wired up only when the witness is configured with an ML-DSA-44
@@ -330,8 +381,14 @@ async fn add_checkpoint(mut req: Request, env: Env) -> Result<Response> {
 ///    the resulting `subtree/v1` signature line.
 ///
 /// [spec]: https://c2sp.org/tlog-witness#sign-subtree
-#[allow(clippy::too_many_lines)] // single-handler pattern; mirrors add-checkpoint.
-async fn sign_subtree(mut req: Request, env: Env) -> Result<Response> {
+#[allow(clippy::too_many_lines)]
+// single-handler pattern; mirrors add-checkpoint.
+// Owned `env`/`body` keep this signature symmetric with the async
+// `add_checkpoint_inner`; being synchronous it would otherwise trip
+// `needless_pass_by_value` for values it only reads.
+#[allow(clippy::needless_pass_by_value)]
+#[worker::send]
+async fn sign_subtree(State(env): State<Env>, body: Bytes) -> ApiResult<impl IntoResponse> {
     // The handler exists in the route table for both algorithms, but the
     // spec marks the endpoint as OPTIONAL: an Ed25519 witness simply
     // doesn't support it. Surface that as 404, matching the spec's
@@ -342,16 +399,14 @@ async fn sign_subtree(mut req: Request, env: Env) -> Result<Response> {
         ..
     } = signer
     else {
-        return Response::error("Not Found", 404);
+        return Err(AppError::NotFound);
     };
 
     // (1) Parse the body.
-    let body = req.bytes().await?;
     if body.len() > MAX_SIGN_SUBTREE_BODY_SIZE {
-        return Response::error(
-            format!("Bad request: body exceeds {MAX_SIGN_SUBTREE_BODY_SIZE} bytes"),
-            400,
-        );
+        return Err(AppError::BadRequest(format!(
+            "body exceeds {MAX_SIGN_SUBTREE_BODY_SIZE} bytes"
+        )));
     }
     let SignSubtreeRequest {
         subtree_start,
@@ -364,7 +419,7 @@ async fn sign_subtree(mut req: Request, env: Env) -> Result<Response> {
         Ok(r) => r,
         Err(e) => {
             log::warn!("sign-subtree: malformed request: {e}");
-            return Response::error(format!("Bad request: {e}"), 400);
+            return Err(AppError::BadRequest(e.to_string()));
         }
     };
 
@@ -376,22 +431,19 @@ async fn sign_subtree(mut req: Request, env: Env) -> Result<Response> {
         Ok(t) => t,
         Err(e) => {
             log::warn!("sign-subtree: malformed checkpoint text: {e:?}");
-            return Response::error(format!("Bad request: {e}"), 400);
+            return Err(AppError::BadRequest(e.to_string()));
         }
     };
     if subtree_end > cp_text.size() {
-        return Response::error(
-            format!(
-                "Bad request: subtree end {subtree_end} > checkpoint size {}",
-                cp_text.size(),
-            ),
-            400,
-        );
+        return Err(AppError::BadRequest(format!(
+            "subtree end {subtree_end} > checkpoint size {}",
+            cp_text.size(),
+        )));
     }
     let subtree = match Subtree::new(subtree_start, subtree_end) {
         Ok(s) => s,
         Err(e) => {
-            return Response::error(format!("Bad request: invalid subtree: {e:?}"), 400);
+            return Err(AppError::BadRequest(format!("invalid subtree: {e:?}")));
         }
     };
 
@@ -402,7 +454,7 @@ async fn sign_subtree(mut req: Request, env: Env) -> Result<Response> {
     // the witness operator.
     let origin = cp_text.origin();
     if log_verifiers(origin).is_none() {
-        return Response::error("Unknown log origin", 404);
+        return Err(AppError::UnknownLogOrigin);
     }
 
     // (4) Stateless verification: the submitted checkpoint MUST carry
@@ -415,14 +467,11 @@ async fn sign_subtree(mut req: Request, env: Env) -> Result<Response> {
         match e {
             NoteError::UnverifiedNote | NoteError::InvalidSignature { .. } => {
                 log::info!("sign-subtree: rejecting note: {e:?}");
-                return Response::error(
-                    "Forbidden: reference checkpoint is not cosigned by this witness",
-                    403,
-                );
+                return Err(AppError::ReferenceCheckpointNotCosignedByThisWitness);
             }
             _ => {
                 log::warn!("sign-subtree: verify failed: {e:?}");
-                return Response::error(format!("Bad request: {e}"), 400);
+                return Err(AppError::BadRequest(e.to_string()));
             }
         }
     }
@@ -437,10 +486,7 @@ async fn sign_subtree(mut req: Request, env: Env) -> Result<Response> {
     )
     .is_err()
     {
-        return Response::error(
-            "Unprocessable Entity: subtree consistency proof failed",
-            422,
-        );
+        return Err(AppError::SubtreeConsistencyProofFailed);
     }
 
     // (6) Sign the subtree. Per the spec the timestamp on a non-zero-
@@ -452,10 +498,11 @@ async fn sign_subtree(mut req: Request, env: Env) -> Result<Response> {
     // signature is bound by the same verification window — the request
     // is meaningful even with a zero timestamp.
     let note_sig = subtree_signer.sign_subtree(0, origin, &subtree, &subtree_hash);
-    let body = serialize_sign_subtree_response(std::slice::from_ref(&note_sig));
-    let headers = Headers::new();
-    headers.set("content-type", "text/plain; charset=utf-8")?;
-    Ok(Response::from_body(ResponseBody::Body(body))?.with_headers(headers))
+    Ok((
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+        serialize_sign_subtree_response(std::slice::from_ref(&note_sig)),
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -500,7 +547,7 @@ async fn dispatch_check_and_update(
     env: &Env,
     origin: &str,
     update: &CheckAndUpdateRequest,
-) -> Result<Option<Response>> {
+) -> Result<Option<axum::response::Response>> {
     let stub = state_stub(env, origin)?;
     let mut resp = stub
         .fetch_with_request(Request::new_with_init(
@@ -525,32 +572,36 @@ async fn dispatch_check_and_update(
         }
         409 => {
             let current: LatestCheckpoint = resp.json().await?;
-            Ok(Some(tlog_size_conflict(&current)?))
+            Ok(Some(tlog_size_conflict(&current)))
         }
-        422 => Ok(Some(Response::error(
-            "Unprocessable Entity: consistency proof failed",
-            422,
-        )?)),
+        422 => Ok(Some(
+            (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "Unprocessable Entity: consistency proof failed",
+            )
+                .into_response(),
+        )),
         400 => {
             let msg = resp.text().await.unwrap_or_else(|_| "Bad request".into());
-            Ok(Some(Response::error(format!("Bad request: {msg}"), 400)?))
+            Ok(Some(AppError::BadRequest(msg).into_response()))
         }
-        status => Ok(Some(Response::error(
-            format!("Internal error: DO returned {status}"),
-            500,
-        )?)),
+        status => Ok(Some(
+            AppError::InternalServerError(format!("Internal error: DO returned {status}"))
+                .into_response(),
+        )),
     }
 }
 
 /// Build the 409 response body per the spec:
 /// `text/x.tlog.size` content type, decimal latest size followed by a newline.
-fn tlog_size_conflict(current: &LatestCheckpoint) -> Result<Response> {
+fn tlog_size_conflict(current: &LatestCheckpoint) -> axum::response::Response {
     let body = format!("{}\n", current.size);
-    let headers = Headers::new();
-    headers.set("content-type", CONTENT_TYPE_TLOG_SIZE)?;
-    Ok(Response::from_body(ResponseBody::Body(body.into_bytes()))?
-        .with_status(409)
-        .with_headers(headers))
+    (
+        StatusCode::CONFLICT,
+        [(header::CONTENT_TYPE, CONTENT_TYPE_TLOG_SIZE)],
+        body,
+    )
+        .into_response()
 }
 
 #[cfg(test)]

--- a/crates/witness_worker/src/frontend_worker.rs
+++ b/crates/witness_worker/src/frontend_worker.rs
@@ -74,14 +74,17 @@ async fn fetch(req: Request, env: Env, _ctx: Context) -> Result<Response> {
             sign_subtree(req, ctx.env).await
         })
         .get("/metadata", |_req, ctx| metadata(&ctx.env))
-        .get("/", |_req, _ctx| {
-            Response::ok(format!(
-                "{} — c2sp.org/tlog-witness witness\n",
-                CONFIG.witness_name
-            ))
-        })
+        .get("/", |_req, _ctx| root())
         .run(req, env)
         .await
+}
+
+/// `GET /` -- witness identity string.
+fn root() -> Result<Response> {
+    Response::ok(format!(
+        "{} — c2sp.org/tlog-witness witness\n",
+        CONFIG.witness_name
+    ))
 }
 
 /// Response body for the `/metadata` endpoint.


### PR DESCRIPTION
The `axum::Router` is much more flexible than the native `worker::Router`
implementation and makes use of the rust http ecosystem. It also allows for type
safe request parameter validation as well as middleware. Which is usefull when
trying to instrument the workers for production (adding metrics, etc). Which is
something I'll be adding in a follow up PR.

- **Factor out route handlers to seperate functions**
    First the request handling logic was factored out to seperate functions
- **Migrate to axum::Router**
    And after that they were migrated to use axum, in the hope that this helps
    review the code.

There is some code duplication in this PR, but it's the "same amount" of code duplication that was already present in the codebase. The deduplication work is left as a future exercise to avoid overloading this PR.
