### PR TITLE
mirror_worker: wire in Sentry observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,8 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "ed25519-dalek",
+ "generic_log_worker",
+ "getrandom 0.3.4",
  "getrandom 0.4.2",
  "hex",
  "jsonschema",

--- a/crates/mirror_worker/Cargo.toml
+++ b/crates/mirror_worker/Cargo.toml
@@ -35,7 +35,9 @@ axum.workspace = true
 config = { path = "./config", package = "mirror_worker_config" }
 console_error_panic_hook.workspace = true
 console_log.workspace = true
+generic_log_worker.workspace = true
 getrandom.workspace = true
+getrandom_03.workspace = true
 hex.workspace = true
 log.workspace = true
 ml-dsa.workspace = true

--- a/crates/mirror_worker/src/frontend_worker.rs
+++ b/crates/mirror_worker/src/frontend_worker.rs
@@ -64,18 +64,26 @@ async fn fetch(
     env: Env,
     _ctx: Context,
 ) -> Result<axum::http::Response<axum::body::Body>> {
-    // `Router`'s `Service::Error` is `Infallible`; `?` performs the
-    // trivial conversion into `worker::Error`.
-    Ok(Router::new()
-        .route(
-            "/add-checkpoint",
-            post(add_checkpoint).layer(DefaultBodyLimit::max(MAX_ADD_CHECKPOINT_BODY_SIZE)),
-        )
-        .route("/metadata", get(metadata))
-        .route("/", get(root))
-        .with_state(env)
-        .call(req)
-        .await?)
+    crate::init_sentry(&env);
+    // Wrap the router in the sentry catch/flush guard so a panic in any
+    // handler is captured and shipped before the WASM isolate is torn
+    // down. `Router`'s `Service::Error` is `Infallible`; the `?` below
+    // performs the trivial conversion into `worker::Error`.
+    let response = generic_log_worker::obs::sentry::catch_unwind_and_flush(async {
+        Router::new()
+            .route(
+                "/add-checkpoint",
+                post(add_checkpoint).layer(DefaultBodyLimit::max(MAX_ADD_CHECKPOINT_BODY_SIZE)),
+            )
+            .route("/metadata", get(metadata))
+            .route("/", get(root))
+            .with_state(env)
+            .call(req)
+            .await
+    })
+    .await?;
+    generic_log_worker::obs::sentry::flush().await;
+    Ok(response)
 }
 
 /// `GET /` -- mirror identity string. Convenience only; not part of the

--- a/crates/mirror_worker/src/lib.rs
+++ b/crates/mirror_worker/src/lib.rs
@@ -213,6 +213,31 @@ pub(crate) fn load_mirror_public_key_der(env: &Env) -> Result<&'static [u8]> {
     Ok(load_mirror_signer(env)?.public_key_der())
 }
 
+/// Initialize sentry from the `SENTRY_DSN` environment variable.
+///
+/// Does nothing when the variable is absent or empty, allowing
+/// deployments without sentry support. Called at the top of the frontend
+/// `fetch` handler and in each Durable Object's `new`, so a panic anywhere
+/// in the worker is captured and flushed.
+pub(crate) fn init_sentry(env: &Env) {
+    if let Ok(dsn) = env.var("SENTRY_DSN") {
+        let access_id = env
+            .var("SENTRY_ACCESS_CLIENT_ID")
+            .ok()
+            .map(|v| v.to_string());
+        let access_secret = env
+            .secret("SENTRY_ACCESS_CLIENT_SECRET")
+            .ok()
+            .map(|v| v.to_string());
+        let _ = generic_log_worker::obs::sentry::init(
+            &dsn.to_string(),
+            env!("DEPLOY_ENV"),
+            access_id.as_deref(),
+            access_secret.as_deref(),
+        );
+    }
+}
+
 #[cfg(test)]
 mod signer_tests {
     //! Unit tests for the mirror signer loader: only ML-DSA-44 keys are

--- a/crates/mirror_worker/src/mirror_state_do.rs
+++ b/crates/mirror_worker/src/mirror_state_do.rs
@@ -171,13 +171,23 @@ struct MirrorState {
     state: State,
 }
 
+// SAFETY: Durable Objects are single-threaded; the `RefUnwindSafe` bound
+// is required by `wasm-bindgen` when building with `panic=unwind` (so the
+// sentry catch-unwind guard can wrap the fetch handler).
+impl std::panic::RefUnwindSafe for MirrorState {}
+
 impl DurableObject for MirrorState {
-    fn new(state: State, _env: Env) -> Self {
+    fn new(state: State, env: Env) -> Self {
+        crate::init_sentry(&env);
         Self { state }
     }
 
     async fn fetch(&self, req: Request) -> Result<Response> {
-        self.fetch_inner(req).await
+        generic_log_worker::obs::sentry::catch_unwind_report_and_flush(
+            &[("handler", "do_fetch"), ("do_type", "mirror_state")],
+            self.fetch_inner(req),
+        )
+        .await
     }
 }
 

--- a/crates/mirror_worker/wrangler.jsonc
+++ b/crates/mirror_worker/wrangler.jsonc
@@ -15,7 +15,10 @@
                 // RUSTFLAGS: force legacy Wasm EH so wasm-bindgen 0.2.126's
                 // wasmparser accepts the module (modern exnref opcodes from
                 // nightly >=2026-05-09 are not yet supported).
-                "command": "cargo install -q worker-build@0.8.5 && DEPLOY_ENV=dev RUSTFLAGS='-Cllvm-args=-wasm-use-legacy-eh' worker-build --release"
+                // --panic-unwind: build with panic=unwind so the sentry
+                // catch-unwind guards in the fetch/DO handlers can report
+                // panics before the isolate is torn down.
+                "command": "cargo install -q worker-build@0.8.5 && DEPLOY_ENV=dev RUSTFLAGS='-Cllvm-args=-wasm-use-legacy-eh' worker-build --release --panic-unwind"
             },
             "workers_dev": true,
             "durable_objects": {


### PR DESCRIPTION
Initialize Sentry from SENTRY_DSN (no-op when unset) and wrap the frontend fetch and the MirrorState DO fetch in the generic_log_worker catch-unwind guards, so a panic anywhere is captured and flushed before the isolate is torn down. This requires building with panic=unwind (--panic-unwind in the worker-build command), which in turn needs getrandom_03 to enable the wasm_js backend for Sentry's transitive getrandom 0.3 dependency.