### PR TITLE
generic_log_worker: share Worker runtime utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4219,7 +4219,6 @@ dependencies = [
  "generic_log_worker",
  "getrandom 0.3.4",
  "getrandom 0.4.2",
- "hex",
  "log",
  "ml-dsa",
  "p256",

--- a/crates/bootstrap_mtc_worker/src/lib.rs
+++ b/crates/bootstrap_mtc_worker/src/lib.rs
@@ -16,6 +16,8 @@ use std::sync::{LazyLock, OnceLock};
 use worker::*;
 use x509_util::CertPool;
 
+pub(crate) use generic_log_worker::obs::sentry::init_from_env as init_sentry;
+
 mod batcher_do;
 mod ccadb_roots_cron;
 mod cleaner_do;
@@ -34,29 +36,6 @@ static CONFIG: LazyLock<AppConfig> = LazyLock::new(|| {
 
 static SIGNING_KEY_MAP: OnceLock<HashMap<String, OnceLock<Ed25519SigningKey>>> = OnceLock::new();
 static ROOTS: OnceLock<CertPool> = OnceLock::new();
-
-/// Initialize sentry from the `SENTRY_DSN` environment variable.
-///
-/// Does nothing when the variable is absent or empty, allowing deployments
-/// without sentry support.
-pub(crate) fn init_sentry(env: &Env) {
-    if let Ok(dsn) = env.var("SENTRY_DSN") {
-        let access_id = env
-            .var("SENTRY_ACCESS_CLIENT_ID")
-            .ok()
-            .map(|v| v.to_string());
-        let access_secret = env
-            .secret("SENTRY_ACCESS_CLIENT_SECRET")
-            .ok()
-            .map(|v| v.to_string());
-        let _ = generic_log_worker::obs::sentry::init(
-            &dsn.to_string(),
-            env!("DEPLOY_ENV"),
-            access_id.as_deref(),
-            access_secret.as_deref(),
-        );
-    }
-}
 
 pub(crate) fn load_signing_key(env: &Env, name: &str) -> Result<&'static Ed25519SigningKey> {
     load_ed25519_key(env, name, &SIGNING_KEY_MAP, &format!("SIGNING_KEY_{name}"))

--- a/crates/ct_worker/src/lib.rs
+++ b/crates/ct_worker/src/lib.rs
@@ -15,6 +15,8 @@ use tlog_checkpoint::{CheckpointSigner, Ed25519CheckpointSigner};
 use worker::{Date, Env, Result, send::SendWrapper};
 use x509_util::CertPool;
 
+pub(crate) use generic_log_worker::obs::sentry::init_from_env as init_sentry;
+
 mod batcher_do;
 mod ccadb_roots_cron;
 mod cleaner_do;
@@ -32,29 +34,6 @@ static CONFIG: LazyLock<AppConfig> = LazyLock::new(|| {
 
 static SIGNING_KEY_MAP: OnceLock<HashMap<String, OnceLock<EcdsaSigningKey>>> = OnceLock::new();
 static WITNESS_KEY_MAP: OnceLock<HashMap<String, OnceLock<Ed25519SigningKey>>> = OnceLock::new();
-
-/// Initialize sentry from the `SENTRY_DSN` environment variable.
-///
-/// Does nothing when the variable is absent or empty, allowing deployments
-/// without sentry support.
-pub(crate) fn init_sentry(env: &Env) {
-    if let Ok(dsn) = env.var("SENTRY_DSN") {
-        let access_id = env
-            .var("SENTRY_ACCESS_CLIENT_ID")
-            .ok()
-            .map(|v| v.to_string());
-        let access_secret = env
-            .secret("SENTRY_ACCESS_CLIENT_SECRET")
-            .ok()
-            .map(|v| v.to_string());
-        let _ = generic_log_worker::obs::sentry::init(
-            &dsn.to_string(),
-            env!("DEPLOY_ENV"),
-            access_id.as_deref(),
-            access_secret.as_deref(),
-        );
-    }
-}
 
 pub(crate) fn load_signing_key(env: &Env, name: &str) -> Result<&'static EcdsaSigningKey> {
     let once = &SIGNING_KEY_MAP.get_or_init(|| {

--- a/crates/generic_log_worker/src/hash_serde.rs
+++ b/crates/generic_log_worker/src/hash_serde.rs
@@ -1,0 +1,75 @@
+use tlog_core::{HASH_SIZE, Hash};
+
+fn from_hex(s: &str) -> Result<Hash, String> {
+    let bytes: [u8; HASH_SIZE] = ::hex::decode(s)
+        .map_err(|e| e.to_string())?
+        .try_into()
+        .map_err(|v: Vec<u8>| format!("hash must be {} bytes, got {}", HASH_SIZE, v.len()))?;
+    Ok(Hash(bytes))
+}
+
+pub mod hex {
+    use super::{Hash, from_hex};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Serialize a hash as a lowercase hex string.
+    ///
+    /// # Errors
+    ///
+    /// Returns the serializer's error.
+    pub fn serialize<S>(hash: &Hash, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        ::hex::encode(hash.0).serialize(serializer)
+    }
+
+    /// Deserialize a hash from a hex string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid hex or a hash of the wrong length.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Hash, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        from_hex(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+pub mod vec_hex {
+    use super::{Hash, from_hex};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Serialize hashes as an array of lowercase hex strings.
+    ///
+    /// # Errors
+    ///
+    /// Returns the serializer's error.
+    pub fn serialize<S>(hashes: &[Hash], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        hashes
+            .iter()
+            .map(|hash| ::hex::encode(hash.0))
+            .collect::<Vec<_>>()
+            .serialize(serializer)
+    }
+
+    /// Deserialize hashes from an array of hex strings.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid hex or a hash of the wrong length.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Hash>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Vec::<String>::deserialize(deserializer)?
+            .iter()
+            .map(|value| from_hex(value).map_err(serde::de::Error::custom))
+            .collect()
+    }
+}

--- a/crates/generic_log_worker/src/lib.rs
+++ b/crates/generic_log_worker/src/lib.rs
@@ -7,6 +7,7 @@ use base64::prelude::BASE64_STANDARD;
 pub mod batcher_do;
 pub mod cleaner_do;
 pub mod frontend;
+pub mod hash_serde;
 pub mod log_ops;
 pub mod obs;
 pub mod sequencer_do;

--- a/crates/generic_log_worker/src/obs/sentry.rs
+++ b/crates/generic_log_worker/src/obs/sentry.rs
@@ -10,22 +10,8 @@
 //! # Usage
 //!
 //! ```ignore
-//! // In your worker crate's lib.rs:
-//! static SENTRY_TRANSPORT: OnceLock<Option<Arc<WorkerTransport>>> = OnceLock::new();
-//!
-//! pub fn init_sentry(env: &Env) -> Option<&'static Arc<WorkerTransport>> {
-//!     SENTRY_TRANSPORT.get_or_init(|| {
-//!         let dsn = env.var("SENTRY_DSN").ok()?.to_string();
-//!         if dsn.is_empty() { return None; }
-//!         obs::sentry::init(&dsn, env!("DEPLOY_ENV"))
-//!     }).as_ref()
-//! }
-//!
-//! // On catastrophic error:
-//! sentry_core::capture_message("something broke", sentry_core::Level::Fatal);
-//! if let Some(transport) = init_sentry(&env) {
-//!     obs::sentry::flush(transport).await;
-//! }
+//! generic_log_worker::obs::sentry::init_from_env(&env);
+//! let response = generic_log_worker::obs::sentry::catch_unwind_and_flush(handler()).await;
 //! ```
 
 use std::panic;
@@ -73,6 +59,30 @@ impl TransportFactory for Factory {
 /// `sentry_core::capture_event` because that calls `random_uuid()` which
 /// requires `getrandom` — unavailable during a WASM panic.
 static PANIC_HOOK_TRANSPORT: OnceLock<WorkerTransport> = OnceLock::new();
+
+/// Initialize Sentry from the standard Worker environment bindings.
+///
+/// Missing or empty `SENTRY_DSN` disables Sentry. The Cloudflare Access
+/// client bindings are optional.
+pub fn init_from_env(env: &worker::Env) {
+    let Ok(dsn) = env.var("SENTRY_DSN") else {
+        return;
+    };
+    let access_client_id = env
+        .var("SENTRY_ACCESS_CLIENT_ID")
+        .ok()
+        .map(|value| value.to_string());
+    let access_client_secret = env
+        .secret("SENTRY_ACCESS_CLIENT_SECRET")
+        .ok()
+        .map(|value| value.to_string());
+    let _ = init(
+        &dsn.to_string(),
+        env!("DEPLOY_ENV"),
+        access_client_id.as_deref(),
+        access_client_secret.as_deref(),
+    );
+}
 
 /// Initialize sentry with a custom Workers-compatible transport.
 ///

--- a/crates/mirror_worker/src/lib.rs
+++ b/crates/mirror_worker/src/lib.rs
@@ -35,6 +35,8 @@ use tlog_mirror::TicketSealer;
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
+pub(crate) use generic_log_worker::obs::sentry::init_from_env as init_sentry;
+
 mod add_entries;
 mod body;
 mod cleaner_do;
@@ -307,31 +309,6 @@ pub(crate) fn load_ticket_sealer(env: &Env) -> Result<&'static TicketSealer> {
         ))
     })?;
     Ok(TICKET_SEALER.get_or_init(|| TicketSealer::new(&key)))
-}
-
-/// Initialize sentry from the `SENTRY_DSN` environment variable.
-///
-/// Does nothing when the variable is absent or empty, allowing
-/// deployments without sentry support. Called at the top of the frontend
-/// `fetch` handler and in each Durable Object's `new`, so a panic anywhere
-/// in the worker is captured and flushed.
-pub(crate) fn init_sentry(env: &Env) {
-    if let Ok(dsn) = env.var("SENTRY_DSN") {
-        let access_id = env
-            .var("SENTRY_ACCESS_CLIENT_ID")
-            .ok()
-            .map(|v| v.to_string());
-        let access_secret = env
-            .secret("SENTRY_ACCESS_CLIENT_SECRET")
-            .ok()
-            .map(|v| v.to_string());
-        let _ = generic_log_worker::obs::sentry::init(
-            &dsn.to_string(),
-            env!("DEPLOY_ENV"),
-            access_id.as_deref(),
-            access_secret.as_deref(),
-        );
-    }
 }
 
 #[cfg(test)]

--- a/crates/mirror_worker/src/mirror_state_do.rs
+++ b/crates/mirror_worker/src/mirror_state_do.rs
@@ -50,7 +50,7 @@ pub struct PendingCheckpoint {
     /// this origin.
     pub size: u64,
     /// Root hash. All-zero if `size` is 0.
-    #[serde(with = "hash_hex")]
+    #[serde(with = "generic_log_worker::hash_serde::hex")]
     pub hash: Hash,
     /// Full signed-note bytes, empty if `size` is 0. Base64 in the
     /// on-disk JSON so the state stays valid UTF-8.
@@ -73,7 +73,7 @@ pub struct CommittedCheckpoint {
     /// origin.
     pub size: u64,
     /// Root hash. All-zero if `size` is 0.
-    #[serde(with = "hash_hex")]
+    #[serde(with = "generic_log_worker::hash_serde::hex")]
     pub hash: Hash,
     /// The served checkpoint bytes: the log's signed note with the
     /// mirror's cosignature line(s) appended, exactly as written to R2.
@@ -96,7 +96,7 @@ pub struct NextEntry {
     /// Number of entries durably persisted as bundles for this origin.
     pub size: u64,
     /// Tree root at `size`. All-zero (and unused) when `size` is 0.
-    #[serde(with = "hash_hex")]
+    #[serde(with = "generic_log_worker::hash_serde::hex")]
     pub hash: Hash,
 }
 
@@ -122,7 +122,7 @@ pub struct CommitRequest {
     /// Proposed new committed tree size.
     pub size: u64,
     /// Proposed new committed root hash.
-    #[serde(with = "hash_hex")]
+    #[serde(with = "generic_log_worker::hash_serde::hex")]
     pub hash: Hash,
     /// Full signed-note bytes for `(size, hash)`, served with the
     /// mirror's cosignature.
@@ -138,7 +138,7 @@ pub struct AdvanceNextEntryRequest {
     /// Proposed new persisted-entry frontier size.
     pub size: u64,
     /// Tree root at `size`.
-    #[serde(with = "hash_hex")]
+    #[serde(with = "generic_log_worker::hash_serde::hex")]
     pub hash: Hash,
 }
 
@@ -152,12 +152,12 @@ pub struct UpdatePendingRequest {
     /// Proposed new tree size.
     pub new_size: u64,
     /// Proposed new root hash.
-    #[serde(with = "hash_hex")]
+    #[serde(with = "generic_log_worker::hash_serde::hex")]
     pub new_hash: Hash,
     /// Consistency proof from `(old_size, stored_hash)` to
     /// `(new_size, new_hash)`, per RFC 6962 section 2.1.2. MUST be empty if
     /// `old_size == 0` or `old_size == new_size`, otherwise MUST verify.
-    #[serde(with = "hash_vec_hex")]
+    #[serde(with = "generic_log_worker::hash_serde::vec_hex")]
     pub proof: Vec<Hash>,
     /// Full signed-note bytes of the new pending checkpoint. Persisted
     /// alongside the size/hash so the mirror can serve them back to
@@ -406,69 +406,6 @@ impl MirrorState {
 pub(crate) fn state_stub(env: &Env, origin: &str) -> Result<Stub> {
     let namespace = env.durable_object(MIRROR_STATE_BINDING)?;
     namespace.id_from_name(origin)?.get_stub()
-}
-
-// ---------------------------------------------------------------------------
-// Serde helpers: emit/parse `Hash` as hex, so the DO's JSON state is
-// human-readable in wrangler's dev console.
-// ---------------------------------------------------------------------------
-mod hash_hex {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use tlog_core::{HASH_SIZE, Hash};
-
-    pub fn serialize<S>(h: &Hash, ser: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        hex::encode(h.0).serialize(ser)
-    }
-
-    pub fn deserialize<'de, D>(de: D) -> std::result::Result<Hash, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(de)?;
-        from_hex(&s).map_err(serde::de::Error::custom)
-    }
-
-    /// Decode a single hex-encoded [`struct@Hash`]. Shared with the `Vec<Hash>`
-    /// helper in the sibling `hash_vec_hex` module.
-    pub(super) fn from_hex(s: &str) -> std::result::Result<Hash, String> {
-        let bytes: [u8; HASH_SIZE] = hex::decode(s)
-            .map_err(|e| e.to_string())?
-            .try_into()
-            .map_err(|v: Vec<u8>| format!("hash must be {} bytes, got {}", HASH_SIZE, v.len()))?;
-        Ok(Hash(bytes))
-    }
-}
-
-/// Serde helper for `Vec<Hash>`. Encodes as a JSON array of hex strings
-/// so the DO RPC body stays human-readable alongside the other
-/// [`hash_hex`]-encoded fields.
-mod hash_vec_hex {
-    use super::hash_hex::from_hex;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use tlog_core::Hash;
-
-    pub fn serialize<S>(v: &[Hash], ser: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        v.iter()
-            .map(|h| hex::encode(h.0))
-            .collect::<Vec<_>>()
-            .serialize(ser)
-    }
-
-    pub fn deserialize<'de, D>(de: D) -> std::result::Result<Vec<Hash>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let strs = Vec::<String>::deserialize(de)?;
-        strs.iter()
-            .map(|s| from_hex(s).map_err(serde::de::Error::custom))
-            .collect()
-    }
 }
 
 #[cfg(test)]

--- a/crates/witness_worker/Cargo.toml
+++ b/crates/witness_worker/Cargo.toml
@@ -34,7 +34,6 @@ ed25519-dalek.workspace = true
 generic_log_worker.workspace = true
 getrandom.workspace = true
 getrandom_03.workspace = true
-hex.workspace = true
 log.workspace = true
 ml-dsa.workspace = true
 pkcs8.workspace = true

--- a/crates/witness_worker/src/lib.rs
+++ b/crates/witness_worker/src/lib.rs
@@ -63,6 +63,8 @@ use tlog_cosignature::{CosignatureV1CheckpointSigner, SubtreeV1CheckpointSigner}
 #[allow(clippy::wildcard_imports)]
 use worker::*;
 
+pub(crate) use generic_log_worker::obs::sentry::init_from_env as init_sentry;
+
 mod frontend_worker;
 mod witness_state_do;
 
@@ -206,29 +208,6 @@ impl WitnessSigner {
 /// dispatch happens at most once per worker instance. Subsequent
 /// requests reuse the parsed key.
 static WITNESS_SIGNER: OnceLock<WitnessSigner> = OnceLock::new();
-
-/// Initialize sentry from the `SENTRY_DSN` environment variable.
-///
-/// Does nothing when the variable is absent or empty, allowing deployments
-/// without sentry support.
-pub(crate) fn init_sentry(env: &Env) {
-    if let Ok(dsn) = env.var("SENTRY_DSN") {
-        let access_id = env
-            .var("SENTRY_ACCESS_CLIENT_ID")
-            .ok()
-            .map(|v| v.to_string());
-        let access_secret = env
-            .secret("SENTRY_ACCESS_CLIENT_SECRET")
-            .ok()
-            .map(|v| v.to_string());
-        let _ = generic_log_worker::obs::sentry::init(
-            &dsn.to_string(),
-            env!("DEPLOY_ENV"),
-            access_id.as_deref(),
-            access_secret.as_deref(),
-        );
-    }
-}
 
 /// Load (or return the already-cached) witness signer.
 ///

--- a/crates/witness_worker/src/witness_state_do.rs
+++ b/crates/witness_worker/src/witness_state_do.rs
@@ -57,7 +57,7 @@ pub struct LatestCheckpoint {
     /// origin.
     pub size: u64,
     /// Root hash of the latest cosigned checkpoint. All-zero if `size` is 0.
-    #[serde(with = "hash_hex")]
+    #[serde(with = "generic_log_worker::hash_serde::hex")]
     pub hash: Hash,
 }
 
@@ -70,12 +70,12 @@ pub struct CheckAndUpdateRequest {
     /// Proposed new tree size.
     pub new_size: u64,
     /// Proposed new root hash.
-    #[serde(with = "hash_hex")]
+    #[serde(with = "generic_log_worker::hash_serde::hex")]
     pub new_hash: Hash,
     /// Consistency proof from `(old_size, stored_hash)` to
     /// `(new_size, new_hash)`, per RFC 6962 §2.1.2. MUST be empty if
     /// `old_size == 0` or `old_size == new_size`, otherwise MUST verify.
-    #[serde(with = "hash_vec_hex")]
+    #[serde(with = "generic_log_worker::hash_serde::vec_hex")]
     pub proof: Vec<Hash>,
 }
 
@@ -204,70 +204,6 @@ impl WitnessState {
 pub(crate) fn state_stub(env: &Env, origin: &str) -> Result<Stub> {
     let namespace = env.durable_object(WITNESS_STATE_BINDING)?;
     namespace.id_from_name(origin)?.get_stub()
-}
-
-// ---------------------------------------------------------------------------
-// Serde helper: emit/parse `Hash` as hex. We use hex so the DO's JSON state
-// is human-readable in wrangler's dev console; the exact encoding is internal
-// and doesn't need to be compact.
-// ---------------------------------------------------------------------------
-mod hash_hex {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use tlog_core::{HASH_SIZE, Hash};
-
-    pub fn serialize<S>(h: &Hash, ser: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        hex::encode(h.0).serialize(ser)
-    }
-
-    pub fn deserialize<'de, D>(de: D) -> std::result::Result<Hash, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(de)?;
-        from_hex(&s).map_err(serde::de::Error::custom)
-    }
-
-    /// Decode a single hex-encoded [`Hash`]. Shared with the `Vec<Hash>`
-    /// helper in the sibling `hash_vec_hex` module.
-    pub(super) fn from_hex(s: &str) -> std::result::Result<Hash, String> {
-        let bytes: [u8; HASH_SIZE] = hex::decode(s)
-            .map_err(|e| e.to_string())?
-            .try_into()
-            .map_err(|v: Vec<u8>| format!("hash must be {} bytes, got {}", HASH_SIZE, v.len()))?;
-        Ok(Hash(bytes))
-    }
-}
-
-/// Serde helper for `Vec<Hash>`. Encodes as a JSON array of hex strings so
-/// the DO RPC body stays human-readable alongside the other
-/// [`hash_hex`]-encoded fields.
-mod hash_vec_hex {
-    use super::hash_hex::from_hex;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use tlog_core::Hash;
-
-    pub fn serialize<S>(v: &[Hash], ser: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        v.iter()
-            .map(|h| hex::encode(h.0))
-            .collect::<Vec<_>>()
-            .serialize(ser)
-    }
-
-    pub fn deserialize<'de, D>(de: D) -> std::result::Result<Vec<Hash>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let strs = Vec::<String>::deserialize(de)?;
-        strs.iter()
-            .map(|s| from_hex(s).map_err(serde::de::Error::custom))
-            .collect()
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- centralize Worker Sentry initialization
- share hex serialization for Durable Object hash state
- preserve existing persisted JSON formats

## Stack
- depends on #285

## Testing
- `cargo fmt --all --check`
- affected-crate tests and checks
- pedantic clippy with warnings denied
- `cargo shear`