### PR TITLE
fix clippy lints surfaced by Rust 1.98

### DIFF
--- a/crates/generic_log_worker/src/log_ops.rs
+++ b/crates/generic_log_worker/src/log_ops.rs
@@ -1407,6 +1407,10 @@ pub async fn upload_issuers(
 
 #[cfg(test)]
 mod tests {
+    // Test backends implement the async storage traits without awaiting; the
+    // trait signatures are `async fn`, so the impls must stay `async` to match.
+    #![allow(clippy::unused_async_trait_impl)]
+
     use super::*;
     use crate::{empty_checkpoint_callback, util};
     use tlog_core::LeafIndex;

--- a/crates/tlog_tiles/src/tile.rs
+++ b/crates/tlog_tiles/src/tile.rs
@@ -1031,9 +1031,9 @@ mod tests {
                 let max_hi = if lo == 0 {
                     u64::MAX
                 } else {
-                    // If `lo` is non-zero, find the maximum power of 2 that divides `lo`.
-                    // This is a bitwise trick that isolates the lowest set bit.
-                    let max_size = lo & lo.wrapping_neg();
+                    // If `lo` is non-zero, find the maximum power of 2 that divides `lo`:
+                    // the lowest set bit.
+                    let max_size = lo.isolate_lowest_one();
                     lo + max_size
                 };
                 for hi in lo + 1..=i.min(max_hi) {

--- a/crates/tlog_tiles_wasm/src/lib.rs
+++ b/crates/tlog_tiles_wasm/src/lib.rs
@@ -118,10 +118,9 @@ pub fn verify_consistency_proof(
         )));
     }
 
-    let proof: Vec<tlog_core::Hash> = proof_hashes
-        .chunks_exact(32)
-        .map(|chunk| tlog_core::Hash(chunk.try_into().unwrap()))
-        .collect();
+    // Length is validated as a multiple of 32 above, so the remainder is empty.
+    let (chunks, _) = proof_hashes.as_chunks::<32>();
+    let proof: Vec<tlog_core::Hash> = chunks.iter().copied().map(tlog_core::Hash).collect();
 
     // Underlying API: (proof, n=new_size, root_hash=new_root, m=old_size, m_hash=old_root)
     tlog_core::verify_consistency_proof(


### PR DESCRIPTION
CI runs clippy from the latest stable (`rustup update stable`), which advanced to 1.98 and started failing the required `cargo clippy -- -D warnings` job on pre-existing code.

- **tlog_tiles_wasm** (required lint): `slice::as_chunks::<32>()` instead of `chunks_exact(32)` (`chunks_exact_to_as_chunks`), which also drops the `try_into().unwrap()`.
- **tlog_tiles** (pedantic): `u64::isolate_lowest_one()` in a test (`manual_isolate_lowest_one`).
- **generic_log_worker** (pedantic): `#![allow(clippy::unused_async_trait_impl)]` on the test storage backends, whose `async fn` trait signatures require the impls stay `async` even without an `await`.

Verified locally on 1.98: `cargo clippy -- -D warnings`, workspace `-Dclippy::pedantic`, `cargo test`, `cargo fmt --all --check`, and `cargo shear` all pass.