### PR TITLE
mirror_worker: align compatibility_date with other workers

### DIFF
--- a/crates/mirror_worker/wrangler.jsonc
+++ b/crates/mirror_worker/wrangler.jsonc
@@ -1,7 +1,7 @@
 {
     "name": "tlog-mirror",
     "main": "build/worker/shim.mjs",
-    "compatibility_date": "2026-07-17",
+    "compatibility_date": "2025-09-25",
     "workers_dev": false,
     "build": {
         "command": "echo 'Default environment not configured. Please specify an environment with the \"-e\" flag.' && exit 1"


### PR DESCRIPTION
The scaffold landed 2026-07-17, which the pinned wrangler runtime cannot start (newest supported date is older) and which diverges from every other worker crate (all 2025-09-25). Nothing in mirror_worker relies on a newer runtime, so align it.