### PR TITLE
Add repository metadata to wasm crates for npm provenance

### DIFF
--- a/crates/signed_note_wasm/Cargo.toml
+++ b/crates/signed_note_wasm/Cargo.toml
@@ -3,6 +3,8 @@ name = "signed_note_wasm"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "wasm-bindgen wrapper for the signed_note crate (c2sp.org/signed-note)"
 publish = false
 

--- a/crates/tlog_tiles_wasm/Cargo.toml
+++ b/crates/tlog_tiles_wasm/Cargo.toml
@@ -3,6 +3,8 @@ name = "tlog_tiles_wasm"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "wasm-bindgen wrapper for the tlog_tiles crate (c2sp.org/tlog-tiles, c2sp.org/tlog-checkpoint)"
 publish = false
 


### PR DESCRIPTION
Triggered pipeline, but it failed https://github.com/cloudflare/azul/actions/runs/32501312751/job/96831377550:
```
Failed to validate repository information: package.json: "repository.url" is "",
expected to match "https://github.com/cloudflare/azul" from provenance
```

Solution: need updated repository.url.