### PR TITLE
tlog: add shared witness validation primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,6 +3393,7 @@ dependencies = [
  "ed25519-dalek",
  "length_prefixed",
  "ml-dsa",
+ "pkcs8",
  "rand 0.10.1",
  "signed_note",
  "tlog_checkpoint",
@@ -3452,6 +3453,7 @@ dependencies = [
  "base64",
  "signed_note",
  "thiserror 2.0.17",
+ "tlog_checkpoint",
  "tlog_core",
 ]
 

--- a/crates/tlog_core/src/lib.rs
+++ b/crates/tlog_core/src/lib.rs
@@ -926,7 +926,7 @@ pub fn subtree_consistency_proof_indexes(
 ///
 /// Will return an error if proof verification fails.
 pub fn verify_consistency_proof(
-    proof: &Proof,
+    proof: &[Hash],
     n: u64,
     root_hash: Hash,
     m: u64,
@@ -952,7 +952,7 @@ pub fn verify_consistency_proof(
 ///
 /// Will return an error if proof verification fails.
 pub fn verify_subtree_consistency_proof(
-    proof: &Proof,
+    proof: &[Hash],
     n: u64,
     root_hash: Hash,
     m: &Subtree,
@@ -1447,15 +1447,15 @@ mod tests {
         assert_eq!(tree_hash(0, &TestHashStorage::new()).unwrap(), EMPTY_HASH);
 
         // Empty tree.
-        verify_consistency_proof(&vec![], 0, EMPTY_HASH, 0, EMPTY_HASH).unwrap();
-        verify_consistency_proof(&vec![], 0, EMPTY_HASH, 1, EMPTY_HASH).unwrap_err();
-        verify_consistency_proof(&vec![], 0, Hash::default(), 0, EMPTY_HASH).unwrap_err();
-        verify_consistency_proof(&vec![Hash::default()], 0, Hash::default(), 1, EMPTY_HASH)
+        verify_consistency_proof(&[], 0, EMPTY_HASH, 0, EMPTY_HASH).unwrap();
+        verify_consistency_proof(&[], 0, EMPTY_HASH, 1, EMPTY_HASH).unwrap_err();
+        verify_consistency_proof(&[], 0, Hash::default(), 0, EMPTY_HASH).unwrap_err();
+        verify_consistency_proof(&[Hash::default()], 0, Hash::default(), 1, EMPTY_HASH)
             .unwrap_err();
 
         // Tree with single leaf.
         verify_inclusion_proof(&vec![], 1, Hash::default(), 0, Hash::default()).unwrap();
-        verify_consistency_proof(&vec![], 1, Hash::default(), 1, Hash::default()).unwrap();
+        verify_consistency_proof(&[], 1, Hash::default(), 1, Hash::default()).unwrap();
     }
 
     #[test]

--- a/crates/tlog_cosignature/Cargo.toml
+++ b/crates/tlog_cosignature/Cargo.toml
@@ -19,6 +19,7 @@ byteorder.workspace = true
 ed25519-dalek.workspace = true
 length_prefixed.workspace = true
 ml-dsa.workspace = true
+pkcs8.workspace = true
 signed_note.workspace = true
 tlog_core.workspace = true
 tlog_checkpoint.workspace = true

--- a/crates/tlog_cosignature/src/subtree_v1.rs
+++ b/crates/tlog_cosignature/src/subtree_v1.rs
@@ -88,9 +88,10 @@ use ml_dsa::{
     MlDsa44, Signature as MlDsaSignature, VerifyingKey as MlDsaVerifyingKey,
     signature::{Signer as MlDsaSigner, Verifier as MlDsaVerifier},
 };
+use pkcs8::{DecodePrivateKey as _, EncodePublicKey as _};
 use signed_note::{KeyName, NoteError, NoteSignature, NoteVerifier, SignatureType};
 use tlog_checkpoint::{CheckpointSigner, CheckpointText, UnixTimestampMillis};
-use tlog_core::{HASH_SIZE, Hash, Subtree};
+use tlog_core::{EMPTY_HASH, HASH_SIZE, Hash, Subtree};
 
 /// The fixed 12-byte label prefix domain-separating `subtree/v1` from
 /// other cosignature formats.
@@ -257,6 +258,26 @@ impl SubtreeV1CheckpointSigner {
         }
     }
 
+    /// Construct an ML-DSA-44 signer and its DER-encoded SPKI from PKCS#8 PEM.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the private key cannot be decoded or its public key
+    /// cannot be encoded.
+    pub fn from_pkcs8_pem_with_public_key(
+        name: KeyName,
+        pem: &str,
+    ) -> Result<(Self, Vec<u8>), String> {
+        let key = MlDsaExpandedSigningKey::<MlDsa44>::from_pkcs8_pem(pem)
+            .map_err(|e| format!("ML-DSA-44 PKCS#8 parse: {e}"))?;
+        let public_key_der = key
+            .verifying_key()
+            .to_public_key_der()
+            .map_err(|e| format!("ML-DSA-44 SPKI encode: {e}"))?
+            .to_vec();
+        Ok((Self::new(name, key), public_key_der))
+    }
+
     /// Sign an arbitrary subtree, returning a `subtree/v1`
     /// [`NoteSignature`].
     ///
@@ -298,17 +319,33 @@ impl SubtreeV1CheckpointSigner {
         subtree: &Subtree,
         hash: &Hash,
     ) -> NoteSignature {
-        assert!(
-            !(subtree.lo() != 0 && timestamp_unix_secs != 0),
-            "timestamp must be zero when start is non-zero",
-        );
-
-        let msg = build_cosigned_message(
-            self.v.name(),
+        self.sign_range(
             timestamp_unix_secs,
             log_origin,
             subtree.lo(),
             subtree.hi(),
+            hash,
+        )
+    }
+
+    fn sign_range(
+        &self,
+        timestamp_unix_secs: u64,
+        log_origin: &str,
+        start: u64,
+        end: u64,
+        hash: &Hash,
+    ) -> NoteSignature {
+        assert!(
+            !(start != 0 && timestamp_unix_secs != 0),
+            "timestamp must be zero when start is non-zero",
+        );
+        let msg = build_cosigned_message(
+            self.v.name(),
+            timestamp_unix_secs,
+            log_origin,
+            start,
+            end,
             hash,
         );
         let sig: MlDsaSignature<MlDsa44> = self.k.sign(&msg);
@@ -331,20 +368,14 @@ impl CheckpointSigner for SubtreeV1CheckpointSigner {
         timestamp: UnixTimestampMillis,
         checkpoint: &CheckpointText,
     ) -> Result<NoteSignature, NoteError> {
-        // The checkpoint case fixes start = 0 and end = checkpoint_size.
-        // `[0, n)` for any n > 0 is always a valid subtree (`0` is a
-        // multiple of every power of 2); `Subtree::new(0, size)` only
-        // fails for `size == 0`, where there is no meaningful subtree
-        // to cosign.
-        let subtree = Subtree::new(0, checkpoint.size()).map_err(|_| NoteError::Format)?;
-        // The spec requires the witness to use a non-zero timestamp
-        // for checkpoint cosignatures; we forward the caller-supplied
-        // timestamp unchanged (in seconds), trusting them not to pass
-        // zero in this path.
-        Ok(self.sign_subtree(
+        if checkpoint.size() == 0 && checkpoint.hash() != &EMPTY_HASH {
+            return Err(NoteError::Format);
+        }
+        Ok(self.sign_range(
             timestamp / 1000,
             checkpoint.origin(),
-            &subtree,
+            0,
+            checkpoint.size(),
             checkpoint.hash(),
         ))
     }
@@ -415,24 +446,28 @@ impl SubtreeV1NoteVerifier {
         hash: &Hash,
         sig_blob: &[u8],
     ) -> bool {
+        self.verify_range(log_origin, subtree.lo(), subtree.hi(), hash, sig_blob)
+    }
+
+    fn verify_range(
+        &self,
+        log_origin: &str,
+        start: u64,
+        end: u64,
+        hash: &Hash,
+        sig_blob: &[u8],
+    ) -> bool {
         let Some(timestamp) = parse_timestamped_signature_timestamp(sig_blob) else {
             return false;
         };
         // Spec: `timestamp` MUST be zero when `start` is non-zero.
-        if subtree.lo() != 0 && timestamp != 0 {
+        if start != 0 && timestamp != 0 {
             return false;
         }
         let Some(sig) = decode_signature(&sig_blob[8..]) else {
             return false;
         };
-        let msg = build_cosigned_message(
-            &self.name,
-            timestamp,
-            log_origin,
-            subtree.lo(),
-            subtree.hi(),
-            hash,
-        );
+        let msg = build_cosigned_message(&self.name, timestamp, log_origin, start, end, hash);
         MlDsaVerifier::verify(&self.verifying_key, &msg, &sig).is_ok()
     }
 }
@@ -457,13 +492,16 @@ impl NoteVerifier for SubtreeV1NoteVerifier {
         let Ok(checkpoint) = CheckpointText::from_bytes(msg) else {
             return false;
         };
-        // `[0, n)` for n > 0 is always a valid subtree; reject empty
-        // checkpoints (size == 0) at this layer rather than panicking
-        // inside `verify_subtree`.
-        let Ok(subtree) = Subtree::new(0, checkpoint.size()) else {
+        if checkpoint.size() == 0 && checkpoint.hash() != &EMPTY_HASH {
             return false;
-        };
-        self.verify_subtree(checkpoint.origin(), &subtree, checkpoint.hash(), sig_blob)
+        }
+        self.verify_range(
+            checkpoint.origin(),
+            0,
+            checkpoint.size(),
+            checkpoint.hash(),
+            sig_blob,
+        )
     }
 
     /// Parse the timestamp prefix from a `timestamped_signature` blob
@@ -679,6 +717,24 @@ mod tests {
             .verify(&VerifierList::new(vec![signer.verifier()]))
             .unwrap();
         assert_eq!(verified.len(), 1);
+    }
+
+    #[test]
+    fn checkpoint_signer_and_verifier_support_empty_tree() {
+        use signed_note::{Note, VerifierList};
+
+        let sk = signing_key(6);
+        let signer = SubtreeV1CheckpointSigner::new(name("witness/w"), sk);
+        let checkpoint = CheckpointText::new("log/origin", 0, EMPTY_HASH, &[]).unwrap();
+        let signature = signer.sign(1_700_000_000_000, &checkpoint).unwrap();
+        let note = Note::new(&checkpoint.to_bytes(), &[signature]).unwrap();
+        assert!(
+            note.verify(&VerifierList::new(vec![signer.verifier()]))
+                .is_ok()
+        );
+
+        let invalid = CheckpointText::new("log/origin", 0, Hash([1; HASH_SIZE]), &[]).unwrap();
+        assert!(signer.sign(1_700_000_000_000, &invalid).is_err());
     }
 
     /// Pin the binary layout of the `cosigned_message` struct against

--- a/crates/tlog_witness/Cargo.toml
+++ b/crates/tlog_witness/Cargo.toml
@@ -18,4 +18,5 @@ crate-type = ["rlib"]
 base64.workspace = true
 signed_note.workspace = true
 thiserror.workspace = true
+tlog_checkpoint.workspace = true
 tlog_core.workspace = true

--- a/crates/tlog_witness/src/add_checkpoint.rs
+++ b/crates/tlog_witness/src/add_checkpoint.rs
@@ -28,7 +28,8 @@
 
 use crate::TlogWitnessError;
 use crate::common::{
-    MAX_CONSISTENCY_PROOF_LINES, MAX_REQUEST_BODY_SIZE, parse_proof_line, parse_tree_size_decimal,
+    MAX_CONSISTENCY_PROOF_LINES, MAX_REQUEST_BODY_SIZE, parse_proof_line, parse_signature_lines,
+    parse_tree_size_decimal, serialize_signature_lines,
 };
 use base64::prelude::*;
 use signed_note::{Note, NoteSignature};
@@ -155,11 +156,7 @@ pub fn serialize_add_checkpoint_request(
 /// should not pass an empty slice for a successful response.
 #[must_use]
 pub fn serialize_add_checkpoint_response(sigs: &[NoteSignature]) -> Vec<u8> {
-    let mut out = Vec::new();
-    for sig in sigs {
-        out.extend_from_slice(&sig.to_bytes());
-    }
-    out
+    serialize_signature_lines(sigs)
 }
 
 /// Parse an `add-checkpoint` success response body into a list of
@@ -174,19 +171,7 @@ pub fn serialize_add_checkpoint_response(sigs: &[NoteSignature]) -> Vec<u8> {
 /// not valid UTF-8, and [`TlogWitnessError::Note`] if any line fails
 /// [`NoteSignature::from_bytes`] parsing.
 pub fn parse_add_checkpoint_response(body: &[u8]) -> Result<Vec<NoteSignature>, TlogWitnessError> {
-    let text = std::str::from_utf8(body)
-        .map_err(|_| TlogWitnessError::MalformedResponse("response is not valid UTF-8".into()))?;
-    let trimmed = text.strip_suffix('\n').unwrap_or(text);
-    if trimmed.is_empty() {
-        return Err(TlogWitnessError::MalformedResponse(
-            "response must contain at least one signature line".into(),
-        ));
-    }
-    let mut sigs = Vec::new();
-    for line in trimmed.split('\n') {
-        sigs.push(NoteSignature::from_bytes(line.as_bytes()).map_err(TlogWitnessError::Note)?);
-    }
-    Ok(sigs)
+    parse_signature_lines(body)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tlog_witness/src/common.rs
+++ b/crates/tlog_witness/src/common.rs
@@ -12,6 +12,7 @@
 //! [`sign_subtree`]: crate::sign_subtree
 
 use base64::prelude::*;
+use signed_note::NoteSignature;
 use tlog_core::{HASH_SIZE, Hash};
 
 /// Maximum number of consistency-proof lines a client may send in either
@@ -109,4 +110,23 @@ pub(crate) fn parse_proof_line(line: &str) -> Result<Hash, TlogWitnessError> {
         ))
     })?;
     Ok(Hash(arr))
+}
+
+pub(crate) fn serialize_signature_lines(sigs: &[NoteSignature]) -> Vec<u8> {
+    sigs.iter().flat_map(NoteSignature::to_bytes).collect()
+}
+
+pub(crate) fn parse_signature_lines(body: &[u8]) -> Result<Vec<NoteSignature>, TlogWitnessError> {
+    let text = std::str::from_utf8(body)
+        .map_err(|_| TlogWitnessError::MalformedResponse("response is not valid UTF-8".into()))?;
+    let trimmed = text.strip_suffix('\n').unwrap_or(text);
+    if trimmed.is_empty() {
+        return Err(TlogWitnessError::MalformedResponse(
+            "response must contain at least one signature line".into(),
+        ));
+    }
+    trimmed
+        .split('\n')
+        .map(|line| NoteSignature::from_bytes(line.as_bytes()).map_err(TlogWitnessError::Note))
+        .collect()
 }

--- a/crates/tlog_witness/src/lib.rs
+++ b/crates/tlog_witness/src/lib.rs
@@ -7,8 +7,8 @@
 //! HTTP witness protocol used by transparency logs to obtain cosignatures.
 //! It is transport-agnostic and has no dependency on any particular HTTP
 //! runtime — deployers plug it into their server of choice and supply their
-//! own policy for verifying the log's checkpoint signature, persisting the
-//! latest cosigned state, and producing cosignatures.
+//! own configured-origin policy, persistent storage, and cosignature
+//! production.
 //!
 //! # What's in scope
 //!
@@ -28,13 +28,15 @@
 //!   shared by both endpoints, applied before any base64 decoding.
 //! - [`CONTENT_TYPE_TLOG_SIZE`]: the `text/x.tlog.size` media type used for
 //!   `add-checkpoint`'s `409 Conflict` response bodies.
+//! - Transport-neutral checkpoint, trusted-signature, subtree, and proof
+//!   validation with domain errors.
+//! - [`validate_checkpoint_transition`]: pure validation for atomic persisted
+//!   checkpoint transitions.
 //!
 //! # What's out of scope
 //!
-//! - Checkpoint-signature verification: the caller is expected to maintain a
-//!   set of trusted log public keys and use its own [`signed_note`]-based
-//!   verifier. The parsers here return the checkpoint [`Note`] with its
-//!   signatures still attached so the caller can inspect them.
+//! - Trusted-key and configured-origin policy: callers supply the verifier
+//!   list after using the shared transport-neutral validation helpers.
 //! - Cosignature production: producing a `cosignature/v1` signature is
 //!   handled by [`tlog_cosignature::CosignatureV1CheckpointSigner`];
 //!   producing a `subtree/v1` signature is handled by
@@ -56,6 +58,7 @@
 mod add_checkpoint;
 mod common;
 mod sign_subtree;
+mod validation;
 
 pub use add_checkpoint::{
     AddCheckpointRequest, parse_add_checkpoint_request, parse_add_checkpoint_response,
@@ -68,4 +71,11 @@ pub use sign_subtree::{
     MAX_CHECKPOINT_SIGNATURES, MAX_SUBTREE_COSIGNATURE_LINES, SignSubtreeRequest,
     parse_sign_subtree_request, parse_sign_subtree_response, serialize_sign_subtree_request,
     serialize_sign_subtree_response,
+};
+pub use validation::{
+    AddCheckpointValidationError, CheckpointState, CheckpointTransitionError, ProofRequirement,
+    SignSubtreeValidationError, TrustedSignatureError, ValidatedAddCheckpointRequest,
+    ValidatedSignSubtreeRequest, validate_add_checkpoint_request, validate_checkpoint_transition,
+    validate_sign_subtree_proof, validate_sign_subtree_request,
+    verify_trusted_checkpoint_signature,
 };

--- a/crates/tlog_witness/src/sign_subtree.rs
+++ b/crates/tlog_witness/src/sign_subtree.rs
@@ -41,7 +41,8 @@ use tlog_core::Hash;
 
 use crate::TlogWitnessError;
 use crate::common::{
-    MAX_CONSISTENCY_PROOF_LINES, MAX_REQUEST_BODY_SIZE, parse_proof_line, parse_tree_size_decimal,
+    MAX_CONSISTENCY_PROOF_LINES, MAX_REQUEST_BODY_SIZE, parse_proof_line, parse_signature_lines,
+    parse_tree_size_decimal, serialize_signature_lines,
 };
 
 /// Maximum number of subtree-cosignature lines a client may send in a
@@ -281,11 +282,7 @@ pub fn serialize_sign_subtree_request(
 /// callers should not pass an empty slice for a successful response.
 #[must_use]
 pub fn serialize_sign_subtree_response(sigs: &[NoteSignature]) -> Vec<u8> {
-    let mut out = Vec::new();
-    for sig in sigs {
-        out.extend_from_slice(&sig.to_bytes());
-    }
-    out
+    serialize_signature_lines(sigs)
 }
 
 /// Parse a `sign-subtree` success response body into a list of
@@ -301,19 +298,7 @@ pub fn serialize_sign_subtree_response(sigs: &[NoteSignature]) -> Vec<u8> {
 /// or not valid UTF-8, and [`TlogWitnessError::Note`] if any line fails
 /// [`NoteSignature::from_bytes`] parsing.
 pub fn parse_sign_subtree_response(body: &[u8]) -> Result<Vec<NoteSignature>, TlogWitnessError> {
-    let text = std::str::from_utf8(body)
-        .map_err(|_| TlogWitnessError::MalformedResponse("response is not valid UTF-8".into()))?;
-    let trimmed = text.strip_suffix('\n').unwrap_or(text);
-    if trimmed.is_empty() {
-        return Err(TlogWitnessError::MalformedResponse(
-            "response must contain at least one signature line".into(),
-        ));
-    }
-    let mut sigs = Vec::new();
-    for line in trimmed.split('\n') {
-        sigs.push(NoteSignature::from_bytes(line.as_bytes()).map_err(TlogWitnessError::Note)?);
-    }
-    Ok(sigs)
+    parse_signature_lines(body)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/tlog_witness/src/validation.rs
+++ b/crates/tlog_witness/src/validation.rs
@@ -1,0 +1,495 @@
+// Copyright (c) 2025-2026 Cloudflare, Inc.
+// Licensed under the BSD-3-Clause license found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+use signed_note::{Note, NoteError, VerifierList};
+use tlog_checkpoint::{CheckpointText, MalformedCheckpointTextError};
+use tlog_core::{
+    EMPTY_HASH, Hash, Subtree, verify_consistency_proof, verify_subtree_consistency_proof,
+};
+
+use crate::{
+    AddCheckpointRequest, SignSubtreeRequest, TlogWitnessError, parse_add_checkpoint_request,
+    parse_sign_subtree_request,
+};
+
+/// An `add-checkpoint` request after wire, checkpoint, and range validation.
+#[derive(Debug)]
+pub struct ValidatedAddCheckpointRequest {
+    old_size: u64,
+    consistency_proof: Vec<Hash>,
+    checkpoint: Note,
+    checkpoint_text: CheckpointText,
+}
+
+impl ValidatedAddCheckpointRequest {
+    #[must_use]
+    pub fn into_parts(self) -> (u64, Vec<Hash>, Note, CheckpointText) {
+        (
+            self.old_size,
+            self.consistency_proof,
+            self.checkpoint,
+            self.checkpoint_text,
+        )
+    }
+}
+
+/// Validate the transport-neutral parts of an `add-checkpoint` request.
+///
+/// # Errors
+///
+/// Returns a domain error for malformed wire data, malformed checkpoint text,
+/// or an old size greater than the submitted checkpoint size.
+pub fn validate_add_checkpoint_request(
+    body: &[u8],
+) -> Result<ValidatedAddCheckpointRequest, AddCheckpointValidationError> {
+    let AddCheckpointRequest {
+        old_size,
+        consistency_proof,
+        checkpoint,
+    } = parse_add_checkpoint_request(body).map_err(AddCheckpointValidationError::Request)?;
+    let checkpoint_text = CheckpointText::from_bytes(checkpoint.text())
+        .map_err(AddCheckpointValidationError::Checkpoint)?;
+    if old_size > checkpoint_text.size() {
+        return Err(AddCheckpointValidationError::OldSizeAfterCheckpoint {
+            old_size,
+            checkpoint_size: checkpoint_text.size(),
+        });
+    }
+    Ok(ValidatedAddCheckpointRequest {
+        old_size,
+        consistency_proof,
+        checkpoint,
+        checkpoint_text,
+    })
+}
+
+/// Domain errors from transport-neutral `add-checkpoint` validation.
+#[derive(Debug, thiserror::Error)]
+pub enum AddCheckpointValidationError {
+    #[error("{0}")]
+    Request(TlogWitnessError),
+    #[error("{0}")]
+    Checkpoint(MalformedCheckpointTextError),
+    #[error("old_size {old_size} > checkpoint size {checkpoint_size}")]
+    OldSizeAfterCheckpoint { old_size: u64, checkpoint_size: u64 },
+}
+
+/// Errors from checking a checkpoint against a caller-supplied trust set.
+#[derive(Debug, thiserror::Error)]
+pub enum TrustedSignatureError {
+    #[error("no valid signatures from trusted keys: {0:?}")]
+    NoValidSignature(NoteError),
+    #[error("unexpected verifier error: {0:?}")]
+    VerifierInvariant(NoteError),
+}
+
+/// Require at least one valid checkpoint signature from `verifiers`.
+///
+/// # Errors
+///
+/// Signature absence and invalid signatures are client-domain failures.
+/// Other verifier errors indicate an invalid verifier configuration or an
+/// invariant violation.
+pub fn verify_trusted_checkpoint_signature(
+    checkpoint: &Note,
+    verifiers: &VerifierList,
+) -> Result<(), TrustedSignatureError> {
+    checkpoint
+        .verify(verifiers)
+        .map(|_| ())
+        .map_err(|error| match error {
+            NoteError::UnverifiedNote | NoteError::InvalidSignature { .. } => {
+                TrustedSignatureError::NoValidSignature(error)
+            }
+            _ => TrustedSignatureError::VerifierInvariant(error),
+        })
+}
+
+/// A `sign-subtree` request after wire, checkpoint, and range validation.
+#[derive(Debug)]
+pub struct ValidatedSignSubtreeRequest {
+    subtree_hash: Hash,
+    subtree_cosignatures: Vec<signed_note::NoteSignature>,
+    consistency_proof: Vec<Hash>,
+    checkpoint: Note,
+    checkpoint_text: CheckpointText,
+    subtree: Subtree,
+}
+
+impl ValidatedSignSubtreeRequest {
+    #[must_use]
+    pub const fn subtree_hash(&self) -> &Hash {
+        &self.subtree_hash
+    }
+
+    #[must_use]
+    pub fn subtree_cosignatures(&self) -> &[signed_note::NoteSignature] {
+        &self.subtree_cosignatures
+    }
+
+    #[must_use]
+    pub fn consistency_proof(&self) -> &[Hash] {
+        &self.consistency_proof
+    }
+
+    #[must_use]
+    pub const fn checkpoint(&self) -> &Note {
+        &self.checkpoint
+    }
+
+    #[must_use]
+    pub const fn checkpoint_text(&self) -> &CheckpointText {
+        &self.checkpoint_text
+    }
+
+    #[must_use]
+    pub const fn subtree(&self) -> &Subtree {
+        &self.subtree
+    }
+}
+
+/// Domain errors from transport-neutral `sign-subtree` validation.
+#[derive(Debug, thiserror::Error)]
+pub enum SignSubtreeValidationError {
+    #[error("{0}")]
+    Request(TlogWitnessError),
+    #[error("{0}")]
+    Checkpoint(MalformedCheckpointTextError),
+    #[error("subtree end {subtree_end} > checkpoint size {checkpoint_size}")]
+    SubtreeAfterCheckpoint {
+        subtree_end: u64,
+        checkpoint_size: u64,
+    },
+    #[error("invalid subtree: {0:?}")]
+    InvalidSubtree(tlog_core::TlogError),
+    #[error("subtree consistency proof failed")]
+    ConsistencyProofFailed,
+}
+
+/// Validate the transport-neutral structural parts of a `sign-subtree` request.
+///
+/// # Errors
+///
+/// Returns a domain error for malformed wire data or checkpoint text, and for
+/// a range that is invalid or extends past the checkpoint.
+pub fn validate_sign_subtree_request(
+    body: &[u8],
+) -> Result<ValidatedSignSubtreeRequest, SignSubtreeValidationError> {
+    let SignSubtreeRequest {
+        subtree_start,
+        subtree_end,
+        subtree_hash,
+        subtree_cosignatures,
+        consistency_proof,
+        checkpoint,
+    } = parse_sign_subtree_request(body).map_err(SignSubtreeValidationError::Request)?;
+    let checkpoint_text = CheckpointText::from_bytes(checkpoint.text())
+        .map_err(SignSubtreeValidationError::Checkpoint)?;
+    if subtree_end > checkpoint_text.size() {
+        return Err(SignSubtreeValidationError::SubtreeAfterCheckpoint {
+            subtree_end,
+            checkpoint_size: checkpoint_text.size(),
+        });
+    }
+    let subtree = Subtree::new(subtree_start, subtree_end)
+        .map_err(SignSubtreeValidationError::InvalidSubtree)?;
+    Ok(ValidatedSignSubtreeRequest {
+        subtree_hash,
+        subtree_cosignatures,
+        consistency_proof,
+        checkpoint,
+        checkpoint_text,
+        subtree,
+    })
+}
+
+/// Verify a validated subtree against its reference checkpoint.
+///
+/// # Errors
+///
+/// Returns [`SignSubtreeValidationError::ConsistencyProofFailed`] if the proof
+/// does not authenticate the subtree.
+pub fn validate_sign_subtree_proof(
+    request: &ValidatedSignSubtreeRequest,
+) -> Result<(), SignSubtreeValidationError> {
+    verify_subtree_consistency_proof(
+        &request.consistency_proof,
+        request.checkpoint_text.size(),
+        *request.checkpoint_text.hash(),
+        &request.subtree,
+        request.subtree_hash,
+    )
+    .map_err(|_| SignSubtreeValidationError::ConsistencyProofFailed)
+}
+
+/// The size and root hash relevant to an atomic checkpoint transition.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CheckpointState {
+    pub size: u64,
+    pub hash: Hash,
+}
+
+/// Why an empty consistency proof is required.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProofRequirement {
+    Initial,
+    SameSize,
+}
+
+/// Domain errors from validating an atomic checkpoint state transition.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum CheckpointTransitionError {
+    #[error("stored size does not match old size")]
+    OldSizeMismatch,
+    #[error("stored hash does not match checkpoint hash at the same size")]
+    HashMismatch,
+    #[error("a size-zero checkpoint must use the empty-tree hash")]
+    InvalidEmptyTreeHash,
+    #[error("consistency proof must be empty")]
+    ProofMustBeEmpty(ProofRequirement),
+    #[error("consistency proof failed")]
+    ConsistencyProofFailed,
+}
+
+/// Validate a checkpoint transition against persisted state.
+///
+/// # Errors
+///
+/// Returns a domain error for stale state, same-size hash disagreement,
+/// forbidden proof data, or a failed consistency proof.
+pub fn validate_checkpoint_transition(
+    current: Option<CheckpointState>,
+    old_size: u64,
+    new: CheckpointState,
+    proof: &[Hash],
+) -> Result<(), CheckpointTransitionError> {
+    if new.size == 0 && new.hash != EMPTY_HASH {
+        return Err(CheckpointTransitionError::InvalidEmptyTreeHash);
+    }
+    let Some(current) = current else {
+        if old_size != 0 {
+            return Err(CheckpointTransitionError::OldSizeMismatch);
+        }
+        if !proof.is_empty() {
+            return Err(CheckpointTransitionError::ProofMustBeEmpty(
+                ProofRequirement::Initial,
+            ));
+        }
+        return Ok(());
+    };
+    if current.size != old_size {
+        return Err(CheckpointTransitionError::OldSizeMismatch);
+    }
+    if old_size == new.size {
+        if current.hash != new.hash {
+            return Err(CheckpointTransitionError::HashMismatch);
+        }
+        if !proof.is_empty() {
+            return Err(CheckpointTransitionError::ProofMustBeEmpty(
+                ProofRequirement::SameSize,
+            ));
+        }
+        return Ok(());
+    }
+    if old_size == 0 {
+        if !proof.is_empty() {
+            return Err(CheckpointTransitionError::ProofMustBeEmpty(
+                ProofRequirement::Initial,
+            ));
+        }
+        return Ok(());
+    }
+    verify_consistency_proof(proof, new.size, new.hash, old_size, current.hash)
+        .map_err(|_| CheckpointTransitionError::ConsistencyProofFailed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+    use signed_note::{KeyName, NoteSignature};
+    use tlog_core::{EMPTY_HASH, node_hash, record_hash};
+
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    fn checkpoint_transition_table() {
+        let a = record_hash(b"a");
+        let b = record_hash(b"b");
+        let two = node_hash(a, b);
+        let cases = [
+            (
+                "empty accepts the protocol zero root",
+                None,
+                0,
+                CheckpointState {
+                    size: 0,
+                    hash: EMPTY_HASH,
+                },
+                vec![],
+                Ok(()),
+            ),
+            (
+                "empty rejects nonzero old",
+                None,
+                1,
+                CheckpointState { size: 1, hash: a },
+                vec![],
+                Err(CheckpointTransitionError::OldSizeMismatch),
+            ),
+            (
+                "empty rejects a non-empty root",
+                None,
+                0,
+                CheckpointState { size: 0, hash: a },
+                vec![],
+                Err(CheckpointTransitionError::InvalidEmptyTreeHash),
+            ),
+            (
+                "empty rejects proof",
+                None,
+                0,
+                CheckpointState { size: 1, hash: a },
+                vec![b],
+                Err(CheckpointTransitionError::ProofMustBeEmpty(
+                    ProofRequirement::Initial,
+                )),
+            ),
+            (
+                "stale old",
+                Some(CheckpointState { size: 1, hash: a }),
+                0,
+                CheckpointState { size: 1, hash: a },
+                vec![],
+                Err(CheckpointTransitionError::OldSizeMismatch),
+            ),
+            (
+                "same size and hash",
+                Some(CheckpointState { size: 1, hash: a }),
+                1,
+                CheckpointState { size: 1, hash: a },
+                vec![],
+                Ok(()),
+            ),
+            (
+                "same size different hash",
+                Some(CheckpointState { size: 1, hash: a }),
+                1,
+                CheckpointState { size: 1, hash: b },
+                vec![],
+                Err(CheckpointTransitionError::HashMismatch),
+            ),
+            (
+                "same size rejects proof",
+                Some(CheckpointState { size: 1, hash: a }),
+                1,
+                CheckpointState { size: 1, hash: a },
+                vec![b],
+                Err(CheckpointTransitionError::ProofMustBeEmpty(
+                    ProofRequirement::SameSize,
+                )),
+            ),
+            (
+                "persisted zero advances without proof",
+                Some(CheckpointState {
+                    size: 0,
+                    hash: EMPTY_HASH,
+                }),
+                0,
+                CheckpointState { size: 1, hash: a },
+                vec![],
+                Ok(()),
+            ),
+            (
+                "persisted zero accepts the same empty checkpoint",
+                Some(CheckpointState {
+                    size: 0,
+                    hash: EMPTY_HASH,
+                }),
+                0,
+                CheckpointState {
+                    size: 0,
+                    hash: EMPTY_HASH,
+                },
+                vec![],
+                Ok(()),
+            ),
+            (
+                "persisted zero rejects a non-empty root",
+                Some(CheckpointState {
+                    size: 0,
+                    hash: EMPTY_HASH,
+                }),
+                0,
+                CheckpointState { size: 0, hash: a },
+                vec![],
+                Err(CheckpointTransitionError::InvalidEmptyTreeHash),
+            ),
+            (
+                "persisted zero rejects proof",
+                Some(CheckpointState {
+                    size: 0,
+                    hash: EMPTY_HASH,
+                }),
+                0,
+                CheckpointState { size: 1, hash: a },
+                vec![b],
+                Err(CheckpointTransitionError::ProofMustBeEmpty(
+                    ProofRequirement::Initial,
+                )),
+            ),
+            (
+                "valid growth",
+                Some(CheckpointState { size: 1, hash: a }),
+                1,
+                CheckpointState { size: 2, hash: two },
+                vec![b],
+                Ok(()),
+            ),
+            (
+                "invalid growth proof",
+                Some(CheckpointState { size: 1, hash: a }),
+                1,
+                CheckpointState { size: 2, hash: two },
+                vec![],
+                Err(CheckpointTransitionError::ConsistencyProofFailed),
+            ),
+        ];
+        for (name, current, old_size, new, proof, expected) in cases {
+            assert_eq!(
+                validate_checkpoint_transition(current, old_size, new, &proof),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn validated_subtree_retains_cosignatures() {
+        let checkpoint = Note::new(
+            format!(
+                "log.example\n1\n{}\n",
+                base64::engine::general_purpose::STANDARD.encode(record_hash(b"entry").0)
+            )
+            .as_bytes(),
+            &[],
+        )
+        .unwrap();
+        let cosignature = NoteSignature::new(
+            KeyName::new("witness.example".to_owned()).unwrap(),
+            7,
+            vec![9; 64],
+        );
+        let body = crate::serialize_sign_subtree_request(
+            0,
+            1,
+            &record_hash(b"entry"),
+            std::slice::from_ref(&cosignature),
+            &[],
+            &checkpoint,
+        )
+        .unwrap();
+        let validated = validate_sign_subtree_request(&body).unwrap();
+        assert_eq!(validated.subtree_cosignatures().len(), 1);
+        assert_eq!(validated.subtree_cosignatures()[0].id(), 7);
+    }
+}


### PR DESCRIPTION
## Summary
- expose transport-neutral witness request and checkpoint-transition validation
- accept consistency proofs as slices
- support ML-DSA key loading and canonical empty checkpoints

## Stack
- depends on #286

## Testing
- `cargo test -p tlog_core -p tlog_cosignature -p tlog_witness`
- pedantic clippy with warnings denied
- `cargo fmt --all --check`
- `cargo shear`