### PR TITLE
Add larger bucket for request time metrics

### DIFF
--- a/crates/generic_log_worker/src/obs/metrics.rs
+++ b/crates/generic_log_worker/src/obs/metrics.rs
@@ -212,7 +212,7 @@ impl FrontendWorkerMetrics {
             "http_request_duration_ms",
             "Duration of an http request made to the frontend worker",
             &["path", "log"],
-            vec![50., 100., 200., 400., 1000., 2000., 4000.],
+            vec![50., 100., 500., 1000., 2000., 4000., 8000., 10_000.],
             r
         )
         .unwrap();


### PR DESCRIPTION
Some requests (add-chain and add-pre-chain) take longer than 4 seconds
consistently so we need buckets reaching into those values to capture spikes in
latency
