### PR TITLE
chore: add @by-cf and remove @rozbb from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # List members individually for permission to run /bonk
-* @lukevalenta @bwesterb @cjpatton @rozbb @mendess @lbaquerofierro @cloudflare/research
+* @lukevalenta @bwesterb @cjpatton @mendess @lbaquerofierro @by-cf @cloudflare/research


### PR DESCRIPTION
Adds @by-cf and removes @rozbb from CODEOWNERS (review / `/bonk` permissions).

Follow-up from #274 (npm publish workflow).